### PR TITLE
fix: remove duplicate references

### DIFF
--- a/output/wordDisplayData#A.json
+++ b/output/wordDisplayData#A.json
@@ -5227,7 +5227,6 @@
       "A 1\nA 1. A registry mark given by underwriters (as at Lloyd's) to ships\nin first-class condition. Inferior grades are indicated by A 2 and A\n3.\n\nNote: A 1 is also applied colloquially to other things to imply\nsuperiority; prime; first-class; first-rate."
     ],
     "references": [
-      "A 1",
       "ASPIC",
       "BAUME",
       "CALIBER; CALIBRE",
@@ -5278,9 +5277,7 @@
     "variants": [
       "AARON'S ROD\nAar\"on's rod`. Etym: [See Exodus vii. 9 and Numbers xvii. 8]\n\n1. (Arch.)\n\nDefn: A rod with one serpent twined around it, thus differing from\nthe caduceus of Mercury, which has two.\n\n2. (Bot.)\n\nDefn: A plant with a tall flowering stem; esp. the great mullein, or\nhag-taper, and the golden-rod."
     ],
-    "references": [
-      "AARON'S ROD"
-    ]
+    "references": []
   },
   {
     "spellings": "AB-",
@@ -6635,8 +6632,7 @@
       "ABB WOOL\nAbb\" wool.\n\nDefn: See Abb."
     ],
     "references": [
-      "ABB",
-      "ABB WOOL"
+      "ABB"
     ]
   },
   {
@@ -6645,7 +6641,6 @@
       "A B C\nA B C\"., n.\n\n1. The first three letters of the alphabet, used for the whole\nalphabet.\n\n2. A primer for teaching the alphabet and first elements of reading.\n[Obs.]\n\n3. The simplest rudiments of any subject; as, the A B C of finance. A\nB C book, a primer. Shak."
     ],
     "references": [
-      "A B C",
       "EYE"
     ]
   },
@@ -11894,9 +11889,7 @@
     "variants": [
       "ABRAUM; ABRAUM SALTS\nA*braum\" or A*braum\" salts, n. Etym: [Ger., fr. abräumen to remove.]\n\nDefn: A red ocher used to darken mahogany and for making chloride of\npotassium."
     ],
-    "references": [
-      "ABRAUM; ABRAUM SALTS"
-    ]
+    "references": []
   },
   {
     "spellings": "ABRAXAS",
@@ -13477,7 +13470,6 @@
       "ABSQUE HOC\nAbs\"que hoc\n\nDefn: . Etym: [L., without this.] (Law) The technical words of denial\nused in traversing what has been alleged, and is repeated."
     ],
     "references": [
-      "ABSQUE HOC",
       "TRAVERSE"
     ]
   },
@@ -15107,7 +15099,6 @@
       "A CAPPELLA\nA cap*pel\"la. Etym: [It. See Chapel.] (Mus.)\n\n(a) In church or chapel style; -- said of compositions sung in the\nold church style, without instrumental accompaniment; as, a mass a\ncapella, i. e., a mass purely vocal.\n(b) A time indication, equivalent to alla breve."
     ],
     "references": [
-      "A CAPPELLA",
       "CAPPELLA"
     ]
   },
@@ -18566,7 +18557,6 @@
       "ACCOUNT BOOK\nAc*count\" book`.\n\nDefn: A book in which accounts are kept. Swift."
     ],
     "references": [
-      "ACCOUNT BOOK",
       "CALENDAR",
       "CHARGE",
       "DIVAN",
@@ -20350,7 +20340,6 @@
       "A CHEVAL\nA` che*val\". [F., lit., on horseback.]\n\nDefn: Astride; with a part on each side; -- used specif. in\ndesignating the position of an army with the wings separated by some\nline of demarcation, as a river or road.\n\nOTHER: A position à cheval on a river is not one which a general willingly\nassumes.\nSwinton."
     ],
     "references": [
-      "A CHEVAL",
       "DUB",
       "PSYCHE",
       "TURNPIKE"
@@ -20442,9 +20431,7 @@
     "variants": [
       "ACHILLES' TENDON\nA*chil\"les' ten\"don, n. Etym: [L. Achillis tendo.] (Anat.)\n\nDefn: The strong tendon formed of the united tendons of the large\nmuscles in the calf of the leg, an inserted into the bone of the\nheel; -- so called from the mythological account of Achilles being\nheld by the heel when dipped in the River Styx."
     ],
-    "references": [
-      "ACHILLES' TENDON"
-    ]
+    "references": []
   },
   {
     "spellings": "ACHILOUS",
@@ -22104,7 +22091,6 @@
       "ACID PROCESS\nAc\"id proc\"ess. (Iron Metal.)\n\nDefn: That variety of either the Bessemer or the open-hearth process\nin which the converter or hearth is lined with acid, that is, highly\nsiliceous, material. Opposed to basic process."
     ],
     "references": [
-      "ACID PROCESS",
       "BASIC PROCESS",
       "TOWER"
     ]
@@ -22642,7 +22628,6 @@
       "ACORN CUP\nA\"corn cup.\n\nDefn: The involucre or cup in which the acorn is fixed."
     ],
     "references": [
-      "ACORN CUP",
       "VALONIA"
     ]
   },
@@ -32567,7 +32552,6 @@
     ],
     "references": [
       "ADAM",
-      "ADAM'S APPLE",
       "LARYNX",
       "THROATBOLL"
     ]
@@ -32853,9 +32837,7 @@
     "variants": [
       "AD CAPTANDUM\nAd cap*tan\"dum. Etym: [L., for catching.]\n\nDefn: A phrase used adjectively sometimes of meretricious attempts to\ncatch or win popular favor."
     ],
-    "references": [
-      "AD CAPTANDUM"
-    ]
+    "references": []
   },
   {
     "spellings": "ADD",
@@ -33027,9 +33009,7 @@
     "variants": [
       "ADDER FLY\nAd\"der fly.\n\nDefn: A dragon fly."
     ],
-    "references": [
-      "ADDER FLY"
-    ]
+    "references": []
   },
   {
     "spellings": "ADDER'S-TONGUE",
@@ -33116,7 +33096,6 @@
       "ADDISON'S DISEASE\nAd\"di*son's dis*ease\". Etym: [Named from Thomas Addison, M. D., of\nLondon, who first described it.] (Med.)\n\nDefn: A morbid condition causing a peculiar brownish discoloration of\nthe skin, and thought, at one time, to be due to disease of the\nsuprarenal capsules (two flat triangular bodies covering the upper\npart of the kidneys), but now known not to be dependent upon this\ncauses exclusively. It is usually fatal."
     ],
     "references": [
-      "ADDISON'S DISEASE",
       "BRONZE",
       "MELASMA"
     ]
@@ -34007,9 +33986,7 @@
     "variants": [
       "ADEN ULCER\nA\"den ul\"cer. [So named after Aden, a seaport in Southern Arabia,\nwhere it occurs.] (Med.)\n\nDefn: A disease endemic in various parts of tropical Asia, due to a\nspecific microörganism which produces chronic ulcers on the limbs. It\nis often fatal. Called also Cochin China ulcer, Persian ulcer,\ntropical ulcer, etc."
     ],
-    "references": [
-      "ADEN ULCER"
-    ]
+    "references": []
   },
   {
     "spellings": "ADEPS",
@@ -34539,9 +34516,7 @@
     "variants": [
       "AD HOMINEM\nAd hom\"i*nem. Etym: [L., to the man.]\n\nDefn: ` phrase applied to an appeal or argument addressed to the\nprinciples, interests, or passions of a man."
     ],
-    "references": [
-      "AD HOMINEM"
-    ]
+    "references": []
   },
   {
     "spellings": "ADHORT",
@@ -34678,9 +34653,7 @@
     "variants": [
       "AD INFINITUM\nAd in`fi*ni\"tum. Etym: [L., to infinity.]\n\nDefn: Without limit; endlessly."
     ],
-    "references": [
-      "AD INFINITUM"
-    ]
+    "references": []
   },
   {
     "spellings": "AD INTERIM",
@@ -34688,7 +34661,6 @@
       "AD INTERIM\nAd in\"ter*imEtym: [L.]\n\nDefn: Meanwhile; temporary."
     ],
     "references": [
-      "AD INTERIM",
       "CHARGE D'AFFAIRES"
     ]
   },
@@ -35933,9 +35905,7 @@
     "variants": [
       "ADJUSTING PLANE; ADJUSTING SURFACE\nAdjusting plane or surface. (Aëronautics)\n\nDefn: A small plane or surface, usually capable of adjustment but not\nof manipulation, for preserving lateral balance in an aëroplane or\nflying machine."
     ],
-    "references": [
-      "ADJUSTING PLANE; ADJUSTING SURFACE"
-    ]
+    "references": []
   },
   {
     "spellings": "ADJUSTIVE",
@@ -36113,7 +36083,6 @@
       "AD LIBITUM\nAd lib\"i*tum\n\nDefn: . At one's pleasure; as one wishes."
     ],
     "references": [
-      "AD LIBITUM",
       "BENE PLACITO",
       "SWIPE"
     ]
@@ -38293,9 +38262,7 @@
     "variants": [
       "ADSUKI BEAN\nAd*su\"ki bean. [Jap. adzuki.]\n\nDefn: A cultivated variety of the Asiatic gram, now introduced into\nthe United States."
     ],
-    "references": [
-      "ADSUKI BEAN"
-    ]
+    "references": []
   },
   {
     "spellings": "ADULARIA",
@@ -38747,7 +38714,6 @@
       "AD VALOREM\nAd va*lo\"rem. Etym: [L., according to the value.] (Com.)\n\nDefn: A term used to denote a duty or charge laid upon goods, at a\ncertain rate per cent upon their value, as stated in their invoice, -\n- in opposition to a specific sum upon a given quantity or number;\nas, an ad valorem duty of twenty per cent."
     ],
     "references": [
-      "AD VALOREM",
       "DUTY"
     ]
   },
@@ -39095,7 +39061,6 @@
       "ADVANCING EDGE\nAd*van\"cing edge. (Aëronautics)\n\nDefn: The front edge (in direction of motion) of a supporting\nsurface; -- contr. with following edge, which is the rear edge."
     ],
     "references": [
-      "ADVANCING EDGE",
       "ANGLE OF ENTRY",
       "ENTERING EDGE; ENTRANT EDGE",
       "LEADING EDGE",
@@ -39107,9 +39072,7 @@
     "variants": [
       "ADVANCING SURFACE\nAd*van\"cing sur\"face. (Aëronautics)\n\nDefn: The first of two or more surfaces arranged in tandem; -- contr.\nwith following surface, which is the rear surface."
     ],
-    "references": [
-      "ADVANCING SURFACE"
-    ]
+    "references": []
   },
   {
     "spellings": "ADVANCIVE",
@@ -40774,18 +40737,14 @@
     "variants": [
       "AERIAL RAILWAY\nA*ë`ri*al rail\"way`.\n\n(a) A stretched wire or rope elevated above the\nground and forming a way along which a trolley may travel, for\nconveying a load suspended from the trolley.\n (b) An elevated cableway."
     ],
-    "references": [
-      "AERIAL RAILWAY"
-    ]
+    "references": []
   },
   {
     "spellings": "AERIAL SICKNESS",
     "variants": [
       "AERIAL SICKNESS\nA*ë\"ri*al sick\"ness.\n\nDefn: A sickness felt by aëronauts due to high speed of flights and\nrapidity in changing altitudes, combining some symptoms of mountain\nsickness and some of seasickness."
     ],
-    "references": [
-      "AERIAL SICKNESS"
-    ]
+    "references": []
   },
   {
     "spellings": "AERIE",
@@ -41421,9 +41380,7 @@
     "variants": [
       "AETHIOPS MINERAL\nÆ\"thi*ops min\"er*al. (Chem.)\n\nDefn: Same as Ethiops mineral. [Obs.]"
     ],
-    "references": [
-      "AETHIOPS MINERAL"
-    ]
+    "references": []
   },
   {
     "spellings": "AETHOGEN",
@@ -44093,9 +44050,7 @@
     "variants": [
       "A. F. OF L.\nA. F. of L. (Abbrev.)\n\nDefn: American Federation of Labor."
     ],
-    "references": [
-      "A. F. OF L."
-    ]
+    "references": []
   },
   {
     "spellings": "AFOOT",
@@ -44207,9 +44162,7 @@
     "variants": [
       "A FORTIORI\nA for`ti*o\"ri. Etym: [L.] (Logic & Math.)\n\nDefn: With stronger reason."
     ],
-    "references": [
-      "A FORTIORI"
-    ]
+    "references": []
   },
   {
     "spellings": "AFOUL",
@@ -46228,7 +46181,6 @@
       "AFTER DAMP\nAft\"er damp`.\n\nDefn: An irrespirable gas, remaining after an explosion of fire damp\nin mines; choke damp. See Carbonic acid."
     ],
     "references": [
-      "AFTER DAMP",
       "CARBONIC"
     ]
   },
@@ -50855,7 +50807,6 @@
       "AGNUS CASTUS\nAg\"nus cas\"tus. Etym: [Gr. (Bot.)\n\nDefn: A species of Vitex (V. agnus castus); the chaste tree. Loudon.\nAnd wreaths of agnus castus others bore. Dryden."
     ],
     "references": [
-      "AGNUS CASTUS",
       "CHASTE"
     ]
   },
@@ -50866,7 +50817,6 @@
     ],
     "references": [
       "AGNUS",
-      "AGNUS DEI",
       "MASS"
     ]
   },
@@ -50875,9 +50825,7 @@
     "variants": [
       "AGNUS SCYTHICUS\nAg\"nus Scyth\"i*cus. [L., Scythian lamb.] (Bot.)\n\nDefn: The Scythian lamb, a kind of woolly-skinned rootstock. See\nBarometz."
     ],
-    "references": [
-      "AGNUS SCYTHICUS"
-    ]
+    "references": []
   },
   {
     "spellings": "AGO",
@@ -52387,9 +52335,7 @@
     "variants": [
       "AICH'S METAL\nAich's met\"al.\n\nDefn: A kind of gun metal, containing copper, zinc, and iron, but no\ntin."
     ],
-    "references": [
-      "AICH'S METAL"
-    ]
+    "references": []
   },
   {
     "spellings": "AID",
@@ -53985,9 +53931,7 @@
     "variants": [
       "AIR BED\nAir\" bed`.\n\nDefn: A sack or matters inflated with air, and used as a bed."
     ],
-    "references": [
-      "AIR BED"
-    ]
+    "references": []
   },
   {
     "spellings": "AIR BLADDER",
@@ -53996,7 +53940,6 @@
     ],
     "references": [
       "AIR",
-      "AIR BLADDER",
       "CARLOCK",
       "CONTRACTIBLE",
       "DIPNOI",
@@ -54017,7 +53960,6 @@
       "AIR BRAKE\nAir\" brake`. (Mach.)\n\nDefn: A railway brake operated by condensed air. Knight."
     ],
     "references": [
-      "AIR BRAKE",
       "BRAKE",
       "TRIPLE"
     ]
@@ -54028,7 +53970,6 @@
       "AIR BRUSH\nAir brush.\n\nDefn: A kind of atomizer for applying liquid coloring matter in a\nspray by compressed air."
     ],
     "references": [
-      "AIR BRUSH",
       "HAIR",
       "PENICILLATE"
     ]
@@ -54047,7 +53988,6 @@
     ],
     "references": [
       "AEROCYST",
-      "AIR CELL",
       "AIR SAC",
       "ALVEOLUS",
       "BRONCHIAL",
@@ -54068,7 +54008,6 @@
     ],
     "references": [
       "AIR",
-      "AIR CHAMBER",
       "AIR VESSEL",
       "CAISSON",
       "CHAMBER",
@@ -54081,18 +54020,14 @@
     "variants": [
       "AIR COCK\nAir\" cock`.\n\nDefn: A faucet to allow escape of air."
     ],
-    "references": [
-      "AIR COCK"
-    ]
+    "references": []
   },
   {
     "spellings": "AIR COOLING",
     "variants": [
       "AIR COOLING\nAir cooling.\n\nDefn: In gasoline-engine motor vehicles, the cooling of the cylinder\nby increasing its radiating surface by means of ribs or radiators,\nand placing it so that it is exposed to a current of air. Cf. Water\ncooling. -- Air\"-cooled`, a."
     ],
-    "references": [
-      "AIR COOLING"
-    ]
+    "references": []
   },
   {
     "spellings": "AIRCRAFT",
@@ -54117,9 +54052,7 @@
     "variants": [
       "AIR DRILL\nAir\" drill`.\n\nDefn: A drill driven by the elastic pressure of condensed air; a\npneumatic drill. Knight."
     ],
-    "references": [
-      "AIR DRILL"
-    ]
+    "references": []
   },
   {
     "spellings": "AIR ENGINE",
@@ -54127,7 +54060,6 @@
       "AIR ENGINE\nAir\" engine`.\n\nDefn: An engine driven by heated or by compressed air. Knight."
     ],
     "references": [
-      "AIR ENGINE",
       "COMPRESSED",
       "ENGINE",
       "HEAT",
@@ -54151,7 +54083,6 @@
       "AIR GAP\nAir gap. (Physics)\n\nDefn: An air-filled gap in a magnetic or electric circuit; specif.,\nin a dynamo or motor, the space between the field-magnet poles and\nthe armature; clearance."
     ],
     "references": [
-      "AIR GAP",
       "SPARK GAP"
     ]
   },
@@ -54161,7 +54092,6 @@
       "AIR GAS\nAir\" gas`.\n\nDefn: See under Gas."
     ],
     "references": [
-      "AIR GAS",
       "GAS",
       "GASOLINE",
       "LIGROIN"
@@ -54173,7 +54103,6 @@
       "AIR GUN\nAir\" gun`.\n\nDefn: A kind of gun in which the elastic force of condensed air is\nused to discharge the ball. The air is powerfully compressed into a\nreservoir attached to the gun, by a condensing pump, and is\ncontrolled by a valve actuated by the trigger."
     ],
     "references": [
-      "AIR GUN",
       "WIND"
     ]
   },
@@ -54183,7 +54112,6 @@
       "AIR HOLE\nAir\" hole`.\n\n1. A hole to admit or discharge air; specifically, a spot in the ice\nnot frozen over.\n\n2. (Founding)\n\nDefn: A fault in a casting, produced by a bubble of air; a blowhole."
     ],
     "references": [
-      "AIR HOLE",
       "BLOWHOLE",
       "FUNNEL",
       "HOLE IN THE AIR",
@@ -54226,9 +54154,7 @@
     "variants": [
       "AIR JACKET\nAir\" jack`et.\n\nDefn: A jacket having air-tight cells, or cavities which can be\nfilled with air, to render persons buoyant in swimming."
     ],
-    "references": [
-      "AIR JACKET"
-    ]
+    "references": []
   },
   {
     "spellings": "AIRLESS",
@@ -54245,7 +54171,6 @@
       "AIR LEVEL\nAir\" lev`el.\n\nDefn: Spirit level. See Level."
     ],
     "references": [
-      "AIR LEVEL",
       "LEVEL"
     ]
   },
@@ -54265,7 +54190,6 @@
     ],
     "references": [
       "AIR",
-      "AIR LINE",
       "BEE LINE",
       "HAIR"
     ]
@@ -54311,7 +54235,6 @@
       "AIR PIPE\nAir\" pipe`.\n\nDefn: A pipe for the passage of air; esp. a ventilating pipe."
     ],
     "references": [
-      "AIR PIPE",
       "TRIPLE"
     ]
   },
@@ -54322,7 +54245,6 @@
     ],
     "references": [
       "AEROPHYTE",
-      "AIR PLANT",
       "EPIPHYTE"
     ]
   },
@@ -54331,9 +54253,7 @@
     "variants": [
       "AIR POISE\nAir\" poise`. Etym: [See Poise.]\n\nDefn: A"
     ],
-    "references": [
-      "AIR POISE"
-    ]
+    "references": []
   },
   {
     "spellings": "AIR PUMP",
@@ -54341,7 +54261,6 @@
       "AIR PUMP\nAir\" pump`.\n\n1. (Physics)\n\nDefn: A kind of pump for exhausting air from a vessel or closed\nspace; also, a pump to condense air of force in into a closed space.\n\n2. (Steam Engines)\n\nDefn: A pump used to exhaust from a condenser the condensed steam,\nthe water used for condensing, and any commingled air."
     ],
     "references": [
-      "AIR PUMP",
       "BELL JAR",
       "DIVING",
       "ELATROMETER",
@@ -54363,7 +54282,6 @@
     ],
     "references": [
       "AIR BLADDER",
-      "AIR SAC",
       "PHYSALIA",
       "PHYSOGRADE",
       "PHYSOPHORAE",
@@ -54378,7 +54296,6 @@
       "AIR SHAFT\nAir\" shaft`.\n\nDefn: A passage, usually vertical, for admitting fresh air into a\nmine or a tunnel."
     ],
     "references": [
-      "AIR SHAFT",
       "PLUMMING",
       "SHAFT"
     ]
@@ -54404,9 +54321,7 @@
     "variants": [
       "AIR STOVE\nAir\" stove`.\n\nDefn: A stove for heating a current of air which is directed against\nits surface by means of pipes, and then distributed through a\nbuilding."
     ],
-    "references": [
-      "AIR STOVE"
-    ]
+    "references": []
   },
   {
     "spellings": "AIR-TIGHT",
@@ -54432,7 +54347,6 @@
     ],
     "references": [
       "AIR CELL",
-      "AIR VESSEL",
       "CYST",
       "GULF",
       "MACROCYSTIS"
@@ -58318,9 +58232,7 @@
     "variants": [
       "ALABAMA PERIOD\nAl`a*ba\"ma pe\"ri*od. (Geol.)\n\nDefn: A period in the American eocene, the lowest in the tertiary age\nexcept the lignitic."
     ],
-    "references": [
-      "ALABAMA PERIOD"
-    ]
+    "references": []
   },
   {
     "spellings": "ALABASTER",
@@ -58871,9 +58783,7 @@
     "variants": [
       "ALBERT WARE\nAl\"bert ware.\n\nDefn: A soft ornamental terra-cotta pottery, sold in the biscuit\nstate for decorating."
     ],
-    "references": [
-      "ALBERT WARE"
-    ]
+    "references": []
   },
   {
     "spellings": "ALBERTYPE",
@@ -59047,9 +58957,7 @@
     "variants": [
       "ALB SUNDAY\nAlb Sunday. (Eccl.)\n\nDefn: The first Sunday after Easter Sunday, properly Albless Sunday,\nbecause in the early church those who had been baptized on Easter eve\nlaid aside on the following Saturday their white albs which had been\nput on after baptism."
     ],
-    "references": [
-      "ALB SUNDAY"
-    ]
+    "references": []
   },
   {
     "spellings": "ALBUGINEOUS",
@@ -59132,9 +59040,7 @@
     "variants": [
       "ALBUM GRAECUM\nAl\"bum Græ\"cum. Etym: [L., Greek white.]\n\nDefn: Dung of dogs or hyenas, which becomes white by exposure to air.\nIt is used in dressing leather, and was formerly used in medicine."
     ],
-    "references": [
-      "ALBUM GRAECUM"
-    ]
+    "references": []
   },
   {
     "spellings": "ALBUMIN",
@@ -60169,9 +60075,7 @@
     "variants": [
       "ALDER FLY\nAl\"der fly.\n\n1. Any of numerous neuropterous insects of the genus Sialis or allied\ngenera. They have aquatic larvæ, which are used for bait.\n\n2.  (Angling) An artificial fly with brown mottled wings, body of\npeacock harl, and black legs."
     ],
-    "references": [
-      "ALDER FLY"
-    ]
+    "references": []
   },
   {
     "spellings": "ALDER-LIEFEST",
@@ -60609,7 +60513,6 @@
       "ALENCON LACE\nA`len`con\" lace\".\n\nDefn: See under Lace."
     ],
     "references": [
-      "ALENCON LACE",
       "LACE"
     ]
   },
@@ -60642,7 +60545,6 @@
       "ALEPPO BOIL; ALEPPO BUTTON; ALEPPO EVIL\nA*lep\"po boil, button, or evil. (Med.)\n\nDefn: A chronic skin affection terminating in an ulcer, most commonly\nof the face. It is endemic along the Mediterranean, and is probably\ndue to a specific bacillus. Called also Aleppo ulcer, Biskara boil,\nDelhi boil, Oriental sore, etc."
     ],
     "references": [
-      "ALEPPO BOIL; ALEPPO BUTTON; ALEPPO EVIL",
       "BISKARA BOIL; BISKARA BUTTON",
       "NATAL BOIL"
     ]
@@ -60653,7 +60555,6 @@
       "ALEPPO GRASS\nAleppo grass. (Bot.)\n\nDefn: One of the cultivated forms of Andropogon Halepensis (syn.\nSorghum Halepense). See Andropogon, below."
     ],
     "references": [
-      "ALEPPO GRASS",
       "ANDROPOGON"
     ]
   },
@@ -60708,9 +60609,7 @@
     "variants": [
       "ALE SILVER\nAle\" sil`ver.\n\nDefn: A duty payable to the lord mayor of London by the sellers of\nale within the city."
     ],
-    "references": [
-      "ALE SILVER"
-    ]
+    "references": []
   },
   {
     "spellings": "ALESTAKE",
@@ -60917,9 +60816,7 @@
     "variants": [
       "ALFA ; ALFA GRASS\nAl\"fa or Al\"fa grass\", n.\n\nDefn: A plant (Macrochloa tenacissima) of North Africa; also, its\nfiber, used in paper making."
     ],
-    "references": [
-      "ALFA ; ALFA GRASS"
-    ]
+    "references": []
   },
   {
     "spellings": "ALFALFA",
@@ -62231,9 +62128,7 @@
     "variants": [
       "ALKALI FLAT\nAlkali flat.\n\nDefn: A sterile plain, containing an excess of alkali, at the bottom\nof an undrained basin in an arid region; a playa."
     ],
-    "references": [
-      "ALKALI FLAT"
-    ]
+    "references": []
   },
   {
     "spellings": "ALKALIFY",
@@ -62379,9 +62274,7 @@
     "variants": [
       "ALKALI SOIL\nAlkali soil.\n\nDefn: Any one of various soils found in arid and semiarid regions,\ncontaining an unusual amount of soluble mineral salts which\neffloresce in the form of a powder or crust (usually white) in dry\nweather following rains or irrigation. The basis of these salts is\nmainly soda with a smaller amount of potash, and usually a little\nlime and  magnesia. Two main classes of alkali are commonly\ndistinguished: black alkali, which may be any alkaline carbonate, but\nwhich practically consists of sodium carbonate (sal soda), which is\nhighly corrosive and destructive to vegetation; and white alkali,\ncharacterized by the presence of sodium sulphate (Glauber's salt),\nwhich is less injurious to vegetation. Black alkali is so called\nbecause water containing it dissolves humus, forming a dark-colored\nsolution which, when it collects in puddles and evaporates, produces\ncharacteristic black spots."
     ],
-    "references": [
-      "ALKALI SOIL"
-    ]
+    "references": []
   },
   {
     "spellings": "ALKALI WASTE",
@@ -62389,7 +62282,6 @@
       "ALKALI WASTE\nAlkali waste.\n\nDefn: Waste material from the manufacture of alkali; specif., soda\nwaste."
     ],
     "references": [
-      "ALKALI WASTE",
       "SODA"
     ]
   },
@@ -66233,7 +66125,6 @@
     ],
     "references": [
       "A CAPPELLA",
-      "ALLA BREVE",
       "C"
     ]
   },
@@ -66894,9 +66785,7 @@
     "variants": [
       "ALL FOOLS' DAY\nAll\" Fools' Day`.\n\nDefn: The first day of April, a day on which sportive impositions are\npracticed.\nThe first of April, some do say, Is set apart for All Fools' Day.\nPoor Robin's Almanack (1760)."
     ],
-    "references": [
-      "ALL FOOLS' DAY"
-    ]
+    "references": []
   },
   {
     "spellings": "ALLFOURS",
@@ -66911,7 +66800,6 @@
       "ALL FOURS\nAll` fours\" Etym: [formerly, All` four\".]\n\nDefn: All four legs of a quadruped; or the two legs and two arms of a\nperson. To be, go, or run, on all fours (Fig.), to be on the same\nfooting; to correspond (with) exactly; to be alike in all the\ncircumstances to be considered. \"This example is on all fours with\nthe other.\" \"No simile can go on all fours.\" Macaulay."
     ],
     "references": [
-      "ALL FOURS",
       "CALIFORNIA JACK",
       "CAPRIOLE",
       "FOUR",
@@ -66930,7 +66818,6 @@
       "ALL HAIL\nAll` hail\". Etym: [All + hail, interj.]\n\nDefn: All health; -- a phrase of salutation or welcome."
     ],
     "references": [
-      "ALL HAIL",
       "SOMETIME"
     ]
   },
@@ -66975,9 +66862,7 @@
     "variants": [
       "ALLHALLOW EVE\nAll`hal\"low eve` (ev`).\n\nDefn: The evening before Allhallows. See Halloween."
     ],
-    "references": [
-      "ALLHALLOW EVE"
-    ]
+    "references": []
   },
   {
     "spellings": "ALLHALLOWMAS",
@@ -67991,9 +67876,7 @@
     "variants": [
       "ALLIGATOR WRENCH\nAl\"li*ga`tor wrench. (Mech.)\n\nDefn: A kind of pipe wrench having a flaring jaw with teeth on one\nside."
     ],
-    "references": [
-      "ALLIGATOR WRENCH"
-    ]
+    "references": []
   },
   {
     "spellings": "ALLIGNMENT",
@@ -68946,7 +68829,6 @@
       "ALLOY STEEL\nAl\"loy steel.\n\nDefn: Any steel containing a notable quantity of some other metal\nalloyed with the iron, usually chromium, nickel, manganese, tungsten,\nor vanadium."
     ],
     "references": [
-      "ALLOY STEEL",
       "CARBON STEEL",
       "MANGANESE STEEL"
     ]
@@ -68967,7 +68849,6 @@
       "ALLHALLOW; ALLHALLOWS",
       "ALLHALLOWMAS",
       "ALLHALLOWTIDE",
-      "ALL SAINTS; ALL SAINTS'",
       "GRAND",
       "HALIMAS; HALMAS",
       "HALLOWEEN",
@@ -68979,9 +68860,7 @@
     "variants": [
       "ALL SOULS' DAY\nAll\" Souls' Day`.\n\nDefn: The second day of November; a feast day of the Roman Catholic\nchurch, on which supplications are made for the souls of the faithful\ndead."
     ],
-    "references": [
-      "ALL SOULS' DAY"
-    ]
+    "references": []
   },
   {
     "spellings": "ALLSPICE",
@@ -69544,7 +69423,6 @@
       "ALMA MATER\nAl\"ma Ma\"ter. Etym: [L., fostering mother.]\n\nDefn: A college or seminary where one is educated."
     ],
     "references": [
-      "ALMA MATER",
       "MATER"
     ]
   },
@@ -69721,7 +69599,6 @@
       "ALMOND FURNACE\nAl\"mond fur`nace. Etym: [Prob. a corruption of Almain furnace, i. e.,\nGerman furnace. See Almain.]\n\nDefn: A kind of furnace used in refining, to separate the metal from\ncinders and other foreign matter. Chambers."
     ],
     "references": [
-      "ALMOND FURNACE",
       "SWEEP"
     ]
   },
@@ -70204,7 +70081,6 @@
     ],
     "references": [
       "AGALLOCH; AGALLOCHUM",
-      "ALOES WOOD",
       "CALAMBOUR",
       "LIGN-ALOES"
     ]
@@ -71445,9 +71321,7 @@
     "variants": [
       "ALPHA PAPER\nAl\"pha pa\"per. (Photog.)\n\nDefn: A sensitized paper for obtaining positives by artificial light.\nIt is coated with gelatin containing silver bromide and chloride.\n[Eng.]"
     ],
-    "references": [
-      "ALPHA PAPER"
-    ]
+    "references": []
   },
   {
     "spellings": "ALPHA RAYS",
@@ -71455,7 +71329,6 @@
       "ALPHA RAYS\nAlpha rays. (Physics & Chem.)\n\nDefn: Rays of relatively low penetrating power emitted by radium and\nother radioactive substances, and shown to consist of positively\ncharged particles (perhaps particles of helium) having enormous\nvelocities but small masses. They are slightly deflected by a strong\nmagnetic or electric field."
     ],
     "references": [
-      "ALPHA RAYS",
       "POLONIUM",
       "RADIUM"
     ]
@@ -71688,7 +71561,6 @@
       "AL SEGNO\nAl` se\"gno. Etym: [It., to the mark or sign.](Mus.)\n\nDefn: A direction for the performer to return and recommence from the\nsign"
     ],
     "references": [
-      "AL SEGNO",
       "DAL SEGNO",
       "SEGNO"
     ]
@@ -77330,7 +77202,6 @@
       "ALTERNATING CURRENT\nAl\"ter*nat`ing cur\"rent. (Elec.)\n\nDefn: A current which periodically changes or reverses its direction\nof flow."
     ],
     "references": [
-      "ALTERNATING CURRENT",
       "COMMUTATOR",
       "DIRECT CURRENT",
       "IMPEDANCE",
@@ -78193,7 +78064,6 @@
       "ALUM ROOT\nAl\"um root`. (Bot.)\n\nDefn: A North American herb (Heuchera Americana) of the Saxifrage\nfamily, whose root has astringent properties."
     ],
     "references": [
-      "ALUM ROOT",
       "SAXIFRAGACEOUS"
     ]
   },
@@ -78203,7 +78073,6 @@
       "ALUM SCHIST; ALUM SHALE\nAl\"um schist\", Al\"um shale\", (Min.)\n\nDefn: A variety of shale or clay slate, containing iron pyrites, the\ndecomposition of which leads to the formation of alum, which often\neffloresces on the rock."
     ],
     "references": [
-      "ALUM SCHIST; ALUM SHALE",
       "AMPELITE"
     ]
   },
@@ -78213,7 +78082,6 @@
       "ALUM STONE\nAl\"um stone`. (Min.)\n\nDefn: A subsulphate of alumina and potash; alunite."
     ],
     "references": [
-      "ALUM STONE",
       "ALUNITE"
     ]
   },
@@ -80066,9 +79934,7 @@
     "variants": [
       "AMAZONITE; AMAZON STONE\nAm\"a*zon*ite, Am\"a*zon stone`, n. Etym: [Named from the river\nAmazon.] (Min.)\n\nDefn: A variety of feldspar, having a verdigris-green color."
     ],
-    "references": [
-      "AMAZONITE; AMAZON STONE"
-    ]
+    "references": []
   },
   {
     "spellings": "AMB-; AMBI-",
@@ -80127,9 +79993,7 @@
     "variants": [
       "AMBARY; AMBARY HEMP\nAm*ba\"ry, n., or Ambary hemp. [Hind. ambara, ambari.]\n\nDefn: A valuable East Indian fiber plant (Hibiscus cannabinus), or\nits fiber, which is used throughout India for making ropes, cordage,\nand a coarse canvas and sackcloth; --called also brown Indian hemp."
     ],
-    "references": [
-      "AMBARY; AMBARY HEMP"
-    ]
+    "references": []
   },
   {
     "spellings": "AMBASSADE; EMBASSADE",
@@ -80280,7 +80144,6 @@
       "AMBER FISH\nAm\"ber fish. (Zoöl.)\n\nDefn: A fish of the southern Atlantic coast (Seriola Carolinensis.)"
     ],
     "references": [
-      "AMBER FISH",
       "RUDDER"
     ]
   },
@@ -80311,27 +80174,21 @@
     "variants": [
       "AMBER ROOM\nAm\"ber room\n\nDefn: A room formerly in the Czar's Summer Palace in Russia, which\nwas richly decorated with walls and fixtures made from amber.  The\namber was removed by occupying German troops during the Second World\nWar and has, as of 1997, never been recovered.  The room is being\nrecreated from old photographs by Russian artisans. PJC"
     ],
-    "references": [
-      "AMBER ROOM"
-    ]
+    "references": []
   },
   {
     "spellings": "AMBER SEED",
     "variants": [
       "AMBER SEED\nAm\"ber seed`.\n\nDefn: Seed of the Hibiscus abelmoschus, somewhat resembling millet,\nbrought from Egypt and the West Indies, and having a flavor like that\nof musk; musk seed. Chambers."
     ],
-    "references": [
-      "AMBER SEED"
-    ]
+    "references": []
   },
   {
     "spellings": "AMBER TREE",
     "variants": [
       "AMBER TREE\nAm\"ber tree`.\n\nDefn: A species of Anthospermum, a shrub with evergreen leaves,\nwhich, when bruised, emit a fragrant odor."
     ],
-    "references": [
-      "AMBER TREE"
-    ]
+    "references": []
   },
   {
     "spellings": "AMBES-AS",
@@ -80788,18 +80645,14 @@
     "variants": [
       "AMBOYNA BUTTON\nAm*boy\"na but\"ton. (Med.)\n\nDefn: A chronic contagious affection of the skin, prevalent in the\ntropics."
     ],
-    "references": [
-      "AMBOYNA BUTTON"
-    ]
+    "references": []
   },
   {
     "spellings": "AMBOYNA PINE",
     "variants": [
       "AMBOYNA PINE\nAmboyna pine. (Bot.)\n\nDefn: The resiniferous tree Agathis Dammara, of the Moluccas."
     ],
-    "references": [
-      "AMBOYNA PINE"
-    ]
+    "references": []
   },
   {
     "spellings": "AMBOYNA WOOD",
@@ -80807,7 +80660,6 @@
       "AMBOYNA WOOD\nAm*boy\"na wood.\n\nDefn: A beautiful mottled and curled wood, used in cabinetwork. It is\nobtained from the Pterocarpus Indicus of Amboyna, Borneo, etc."
     ],
     "references": [
-      "AMBOYNA WOOD",
       "KYABOCA WOOD",
       "LINGOA WOOD"
     ]
@@ -80880,9 +80732,7 @@
     "variants": [
       "AMBROSIA BEETLE\nAmbrosia beetle. (Zoöl.)\n\nDefn: A bark beetle that feeds on ambrosia."
     ],
-    "references": [
-      "AMBROSIA BEETLE"
-    ]
+    "references": []
   },
   {
     "spellings": "AMBROSIAC",
@@ -81488,9 +81338,7 @@
     "variants": [
       "A MENSA ET THORO\nA men\"sa et tho\"ro. Etym: [L., from board and bed.] (Law)\n\nDefn: A kind of divorce which does not dissolve the marriage bond,\nbut merely authorizes a separate life of the husband and wife.\nAbbott."
     ],
-    "references": [
-      "A MENSA ET THORO"
-    ]
+    "references": []
   },
   {
     "spellings": "AMENT",
@@ -82872,7 +82720,6 @@
     ],
     "references": [
       "AFRICAN",
-      "AMERICAN PLAN",
       "BUTTONWOOD",
       "CREEPING",
       "FIREWEED",
@@ -82907,9 +82754,7 @@
     "variants": [
       "AMERICAN PROTECTIVE ASSOCIATION\nA*mer\"i*can Pro*tect\"ive As*so`ci*a\"tion.\n\nDefn: A secret organization in the United States, formed in Iowa in\n1887, ostensibly for the protection of American institutions by\nkeeping Roman Catholics out of public office. Abbrev. commonly to A.P.A."
     ],
-    "references": [
-      "AMERICAN PROTECTIVE ASSOCIATION"
-    ]
+    "references": []
   },
   {
     "spellings": "AMES-ACE",
@@ -83727,7 +83572,6 @@
     ],
     "references": [
       "AMMONIA",
-      "AMMONIAC; GUM AMMONIAC",
       "ARMONIAC",
       "BEAUMONTAGUE",
       "CHLORIDE",
@@ -83747,7 +83591,6 @@
       "AMMONIACAL FERMENTATION\nAm`mo*ni\"a*cal fer`men*ta\"tion.\n\nDefn: Any fermentation process by which ammonia is formed, as that by\nwhich urea is converted into ammonium carbonate when urine is exposed\nto the air."
     ],
     "references": [
-      "AMMONIACAL FERMENTATION",
       "FERMENTATION"
     ]
   },
@@ -85694,9 +85537,7 @@
     "variants": [
       "AMOUR PROPRE\nA\"mour` pro\"pre. Etym: [F.]\n\nDefn: Self-love; self-esteem."
     ],
-    "references": [
-      "AMOUR PROPRE"
-    ]
+    "references": []
   },
   {
     "spellings": "AMOVABILITY",
@@ -85763,18 +85604,14 @@
     "variants": [
       "AMPERE FOOT\nAm`père\" foot. (Elec.)\n\nDefn: A unit, employed in calculating fall of pressure in\ndistributing mains, equivalent to a current of one ampère flowing\nthrough one foot of conductor."
     ],
-    "references": [
-      "AMPERE FOOT"
-    ]
+    "references": []
   },
   {
     "spellings": "AMPERE HOUR; AMPERE MINUTE; AMPERE SECOND",
     "variants": [
       "AMPERE HOUR; AMPERE MINUTE; AMPERE SECOND\nAmpère hour. (Elec.)\n\nDefn: The quantity of electricity delivered in one hour by a current\nwhose average strength is one ampère. It is used as a unit of\nquantity, and is equal to 3600 coulombs. The terms Ampère minute and\nAmpère second are sometimes similarly used."
     ],
-    "references": [
-      "AMPERE HOUR; AMPERE MINUTE; AMPERE SECOND"
-    ]
+    "references": []
   },
   {
     "spellings": "AMPEREMETER; AMPEROMETER",
@@ -85790,9 +85627,7 @@
     "variants": [
       "AMPERE TURN\nAmpère turn. (Elec.)\n\nDefn: A unit equal to the product of one complete convolution (of a\ncoiled conductor) into one ampère of current; thus, a conductor\nhaving five convolutions and carrying a current of half an ampère is\nsaid to have 2½ ampère turns. The magnetizing effect of a coil is\nproportional to the number of its ampère turns."
     ],
-    "references": [
-      "AMPERE TURN"
-    ]
+    "references": []
   },
   {
     "spellings": "AMPERSAND",
@@ -87116,7 +86951,6 @@
     "references": [
       "ALCOHOL",
       "AMYL",
-      "AMYL ALCOHOL",
       "FUSEL; FUSEL OIL",
       "POTATO",
       "VALERIC"
@@ -87153,7 +86987,6 @@
     ],
     "references": [
       "AMYL ALCOHOL",
-      "AMYL NITRITE",
       "NITRITE"
     ]
   },
@@ -94601,7 +94434,6 @@
       "ANCHOR ESCAPEMENT\nAn\"chor es*cape\"ment. (Horol.)\n\n(a) The common recoil escapement.\n(b) A variety of the lever escapement with a wide impulse pin."
     ],
     "references": [
-      "ANCHOR ESCAPEMENT",
       "ESCAPEMENT"
     ]
   },
@@ -94689,9 +94521,7 @@
     "variants": [
       "ANCHOR LIGHT\nAnchor light. (Naut.)\n\nDefn: The lantern shown at night by a vessel at anchor. International\nrules of the road require vessels at anchor to carry from sunset to\nsunrise a single white light forward if under 150 feet in length, and\nif longer, two such lights, one near the stern and one forward."
     ],
-    "references": [
-      "ANCHOR LIGHT"
-    ]
+    "references": []
   },
   {
     "spellings": "ANCHOR SHOT",
@@ -94699,7 +94529,6 @@
       "ANCHOR SHOT\nAnchor shot. (Billiards)\n\nDefn: A shot made with the object balls in an anchor space."
     ],
     "references": [
-      "ANCHOR SHOT",
       "GRAPPLE"
     ]
   },
@@ -94709,8 +94538,7 @@
       "ANCHOR SPACE\nAnchor space. (Billiards)\n\nDefn: In the balk-line game, any of eight spaces, 7 inches by 3½,\nlying along a cushion and bisected transversely by a balk line.\nObject balls in an anchor space are treated as in balk."
     ],
     "references": [
-      "ANCHOR SHOT",
-      "ANCHOR SPACE"
+      "ANCHOR SHOT"
     ]
   },
   {
@@ -94719,7 +94547,6 @@
       "ANCHOR WATCH\nAnchor watch. (Naut.)\n\nDefn: A detail of one or more men who keep watch on deck at night\nwhen a vessel is at anchor."
     ],
     "references": [
-      "ANCHOR WATCH",
       "WATCH"
     ]
   },
@@ -94737,9 +94564,7 @@
     "variants": [
       "ANCHOVY PEAR\nAn*cho\"vy pear`. (Bot.)\n\nDefn: A West Indian fruit like the mango in taste, sometimes pickled;\nalso, the tree (Grias cauliflora) bearing this fruit."
     ],
-    "references": [
-      "ANCHOVY PEAR"
-    ]
+    "references": []
   },
   {
     "spellings": "ANCHUSIN",
@@ -95589,9 +95414,7 @@
     "variants": [
       "ANCILLARY ADMINISTRATION\nAn\"cil*la*ry ad*min`is*tra\"tion. (Law)\n\nDefn: An administration subordinate to, and in aid of, the primary or\nprincipal administration of an estate."
     ],
-    "references": [
-      "ANCILLARY ADMINISTRATION"
-    ]
+    "references": []
   },
   {
     "spellings": "ANCILLE",
@@ -101582,7 +101405,6 @@
     ],
     "references": [
       "ANGEL",
-      "ANGEL FISH",
       "FIDDLE",
       "KINGSTON; KINGSTONE",
       "MERMAID",
@@ -102371,9 +102193,7 @@
     "variants": [
       "ANGLE OF ENTRY\nAn\"gle of en\"try. (Aëronautics)\n\nDefn: The angle between the tangent to the advancing edge (of an\naërocurve) and the line of motion; -- contrasted with angle of trail,\nwhich is the angle between the tangent to the following edge and the\nline of motion."
     ],
-    "references": [
-      "ANGLE OF ENTRY"
-    ]
+    "references": []
   },
   {
     "spellings": "ANGLE OF INCIDENCE",
@@ -102381,7 +102201,6 @@
       "ANGLE OF INCIDENCE\nAngle of incidence. (Aëronautics)\n\nDefn: The angle between the chord of an aërocurve and the relative\ndirection of the undisturbed air current."
     ],
     "references": [
-      "ANGLE OF INCIDENCE",
       "CRITICAL",
       "INCIDENCE",
       "INDEX",
@@ -103011,9 +102830,7 @@
     "variants": [
       "ANGOLA PEA\nAn*go\"la pea`. (Bot.)\n\nDefn: A tropical plant (Cajanus indicus) and its edible seed, a kind\nof pulse; -- so called from Angola in Western Africa. Called also\npigeon pea and Congo pea."
     ],
-    "references": [
-      "ANGOLA PEA"
-    ]
+    "references": []
   },
   {
     "spellings": "ANGOR",
@@ -103044,7 +102861,6 @@
       "ANGOSTURA BARK\nAn`gos*tu\"ra bark\". Etym: [From Angostura, in Venezuela.]\n\nDefn: An aromatic bark used as a tonic, obtained from a South\nAmerican of the rue family (Galipea cusparia, or officinalis). U. S.\nDisp."
     ],
     "references": [
-      "ANGOSTURA BARK",
       "ANGUSTURA BARK"
     ]
   },
@@ -103053,9 +102869,7 @@
     "variants": [
       "ANGOUMOIS MOTH\nAn`gou`mois\" moth\". Etym: [So named from Angoumois in France.]\n(Zoöl.)\n\nDefn: A small moth (Gelechia cerealella) which is very destructive to\nwheat and other grain. The larva eats out the inferior of the grain,\nleaving only the shell."
     ],
-    "references": [
-      "ANGOUMOIS MOTH"
-    ]
+    "references": []
   },
   {
     "spellings": "ANGRILY",
@@ -103495,9 +103309,7 @@
     "variants": [
       "ANGUSTURA BARK\nAn`gus*tu\"ra bark`.\n\nDefn: See Angostura bark."
     ],
-    "references": [
-      "ANGUSTURA BARK"
-    ]
+    "references": []
   },
   {
     "spellings": "ANGWANTIBO",
@@ -105983,7 +105795,6 @@
       "ANNO DOMINI\nAn\"no Dom\"i*ni. Etym: [L., in the year of [our] Lord [Jesus Christ];\nusually abbrev. a. d.]\n\nDefn: In the year of the Christian era; as, a. d. 1887."
     ],
     "references": [
-      "ANNO DOMINI",
       "YEAR"
     ]
   },
@@ -106861,7 +106672,6 @@
       "ANNUNCIATION LILY\nAn*nun`ci*a\"tion lil\"y. (Bot.)\n\nDefn: The common white lily (Lilium candidum). So called because it\nis usually introduced by painters in pictures of the Annunciation."
     ],
     "references": [
-      "ANNUNCIATION LILY",
       "EASTER LILY"
     ]
   },
@@ -109898,9 +109708,7 @@
     "variants": [
       "AN 'T\nAn 't.\n\nDefn: An it, that is, and it or if it. See An, conj. [Obs.]"
     ],
-    "references": [
-      "AN 'T"
-    ]
+    "references": []
   },
   {
     "spellings": "AN'T",
@@ -110451,7 +110259,6 @@
     ],
     "references": [
       "ANT",
-      "ANT BIRD",
       "ANT THRUSH",
       "ARGALA",
       "GUIDGUID",
@@ -110471,9 +110278,7 @@
     "variants": [
       "ANT COW\nAnt cow. (Zoöl.)\n\nDefn: Any aphid from which ants obtain honeydew."
     ],
-    "references": [
-      "ANT COW"
-    ]
+    "references": []
   },
   {
     "spellings": "ANTE-",
@@ -110776,9 +110581,7 @@
     "variants": [
       "ANT EGG\nAnt\" egg`.\n\nDefn: One of the small white egg-shaped pupæ or cocoons of the ant,\noften seen in or about ant-hills, and popularly supposed to be eggs."
     ],
-    "references": [
-      "ANT EGG"
-    ]
+    "references": []
   },
   {
     "spellings": "ANTELOPE",
@@ -110883,9 +110686,7 @@
     "variants": [
       "ANTE MORTEM\nAn`te mor\"tem. [L.]\n\nDefn: Before death; -- generally used adjectivelly; as, an ante-\nmortem statement; ante-mortem examination.\n\n The ante-mortem statement, or dying declaration made in view of\ndeath, by one injured, as to the cause and manner of the injury, is\noften receivable in evidence against one charged with causing the\ndeath."
     ],
-    "references": [
-      "ANTE MORTEM"
-    ]
+    "references": []
   },
   {
     "spellings": "ANTEMOSAIC",
@@ -111639,7 +111440,6 @@
       "ANTHONY'S FIRE\nAn\"tho*ny's Fire`.\n\nDefn: See Saint Anthony's Fire, under Saint."
     ],
     "references": [
-      "ANTHONY'S FIRE",
       "ERYSIPELAS",
       "FIRE",
       "SAINT"
@@ -111777,9 +111577,7 @@
     "variants": [
       "ANTHRACENE OIL\nAn\"thra*cene oil.\n\nDefn: A heavy green oil (partially solidifying on cooling), which\ndistills over from coal tar at a temperature above 270º. It is the\nprincipal source of anthracene."
     ],
-    "references": [
-      "ANTHRACENE OIL"
-    ]
+    "references": []
   },
   {
     "spellings": "ANTHRACIC",
@@ -111911,9 +111709,7 @@
     "variants": [
       "ANTHRAX VACCINE\nAn\"thrax vac\"cine. (Veter.)\n\nDefn: A fluid vaccine obtained by growing a bacterium (Bacterium\nanthracis) in beef broth. It is used to immunize animals, esp.\ncattle."
     ],
-    "references": [
-      "ANTHRAX VACCINE"
-    ]
+    "references": []
   },
   {
     "spellings": "ANTHRENUS",
@@ -114767,7 +114563,6 @@
     ],
     "references": [
       "ANT",
-      "ANT THRUSH",
       "BREVE",
       "FORMICAROID",
       "PITTA",
@@ -122211,7 +122006,6 @@
       "APARTMENT HOUSE\nA*part\"ment house.\n\nDefn: A building comprising a number of suites designed for separate\nhousekeeping tenements, but having conveniences, such as heat, light,\nelevator service, etc., furnished in common; -- often distinguished\nin the United States from a flat house."
     ],
     "references": [
-      "APARTMENT HOUSE",
       "TENEMENT"
     ]
   },
@@ -122916,7 +122710,6 @@
       "APHIS LION\nA\"phis li\"on. (Zoöl.)\n\nDefn: The larva of the lacewinged flies (Chrysopa), which feeds\nvoraciously upon aphids. The name is also applied to the larvæ of the\nladybugs (Coccinella)."
     ],
     "references": [
-      "APHIS LION",
       "PEDICEL"
     ]
   },
@@ -123019,9 +122812,7 @@
     "variants": [
       "APHOTIC REGION\nAphotic region. (Phytogeog.)\n\nDefn: A depth of water so great that only those organisms can exist\nthat do not assimilate."
     ],
-    "references": [
-      "APHOTIC REGION"
-    ]
+    "references": []
   },
   {
     "spellings": "APHRASIA",
@@ -123863,9 +123654,7 @@
     "variants": [
       "APOLLINARIS WATER\nA*pol`li*na\"ris wa\"ter.\n\nDefn: An effervescing alkaline mineral water used as a table\nbeverage. It is obtained from a spring in Apollinarisburg, near Bonn."
     ],
-    "references": [
-      "APOLLINARIS WATER"
-    ]
+    "references": []
   },
   {
     "spellings": "APOLLO",
@@ -124390,7 +124179,6 @@
       "A POSTERIORI\nA` pos*te`ri*o\"ri. Etym: [L. a (ab) + posterior latter.]\n\n1. (Logic)\n\nDefn: Characterizing that kind of reasoning which derives\npropositions from the observation of facts, or by generalizations\nfrom facts arrives at principles and definitions, or infers causes\nfrom effects. This is the reverse of a priori reasoning.\n\n2. (Philos.)\n\nDefn: Applied to knowledge which is based upon or derived from facts\nthrough induction or experiment; inductive or empirical."
     ],
     "references": [
-      "A POSTERIORI",
       "A PRIORI"
     ]
   },
@@ -124513,9 +124301,7 @@
     "variants": [
       "APOSTOLIC DELEGATE\nAp`os*tol\"ic del\"e*gate. (R. C. Ch.)\n\nDefn: The diplomatic agent of the pope highest in grade, superior to\na nuncio."
     ],
-    "references": [
-      "APOSTOLIC DELEGATE"
-    ]
+    "references": []
   },
   {
     "spellings": "APOSTOLICISM; APOSTOLICITY",
@@ -127254,9 +127040,7 @@
     "variants": [
       "APPENDIX VERMIFORMIS\nAp*pen\"dix ver`mi*for\"mis. [NL.] (Anat.)\n\nDefn: The vermiform appendix."
     ],
-    "references": [
-      "APPENDIX VERMIFORMIS"
-    ]
+    "references": []
   },
   {
     "spellings": "APPENSION",
@@ -127862,7 +127646,6 @@
       "APPLE PIE\nAp\"ple pie`.\n\nDefn: A pie made of apples (usually sliced or stewed) with spice and\nsugar. Apple-pie bed, a bed in which, as a joke, the sheets are so\ndoubled (like the cover of an apple turnover) as to prevent any one\nfrom getting at his length between them. Halliwell, Conybeare.\n -- Apple-pie order, perfect order or arrangement. [Colloq.]\nHalliwell."
     ],
     "references": [
-      "APPLE PIE",
       "PIE",
       "POOR-JOHN"
     ]
@@ -130466,7 +130249,6 @@
     "references": [
       "ANALOGISM",
       "A POSTERIORI",
-      "A PRIORI",
       "APRIORISM",
       "APRIORITY",
       "INNATE",
@@ -130572,18 +130354,14 @@
     "variants": [
       "APRON MAN\nA\"pron man`.\n\nDefn: A man who wears an apron; a laboring man; a mechanic. [Obs.]\nShak."
     ],
-    "references": [
-      "APRON MAN"
-    ]
+    "references": []
   },
   {
     "spellings": "APRON STRING",
     "variants": [
       "APRON STRING\nA\"pron string`.\n\nDefn: The string of an apron. To be tied to a wife's or mother's\napron strings, to be unduly controlled by a wife or mother.\nHe was so made that he could not submit to be tied to the apron\nstrings even of the best of wives. Macaulay."
     ],
-    "references": [
-      "APRON STRING"
-    ]
+    "references": []
   },
   {
     "spellings": "APROPOS",
@@ -131056,7 +130834,6 @@
       "AQUA FORTIS\nA`qua for\"tis. Etym: [L., strong water.] (Chem.)\n\nDefn: Nitric acid. [Archaic]"
     ],
     "references": [
-      "AQUA FORTIS",
       "CORRODE"
     ]
   },
@@ -133152,9 +132929,7 @@
     "variants": [
       "ARBOR DIANAE\nAr\"bor Di*a\"næ. Etym: [L., the tree of Diana, or silver.] (Chem.)\n\nDefn: A precipitation of silver, in a beautiful arborescent form."
     ],
-    "references": [
-      "ARBOR DIANAE"
-    ]
+    "references": []
   },
   {
     "spellings": "ARBOREAL",
@@ -133326,18 +133101,14 @@
     "variants": [
       "ARBOR VINE\nAr\"bor vine`.\n\nDefn: A species of bindweed."
     ],
-    "references": [
-      "ARBOR VINE"
-    ]
+    "references": []
   },
   {
     "spellings": "ARBOR VITAE",
     "variants": [
       "ARBOR VITAE\nAr\"bor vi\"tæ. Etym: [L., tree of life.]\n\n1. (Bot.)\n\nDefn: An evergreen tree of the cypress tribe, genus Thuja. The\nAmerican species is the T. occidentalis.\n\n2. (Anat.)\n\nDefn: The treelike disposition of the gray and white nerve tissues in\nthe cerebellum, as seen in a vertical section."
     ],
-    "references": [
-      "ARBOR VITAE"
-    ]
+    "references": []
   },
   {
     "spellings": "ARBUSCLE",
@@ -134164,9 +133935,7 @@
     "variants": [
       "ARCH BRICK\nArch\" brick`.\n\nDefn: A wedge-shaped brick used in the building of an arch."
     ],
-    "references": [
-      "ARCH BRICK"
-    ]
+    "references": []
   },
   {
     "spellings": "ARCHBUTLER",
@@ -134459,7 +134228,6 @@
       "ARCHER FISH\nArch\"er fish`. (Zoöl.)\n\nDefn: A small fish (Toxotes jaculator), of the East Indies; -- so\ncalled from its ejecting drops of water from its mouth at its prey.\nThe name is also applied to Chætodon rostratus."
     ],
     "references": [
-      "ARCHER FISH",
       "JACULATOR",
       "TOXOTES"
     ]
@@ -134636,9 +134404,7 @@
     "variants": [
       "ARCHIBALD WHEEL\nAr\"chi*bald wheel.\n\nDefn: A metal-hubbed wheel of great strength and elasticity, esp.\nadapted for artillery carriages and motor cars."
     ],
-    "references": [
-      "ARCHIBALD WHEEL"
-    ]
+    "references": []
   },
   {
     "spellings": "ARCHIBLASTULA",
@@ -135235,9 +135001,7 @@
     "variants": [
       "ARCH STONE\nArch\" stone`.\n\nDefn: A wedge-shaped stone used in an arch; a voussoir."
     ],
-    "references": [
-      "ARCH STONE"
-    ]
+    "references": []
   },
   {
     "spellings": "ARCHTRAITOR",
@@ -135298,9 +135062,7 @@
     "variants": [
       "ARC LIGHT\nArc light. (Elec.)\n\nDefn: The light of an arc lamp."
     ],
-    "references": [
-      "ARC LIGHT"
-    ]
+    "references": []
   },
   {
     "spellings": "ARCOGRAPH",
@@ -135609,9 +135371,7 @@
     "variants": [
       "ARDOIS SYSTEM\nAr`dois\" sys\"tem. (Naut.)\n\nDefn: A widely used system of electric night signals in which a\nseries of double electric lamps (white and red) is arranged\nvertically on a mast, and operated from a keyboard below."
     ],
-    "references": [
-      "ARDOIS SYSTEM"
-    ]
+    "references": []
   },
   {
     "spellings": "ARDOR",
@@ -141205,7 +140965,6 @@
       "ARGAND LAMP\nAr\"gand lamp`. Etym: [Named from the inventor, Aimé Argand of\nGeneva.]\n\nDefn: A lamp with a circular hollow wick and glass chimney which\nallow a current of air both inside and outside of the flame. Argand\nburner, a burner for an Argand lamp, or a gas burner in which the\nprinciple of that lamp is applied."
     ],
     "references": [
-      "ARGAND LAMP",
       "ASTRAL",
       "FROST",
       "OXIDATOR",
@@ -141991,9 +141750,7 @@
     "variants": [
       "ARGUS SHELL\nAr\"gus shell` . (Zoöl.)\n\nDefn: A species of shell (Cypræa argus), beautifully variegated with\nspots resembling those in a peacock's tail."
     ],
-    "references": [
-      "ARGUS SHELL"
-    ]
+    "references": []
   },
   {
     "spellings": "ARGUTATION",
@@ -142131,7 +141888,6 @@
       "ARIEL; ARIEL GAZELLE\nA\"ri*el, n., or; A\"ri*el ga*zelle\". Etym: [Ar. aryil, ayyil, stag.]\n(Zoöl.) A)\n\nDefn: A variety of the gazelle (Antilope, or Gazella, dorcas), found\nin Arabia and adjacent countries. (b) A squirrel-like Australian\nmarsupial, a species of Petaurus. (c) A beautiful Brazilian toucan\nRamphastos ariel)."
     ],
     "references": [
-      "ARIEL; ARIEL GAZELLE",
       "BREAK",
       "COROLLARY",
       "FAIRY",
@@ -142507,7 +142263,6 @@
       "ARISTOTLE'S LANTERN\nAr\"is*to`tle's lan\"tern. (Zoöl.)\n\nDefn: The five united jaws and accessory ossicles of certain sea\nurchins."
     ],
     "references": [
-      "ARISTOTLE'S LANTERN",
       "LANTERN"
     ]
   },
@@ -142684,9 +142439,7 @@
     "variants": [
       "ARK SHELL\nArk\" shell`. (Zoöl.)\n\nDefn: A marine bivalve shell belonging to the genus Arca and its\nallies."
     ],
-    "references": [
-      "ARK SHELL"
-    ]
+    "references": []
   },
   {
     "spellings": "ARLES",
@@ -143692,9 +143445,7 @@
     "variants": [
       "ARMORED CRUISER\nAr\"mored cruis\"er. (Nav.)\n\nDefn: A man-of-war carrying a large coal supply, and more or less\nprotected from the enemy's shot by iron or steel armor. There is no\ndistinct and accepted classification distinguishing armored and\nprotected cruisers from each other, except that the first have more\nor heavier armor than the second."
     ],
-    "references": [
-      "ARMORED CRUISER"
-    ]
+    "references": []
   },
   {
     "spellings": "ARMORER",
@@ -144652,7 +144403,6 @@
       "ARMY ORGANIZATION\nArmy organization.\n\nDefn: The system by which a country raises, classifies, arranges, and\nequips its armed land forces. The usual divisions are: (1) A regular\nor active army, in which soldiers serve continuously with the colors\nand live in barracks or cantonments when not in the field; (2) the\nreserves of this army, in which the soldiers, while remaining\nconstantly subject to a call to the colors, live at their homes,\nbeing summoned more or less frequently to report for instruction,\ndrill, or maneuvers; and (3) one or more classes of soldiers\norganized largely for territorial defense, living at home and having\nonly occasional periods of drill and instraction, who are variously\ncalled home reserves (as in the table below), second, third, etc.,\nline of defense (the regular army and its reserves ordinarily\nconstituting the first line of defense), territorial forces, or the\nlike. In countries where conscription prevails a soldier is supposed\nto serve a given number of years.  He is usually enrolled first in\nthe regular army, then passes to its reserve, then into the home\nreserves, to serve until he reaches the age limit. It for any reason\nhe is not enrolled in the regular army, he may begin his service in\nthe army reserves or even the home reserves, but then serves the full\nnumber of years or up to the age limit. In equipment the organization\nof the army is into the three great arms of infantry, cavalry, and\nartillery, together with more or less numerous other branches, such\nas engineers, medical corps, etc., besides the staff organizations\nsuch as those of the pay and subsistence departments."
     ],
     "references": [
-      "ARMY ORGANIZATION",
       "AUSZUG",
       "GARDE CIVIQUE",
       "HONVEDSEG",
@@ -144668,7 +144418,6 @@
       "ARMY WORM\nAr\"my worm`. (Zoöl.)\n\n(a) A lepidopterous insect, which in the larval state often travels\nin great multitudes from field to field, destroying grass, grain, and\nother crops. The common army worm of the northern United States is\nLeucania unipuncta. The name is often applied to other related\nspecies, as the cotton worm.\n(b) The larva of a small two-winged fly (Sciara), which marches in\nlarge companies, in regular order. See Cotton worm, under Cotton."
     ],
     "references": [
-      "ARMY WORM",
       "CATERPILLAR",
       "COTTON",
       "IMAGO"
@@ -146998,9 +146747,7 @@
     "variants": [
       "ARROW GRASS\nAr\"row grass`, n. (Bot.)\n\nDefn: An herbaceous grasslike plant (Triglochin palustre, and other\nspecies) with pods opening so as to suggest barbed arrowheads."
     ],
-    "references": [
-      "ARROW GRASS"
-    ]
+    "references": []
   },
   {
     "spellings": "ARROWHEAD",
@@ -150116,9 +149863,7 @@
     "variants": [
       "ARTILLERY WHEEL\nAr*til\"ler*y wheel.\n\nDefn: A kind of heavily built dished wheel with a long axle box, used\non gun carriages, usually having 14 spokes and 7 felloes; hence, a\nwheel of similar construction for use on automobiles, etc."
     ],
-    "references": [
-      "ARTILLERY WHEEL"
-    ]
+    "references": []
   },
   {
     "spellings": "ARTIODACTYLA",
@@ -150392,9 +150137,7 @@
     "variants": [
       "ART UNION\nArt` un\"ion.\n\nDefn: An association for promoting art (esp. the arts of design), and\ngiving encouragement to artists."
     ],
-    "references": [
-      "ART UNION"
-    ]
+    "references": []
   },
   {
     "spellings": "ARUM",
@@ -156927,7 +156670,6 @@
       "ASH WEDNESDAY\nAsh` Wednes\"day.\n\nDefn: The first day of Lent; -- so called from a custom in the Roman\nCatholic church of putting ashes, on that day, upon the foreheads of\npenitents."
     ],
     "references": [
-      "ASH WEDNESDAY",
       "LENT",
       "OPETIDE",
       "SHROVE",
@@ -157866,9 +157608,7 @@
     "variants": [
       "ASPECT RATIO\nAspect ratio. (Aëronautics)\n\nDefn: The ratio of the long to the short side of an aëroplane,\naërocurve, or wing."
     ],
-    "references": [
-      "ASPECT RATIO"
-    ]
+    "references": []
   },
   {
     "spellings": "ASPEN; ASP",
@@ -158830,9 +158570,7 @@
     "variants": [
       "ASSAY POUND\nAs\"say pound.\n\nDefn: A small standard weight used in assaying bullion, etc.,\nsometimes equaling 0.5 gram, but varying with the assayer."
     ],
-    "references": [
-      "ASSAY POUND"
-    ]
+    "references": []
   },
   {
     "spellings": "ASSAY TON",
@@ -158840,8 +158578,7 @@
       "ASSAY TON\nAssay ton.\n\nDefn: A weight of 29.166 + grams used in assaying, for convenience.\nSince it bears the same relation to the milligram that a ton of 2000\navoirdupois pounds does to the troy ounce, the weight in milligrams\nof precious metal obtained from an assay ton of ore gives directly\nthe number of ounces to the ton."
     ],
     "references": [
-      "ASSAY",
-      "ASSAY TON"
+      "ASSAY"
     ]
   },
   {
@@ -162065,9 +161802,7 @@
     "variants": [
       "ASTHMA PAPER\nAsth\"ma pa\"per.\n\nDefn: Paper impregnated with saltpeter. The fumes from the burning\npaper are often inhaled as an alleviative by asthmatics."
     ],
-    "references": [
-      "ASTHMA PAPER"
-    ]
+    "references": []
   },
   {
     "spellings": "ASTHMATIC; ASTHMATICAL",
@@ -168416,7 +168151,6 @@
       "ATAMASCO LILY\nAt`a*mas\"co lil\"y. [Atamasco is fr. North American Indian.] (Bot.)\n\nDefn: See under Lily."
     ],
     "references": [
-      "ATAMASCO LILY",
       "EASTER LILY",
       "LILY"
     ]
@@ -168522,9 +168256,7 @@
     "variants": [
       "ATELETS SAUCE; SAUCE AUX HATELETS\nA`te*lets\" sauce or  Sauce` aux ha`te*lets\". [F. hâtelet skewer.]\n\nDefn: A sauce (such as egg and bread crumbs) used for covering bits\nof meat, small birds, or fish, strung on skewers for frying."
     ],
-    "references": [
-      "ATELETS SAUCE; SAUCE AUX HATELETS"
-    ]
+    "references": []
   },
   {
     "spellings": "ATELIER",
@@ -169165,7 +168897,6 @@
     ],
     "references": [
       "ATLAS",
-      "ATLAS POWDER",
       "POWDER"
     ]
   },
@@ -169799,7 +169530,6 @@
       "ANNOY",
       "APOSTASY",
       "AT",
-      "AT ONE",
       "ATONE",
       "ATONEMENT",
       "ATONES",
@@ -172744,8 +172474,7 @@
       "ATTRACTION SPHERE\nAt*trac\"tion sphere.\n\n1. (Zoöl.)\n (a) The central mass of the aster in mitotic cell division;\ncentrosphere.\n (b) Less often, the mass of archoplasm left by the aster in the\nresting cell.\n\n2.  (Bot.) A small body situated on or near the nucleus in the cells\nof some of the lower plants, consisting of two centrospheres\ncontaining centrosomes. It exercises an important function in\nmitosis."
     ],
     "references": [
-      "ARCHOPLASM",
-      "ATTRACTION SPHERE"
+      "ARCHOPLASM"
     ]
   },
   {
@@ -173197,7 +172926,6 @@
       "AUCTION BRIDGE\nAuc\"tion bridge.\n\nDefn: A variety of the game of bridge in which the players, beginning\nwith the dealer, bid for the privilege of naming the trump and\nplaying with the dummy for that deal, there being heavy penalties for\na player's failure to make good his bid. The score value of each\ntrick more than six taken by the successful bidder is as follows:\nwhen the trump is spades, 2; clubs, 6; diamonds, 7; hearts, 8; royal\nspades (lilies), 9; and when the deal is played with no trump, 10."
     ],
     "references": [
-      "AUCTION BRIDGE",
       "ROYAL SPADE"
     ]
   },
@@ -173223,7 +172951,6 @@
       "AUCTION PITCH\nAuction pitch.\n\nDefn: A game of cards in which the players bid for the privilege of\ndetermining or \"pitching\" the trump suit.  R. F. Foster."
     ],
     "references": [
-      "AUCTION PITCH",
       "PEDRO",
       "SANCHO PEDRO"
     ]
@@ -173480,7 +173207,6 @@
       "AUDITA QUERELA\nAu*di\"ta que*re\"la. Etym: [L., the complaint having been heard.]\n(Law)\n\nDefn: A writ which lies for a party against whom judgment is\nrecovered, but to whom good matter of discharge has subsequently\naccrued which could not have been availed of to prevent such\njudgment. Wharton."
     ],
     "references": [
-      "AUDITA QUERELA",
       "QUERELE"
     ]
   },
@@ -173611,9 +173337,7 @@
     "variants": [
       "AU FAIT\nAu` fait\". Etym: [F. Lit., to the deed, act, or point. Fait is fr. L.\nfactum. See Fact.]\n\nDefn: Expert; skillful; well instructed."
     ],
-    "references": [
-      "AU FAIT"
-    ]
+    "references": []
   },
   {
     "spellings": "AUFKLARUNG",
@@ -173627,9 +173351,7 @@
     "variants": [
       "AU FOND\nAu` fond\". [F., lit., at the bottom.]\n\nDefn: At bottom; fundamentally; essentially."
     ],
-    "references": [
-      "AU FOND"
-    ]
+    "references": []
   },
   {
     "spellings": "AUGEAN",
@@ -173834,9 +173556,7 @@
     "variants": [
       "AU GRATIN\nAu` gra`tin\". [F.] (Cookery)\n\nDefn: With a crust made by browning in the oven; as, spaghetti may be\nserved au gratin."
     ],
-    "references": [
-      "AU GRATIN"
-    ]
+    "references": []
   },
   {
     "spellings": "AUGRIM",
@@ -174128,7 +173848,6 @@
       "AULD LANG SYNE\nAuld` lang syne\".\n\nDefn: A Scottish phrase used in recalling recollections of times long\nsince past. \"The days of auld lang syne.\""
     ],
     "references": [
-      "AULD LANG SYNE",
       "OLD LANG SYNE"
     ]
   },
@@ -174137,9 +173856,7 @@
     "variants": [
       "AULD LICHT; AULD LIGHT\nAuld licht, Auld light . (Eccl. Hist.)\n\n (a) A member of the conservative party in the Church of Scotland in\nthe latter part of the 18th century.\n (b) Same as Burgher, n., 2."
     ],
-    "references": [
-      "AULD LICHT; AULD LIGHT"
-    ]
+    "references": []
   },
   {
     "spellings": "AULETIC",
@@ -174381,9 +174098,7 @@
     "variants": [
       "AU REVOIR\nAu` re*voir\". [F., lit., to the seeing again.]\n\nDefn: Good-by until we meet again."
     ],
-    "references": [
-      "AU REVOIR"
-    ]
+    "references": []
   },
   {
     "spellings": "AURIC",
@@ -175185,9 +174900,7 @@
     "variants": [
       "AUSTRALIAN BALLOT\nAus*tra\"li*an bal\"lot. (Law)\n\nDefn: A system of balloting or voting in public elections, originally\nused in South Australia, in which there is such an arrangement for\npolling votes that secrecy is compulsorily maintained, and the ballot\nused is an official ballot printed and distributed by the government."
     ],
-    "references": [
-      "AUSTRALIAN BALLOT"
-    ]
+    "references": []
   },
   {
     "spellings": "AUSTRALIZE",
@@ -176367,9 +176080,7 @@
     "variants": [
       "AUTHORIZE ONE'S SELF\nTo authorize one's self\n\nDefn: , to rely for authority. [Obs.]\nAuthorizing himself, for the most part, upon other histories. Sir P.\nSidney."
     ],
-    "references": [
-      "AUTHORIZE ONE'S SELF"
-    ]
+    "references": []
   },
   {
     "spellings": "AUTHORIZER",
@@ -176708,18 +176419,14 @@
     "variants": [
       "AUTOGENETIC DRAINAGE\nAutogenetic drainage. (Phys. Geog.)\n\nDefn: A system of natural drainage developed by the constituent\nstreams through headwater erosion."
     ],
-    "references": [
-      "AUTOGENETIC DRAINAGE"
-    ]
+    "references": []
   },
   {
     "spellings": "AUTOGENETIC TOPOGRAPHY",
     "variants": [
       "AUTOGENETIC TOPOGRAPHY\nAutogenetic topography. (Phys. Geog.)\n\nDefn: A system of land forms produced by the free action of rain and\nstreams on rocks of uniform texture."
     ],
-    "references": [
-      "AUTOGENETIC TOPOGRAPHY"
-    ]
+    "references": []
   },
   {
     "spellings": "AUTOGENOUS",
@@ -176858,9 +176565,7 @@
     "variants": [
       "AUTOKINETIC SYSTEM\nAutokinetic system.\n\nDefn: In fire-alarm telegraphy, a system so arranged that when one\nalarm is being transmitted, no other alarm, sent in from another\npoint, will be transmitted until after the first alarm has been\ndisposed of."
     ],
-    "references": [
-      "AUTOKINETIC SYSTEM"
-    ]
+    "references": []
   },
   {
     "spellings": "AUTOLATRY",
@@ -176991,9 +176696,7 @@
     "variants": [
       "AUTOMIXTE SYSTEM\nAu`to*mixte\" system. (Mach.)\n\nDefn: A system (devised by Henri Pieper, a Belgian) of driving\nautomobiles employing a gasoline engine and an auxiliary reversible\ndynamo. When there is an excess of power the dynamo is driven by the\nengine so as to charge a small storage battery; when there is a\ndeficiency of power the dynamo reverses and acts as an auxiliary\nmotor. Sometimes called Pieper system. -- Automixte car, etc."
     ],
-    "references": [
-      "AUTOMIXTE SYSTEM"
-    ]
+    "references": []
   },
   {
     "spellings": "AUTOMOBILE",
@@ -177848,7 +177551,6 @@
     "references": [
       "ANGELUS",
       "AVE",
-      "AVE MARIA; AVE MARY",
       "FORTH",
       "HAIL",
       "ROSARY"
@@ -178589,9 +178291,7 @@
     "variants": [
       "AVIGNON BERRY\nA`vignon\" ber\"ry. (Bot.)\n\nDefn: The fruit of the Rhamnus infectorius, eand of other species of\nthe same genus; -- so called from the city of Avignon, in France. It\nis used by dyers and painters for coloring yellow. Called also French\nberry."
     ],
-    "references": [
-      "AVIGNON BERRY"
-    ]
+    "references": []
   },
   {
     "spellings": "AVILE",
@@ -180617,9 +180317,7 @@
     "variants": [
       "AWKWARD SQUAD\nAwk\"ward squad. (Mil.)\n\nDefn: A squad of inapt recruits assembled for special drill."
     ],
-    "references": [
-      "AWKWARD SQUAD"
-    ]
+    "references": []
   },
   {
     "spellings": "AWL",
@@ -181512,7 +181210,6 @@
     ],
     "references": [
       "ARTILLERY WHEEL",
-      "AXLE BOX",
       "AXLE GUARD",
       "BISSELL TRUCK",
       "BOX",
@@ -181541,7 +181238,6 @@
     ],
     "references": [
       "AXLE BOX",
-      "AXLE GUARD",
       "JAW"
     ]
   },
@@ -181582,8 +181278,7 @@
       "AXMINSTER; AXMINSTER CARPET\nAx\"min*ster, n., or Axminster carpet .\n\n (a) [More fully chenille Axminster.] A variety of Turkey carpet,\nwoven by machine or, when more than 27 inches wide, on a hand loom,\nand consisting of strips of worsted chenille so colored as to produce\na pattern on a stout jute backing. It has a fine soft pile. So called\nfrom Axminster, England, where it was formerly (1755 -- 1835) made.\n (b) A similar but cheaper machine-made carpet, resembling moquette\nin construction and appearance, but finer and of better material."
     ],
     "references": [
-      "AXMINSTER",
-      "AXMINSTER; AXMINSTER CARPET"
+      "AXMINSTER"
     ]
   },
   {

--- a/output/wordDisplayData#B.json
+++ b/output/wordDisplayData#B.json
@@ -1352,8 +1352,7 @@
       "BABBITT METAL\nBab\"bitt met`al. Etym: [From the inventor, Isaac Babbitt of\nMassachusetts.]\n\nDefn: A soft white alloy of variable composition (as a nine parts of\ntin to one of copper, or of fifty parts of tin to five of antimony\nand one of copper) used in bearings to diminish friction."
     ],
     "references": [
-      "BABBITT",
-      "BABBITT METAL"
+      "BABBITT"
     ]
   },
   {
@@ -1640,7 +1639,6 @@
       "BABY FARM\nBa\"by farm`.\n\nDefn: A place where the nourishment and care of babies are offered\nfor hire."
     ],
     "references": [
-      "BABY FARM",
       "BABY FARMER",
       "BABY FARMING"
     ]
@@ -1650,18 +1648,14 @@
     "variants": [
       "BABY FARMER\nBa\"by farm`er.\n\nDefn: One who keeps a baby farm."
     ],
-    "references": [
-      "BABY FARMER"
-    ]
+    "references": []
   },
   {
     "spellings": "BABY FARMING",
     "variants": [
       "BABY FARMING\nBa\"by farm`ing.\n\nDefn: The business of keeping a baby farm."
     ],
-    "references": [
-      "BABY FARMING"
-    ]
+    "references": []
   },
   {
     "spellings": "BABYHOOD",
@@ -1702,7 +1696,6 @@
       "BABY JUMPER\nBa\"by jump`er.\n\nDefn: A hoop suspended by an elastic strap, in which a young child\nmay be held secure while amusing itself by jumping on the floor."
     ],
     "references": [
-      "BABY JUMPER",
       "JUMPER"
     ]
   },
@@ -2072,9 +2065,7 @@
     "variants": [
       "BACHELOR'S BUTTON\nBach\"e*lor's but\"ton\n\nDefn: , (Bot.) A plant with flowers shaped like buttons; especially,\nseveral species of Ranunculus, and the cornflower (Centaures cyanus)\nand globe amaranth (Gomphrena).\n\nNote: Bachelor's buttons, a name given to several flowers \"from their\nsimilitude to the jagged cloathe buttons, anciently worne in this\nkingdom\", according to Johnson's Gerarde, p.472 (1633); but by other\nwriters ascribed to \"a habit of country fellows to carry them in\ntheir pockets to divine their success with their sweethearts.\" Dr.\nPrior."
     ],
-    "references": [
-      "BACHELOR'S BUTTON"
-    ]
+    "references": []
   },
   {
     "spellings": "BACHELORSHIP",
@@ -3270,7 +3261,6 @@
       "BACK DOOR\nBack\" door\".\n\nDefn: A door in the back part of a building; hence, an indirect way.\nAtterbury."
     ],
     "references": [
-      "BACK DOOR",
       "POSTERN"
     ]
   },
@@ -3325,7 +3315,6 @@
       "BACK FIRE\nBack fire.\n\n (a) A fire started ahead of a forest or prairie fire to burn only\nagainst the wind, so that when the two fires meet both must go out\nfor lack of fuel.\n (b) A premature explosion in the cylinder of a gas or oil engine\nduring the exhaust or the compression stroke, tending to drive the\npiston in a direction reverse to that in which it should travel;\nalso, an explosion in the exhaust passages of such ah engine."
     ],
     "references": [
-      "BACK FIRE",
       "BACK-FIRE"
     ]
   },
@@ -3629,7 +3618,6 @@
     ],
     "references": [
       "BACK",
-      "BACK STAIRS",
       "BACKSTAIRS; BACKSTAIR"
     ]
   },
@@ -6280,9 +6268,7 @@
     "variants": [
       "BADGER GAME\nBadg\"er game.\n\nDefn: The method of blackmailing by decoying a person into a\ncompromising situation and extorting money by threats of exposure.\n[Cant]"
     ],
-    "references": [
-      "BADGER GAME"
-    ]
+    "references": []
   },
   {
     "spellings": "BADGERING",
@@ -6305,9 +6291,7 @@
     "variants": [
       "BADGER STATE\nBadger State.\n\nDefn: Wisconsin; -- a nickname."
     ],
-    "references": [
-      "BADGER STATE"
-    ]
+    "references": []
   },
   {
     "spellings": "BADIAGA",
@@ -6345,9 +6329,7 @@
     "variants": [
       "BAD LANDS\nBad\" lands\".\n\nDefn: Barren regions, especially in the western United States, where\nhorizontal strata (Tertiary deposits) have been often eroded into\nfantastic forms, and much intersected by canons, and where lack of\nwood, water, and forage increases the difficulty of traversing the\ncountry, whence the name, first given by the Canadian French,\nMauvaises Terres (bad lands)."
     ],
-    "references": [
-      "BAD LANDS"
-    ]
+    "references": []
   },
   {
     "spellings": "BADLY",
@@ -6751,9 +6733,7 @@
     "variants": [
       "BAGGAGE MASTER\nBag\"gage mas`ter.\n\nDefn: One who has charge of the baggage at a railway station or upon\na line of public travel. [U.S.]"
     ],
-    "references": [
-      "BAGGAGE MASTER"
-    ]
+    "references": []
   },
   {
     "spellings": "BAGGAGER",
@@ -6812,7 +6792,6 @@
       "BAG NET\nBag\" net`.\n\nDefn: A bag-shaped net for catching fish."
     ],
     "references": [
-      "BAG NET",
       "FISHING",
       "FYKE",
       "TRAWL"
@@ -7019,7 +6998,6 @@
       "BAIL BOND\nBail\" bond`. (Law)\n\n(a) A bond or obligation given by a prisoner and his surety, to\ninsure the prisoner's appearance in court, at the return of the writ.\n(b) Special bail in court to abide the judgment. Bouvier."
     ],
     "references": [
-      "BAIL BOND",
       "BAILPIECE",
       "JUMP"
     ]
@@ -7389,9 +7367,7 @@
     "variants": [
       "BAILY'S BEADS\nBai\"ly's beads. (Astron.)\n\nDefn: A row of bright spots observed in connection with total\neclipses of the sun. Just before and after a total eclipse, the\nslender, unobscured crescent of the sun's disk appears momentarily\nlike a row of bright spots resembling a string of beads. The\nphenomenon (first fully described by Francis Baily, 1774 -- 1844) is\nthought to be an effect of irradiation, and of inequalities of the\nmoon's edge."
     ],
-    "references": [
-      "BAILY'S BEADS"
-    ]
+    "references": []
   },
   {
     "spellings": "BAIN",
@@ -7901,7 +7877,6 @@
     ],
     "references": [
       "BALANCE",
-      "BALANCE WHEEL",
       "COMPENSATION",
       "PALLET",
       "WHEEL"
@@ -7947,7 +7922,6 @@
       "BALAS RUBY\nBal\"as ru`by. Etym: [OE. bales, balais, F. balais, LL. balascus, fr.\nAr. balakhsh, so called from Badakhshan, Balashan, or Balaxiam, a\nplace in the neighborhood of Samarcand, where this ruby is found.]\n(Min.)\n\nDefn: A variety of spinel ruby, of a pale rose red, or inclining to\norange. See Spinel."
     ],
     "references": [
-      "BALAS RUBY",
       "RUBY"
     ]
   },
@@ -8083,7 +8057,6 @@
       "BALD EAGLE\nBald\" ea\"gle. (Zoöl.)\n\nDefn: The white-headed eagle (Haliæetus leucocephalus) of America.\nThe young, until several years old, lack the white feathers on the\nhead.\n\nNote: The bald eagle is represented in the coat of arms, and on the\ncoins, of the United States."
     ],
     "references": [
-      "BALD EAGLE",
       "EAGLE",
       "OSSIFRAGE"
     ]
@@ -8846,9 +8819,7 @@
     "variants": [
       "BALLAD MONGER\nBal\"lad mon`ger. Etym: [See Monger.]\n\nDefn: A seller or maker of ballads; a poetaster. Shak."
     ],
-    "references": [
-      "BALLAD MONGER"
-    ]
+    "references": []
   },
   {
     "spellings": "BALLADRY",
@@ -9074,7 +9045,6 @@
       "BALLOON FISH\nBal*loon\" fish`. (Zoöl.)\n\nDefn: A fish of the genus Diodon or the genus Tetraodon, having the\npower of distending its body by taking air or water into its\ndilatable esophagus. See Globefish, and Bur fish."
     ],
     "references": [
-      "BALLOON FISH",
       "BUR FISH"
     ]
   },
@@ -9096,7 +9066,6 @@
       "BALLOONING SPIDER\nBal*loon\"ing spi\"der. (Zoöl.)\n\nDefn: A spider which has the habit of rising into the air. Many kinds\n( esp. species of Lycosa) do this while young by ejecting threads of\nsilk until the force of the wind upon them carries the spider aloft."
     ],
     "references": [
-      "BALLOONING SPIDER",
       "FLYING",
       "GOSSAMER"
     ]
@@ -9477,7 +9446,6 @@
       "BALTIMORE BIRD; BALTIMORE ORIOLE\nBal\"ti*more bird`. Bal\"ti*more o\"ri*ole. (Zoöl.)\n\nDefn: A common American bird (Icterus galbula), named after Lord\nBaltimore, because its colors (black and orange red) are like those\nof his coat of arms; -- called also golden robin."
     ],
     "references": [
-      "BALTIMORE BIRD; BALTIMORE ORIOLE",
       "FIREBIRD",
       "GOLDEN",
       "HANGBIRD",
@@ -9698,9 +9666,7 @@
     "variants": [
       "BANANA SOLUTION\nBa*na\"na so*lu\"tion.\n\nDefn: A solution used as a vehicle in applying bronze pigments. In\naddition to acetote, benzine, and a little pyroxylin, it contains\namyl acetate, which gives it the odor of bananas."
     ],
-    "references": [
-      "BANANA SOLUTION"
-    ]
+    "references": []
   },
   {
     "spellings": "BANAT",
@@ -10174,7 +10140,6 @@
       "BAND FISH\nBand\" fish`. (Zoöl.)\n\nDefn: A small red fish of the genus Cepola; the ribbon fish."
     ],
     "references": [
-      "BAND FISH",
       "FIREFLAME",
       "RED-RIBAND",
       "RIBBON",
@@ -10196,9 +10161,7 @@
     "variants": [
       "BANDING PLANE\nBand\"ing plane`.\n\nDefn: A plane used for cutting out grooves and inlaying strings and\nbands in straight and circular work."
     ],
-    "references": [
-      "BANDING PLANE"
-    ]
+    "references": []
   },
   {
     "spellings": "BANDIT",
@@ -10762,7 +10725,6 @@
       "BANK BILL\nBank\" bill`.\n\n1. In America (and formerly in England), a promissory note of a bank\npayable to the bearer on demand, and used as currency; a bank note.\n\n2. In England, a note, or a bill of exchange, of a bank, payable to\norder, and usually at some future specified time. Such bills are\nnegotiable, but form, in the strict sense of the term, no part of the\ncurrency."
     ],
     "references": [
-      "BANK BILL",
       "BANK NOTE",
       "NUMBER"
     ]
@@ -10772,9 +10734,7 @@
     "variants": [
       "BANK BOOK\nBank\" book`.\n\nDefn: A book kept by a depositor, in which an officer of a bank\nenters the debits and credits of the depositor's account with the\nbank."
     ],
-    "references": [
-      "BANK BOOK"
-    ]
+    "references": []
   },
   {
     "spellings": "BANK DISCOUNT",
@@ -10782,7 +10742,6 @@
       "BANK DISCOUNT\nBank discount.\n\nDefn: A sum equal to the interest at a given rate on the principal\n(face) of a bill or note from the time of discounting until it\nbecomes due."
     ],
     "references": [
-      "BANK DISCOUNT",
       "DISCOUNT"
     ]
   },
@@ -10847,7 +10806,6 @@
     ],
     "references": [
       "BANK BILL",
-      "BANK NOTE",
       "COUNTERFEIT",
       "COUNTERFEITER",
       "CURRENCY",
@@ -10935,7 +10893,6 @@
     ],
     "references": [
       "BANK",
-      "BANK SWALLOW",
       "MARTIN",
       "PIT",
       "SAND",
@@ -11139,9 +11096,7 @@
     "variants": [
       "BANTAM WORK\nBan\"tam work`.\n\nDefn: Carved and painted work in imitation of Japan ware."
     ],
-    "references": [
-      "BANTAM WORK"
-    ]
+    "references": []
   },
   {
     "spellings": "BANTENG",
@@ -12309,7 +12264,6 @@
       "BARBER FISH\nBar\"ber fish. (Zoöl.)\n\nDefn: See Surgeon fish."
     ],
     "references": [
-      "BARBER FISH",
       "DOCTOR"
     ]
   },
@@ -12412,7 +12366,6 @@
       "BARBITURIC ACID\nBar`bi*tu\"ric ac\"id. (Chem.)\n\nDefn: A white, crystalline substance,"
     ],
     "references": [
-      "BARBITURIC ACID",
       "VIOLANTIN",
       "VIOLURIC"
     ]
@@ -12422,9 +12375,7 @@
     "variants": [
       "BARBIZON SCHOOL; BARBISON SCHOOL\nBar`bi`zon\" school or Bar`bi`son\" school. (Painting)\n\nDefn: A French school of the middle of the 19th century centering in\nthe village of Barbizon near the forest of Fontainebleau. Its members\nwent straight to nature in disregard of academic tradition, treating\ntheir subjects faithfully and with poetic feeling for color, light,\nand atmosphere. It is exemplified, esp. in landscapes, by Corot,\nRousseau, Daubigny, Jules Dupré, and Diaz. Associated with them are\ncertain painters of animals, as Troyon and Jaque, and of peasant\nlife, as Millet and Jules Breton."
     ],
-    "references": [
-      "BARBIZON SCHOOL; BARBISON SCHOOL"
-    ]
+    "references": []
   },
   {
     "spellings": "BARBLE",
@@ -13103,7 +13054,6 @@
       "BAR IRON\nBar\" i`ron.\n\nDefn: See under Iron."
     ],
     "references": [
-      "BAR IRON",
       "CABBLING",
       "IRON",
       "LARGET",
@@ -13485,8 +13435,7 @@
       "BARK BEETLE\nBark\" bee`tle. (Zoöl.)\n\nDefn: A small beetle of many species (family Scolytidæ), which in the\nlarval state bores under or in the bark of trees, often doing great\ndamage."
     ],
     "references": [
-      "AMBROSIA BEETLE",
-      "BARK BEETLE"
+      "AMBROSIA BEETLE"
     ]
   },
   {
@@ -13537,9 +13486,7 @@
     "variants": [
       "BARKER'S MILL\nBark\"er's mill`. Etym: [From Dr. Barker, the inventor.]\n\nDefn: A machine, invented in the 17th century, worked by a form of\nreaction wheel. The water flows into a vertical tube and gushes from\napertures in hollow horizontal arms, causing the machine to revolve\non its axis."
     ],
-    "references": [
-      "BARKER'S MILL"
-    ]
+    "references": []
   },
   {
     "spellings": "BARKERY",
@@ -13553,9 +13500,7 @@
     "variants": [
       "BARKING IRONS\nBark\"ing i`rons.\n\n1. Instruments used in taking off the bark of trees. Gardner.\n\n2. A pair of pistols. [Slang]"
     ],
-    "references": [
-      "BARKING IRONS"
-    ]
+    "references": []
   },
   {
     "spellings": "BARKLESS",
@@ -13570,7 +13515,6 @@
       "BARK LOUSE\nBark\" louse`. (Zoöl.)\n\nDefn: An insect of the family Coccidæ, which infests the bark of\ntrees and vines.\n\nNote: The wingless females assume the shape of scales. The bark louse\nof vine is Pulvinaria innumerabilis; that of the pear is Lecanium\npyri. See Orange scale."
     ],
     "references": [
-      "BARK LOUSE",
       "BARNACLE",
       "COTTON"
     ]
@@ -14308,7 +14252,6 @@
       "BARRED OWL\nBarred\" owl\". (Zoöl.)\n\nDefn: A large American owl (Syrnium nebulosum); -- so called from the\ntransverse bars of a dark brown color on the breast."
     ],
     "references": [
-      "BARRED OWL",
       "HOOT"
     ]
   },
@@ -14445,9 +14388,7 @@
     "variants": [
       "BARREL PROCESS\nBar\"rel proc\"ess. (Metal.)\n\nDefn: A process of extracting gold or silver by treating the ore in a\nrevolving barrel, or drum, with mercury, chlorine, cyanide solution,\nor other reagent."
     ],
-    "references": [
-      "BARREL PROCESS"
-    ]
+    "references": []
   },
   {
     "spellings": "BARREN",
@@ -15072,9 +15013,7 @@
     "variants": [
       "BARTHOLOMEW TIDE\nBar*thol\"o*mew tide`.\n\nDefn: Time of the festival of St. Bartholomew, August 24th. Shak."
     ],
-    "references": [
-      "BARTHOLOMEW TIDE"
-    ]
+    "references": []
   },
   {
     "spellings": "BARTIZAN",
@@ -16290,7 +16229,6 @@
       "BASEDOW'S DISEASE\nBa\"se*dow's dis*ease\". Etym: [Named for Dr. Basedow, a German\nphysician.] (Med.)\n\nDefn: A disease characterized by enlargement of the thyroid gland,\nprominence of the eyeballs, and inordinate action of the heart; --\ncalled also exophthalmic goiter. Flint."
     ],
     "references": [
-      "BASEDOW'S DISEASE",
       "GRAVES' DISEASE"
     ]
   },
@@ -16387,9 +16325,7 @@
     "variants": [
       "BASE VIOL\nBase\" vi`ol.\n\nDefn: See Bass viol."
     ],
-    "references": [
-      "BASE VIOL"
-    ]
+    "references": []
   },
   {
     "spellings": "BASH",
@@ -16617,7 +16553,6 @@
     ],
     "references": [
       "ACID PROCESS",
-      "BASIC PROCESS",
       "BASIC STEEL",
       "THOMAS PROCESS"
     ]
@@ -16628,7 +16563,6 @@
       "BASIC SLAG\nBasic slag.\n\nDefn: A by-product from the manufacture of steel by the basic\nprocess, used as a fertilizer. It is rich in lime and contains 14 to\n20 per cent of phosphoric acid. Called also Thomas slag, phosphatic\nslag, and odorless phosphate."
     ],
     "references": [
-      "BASIC SLAG",
       "SCOUR",
       "THOMAS PHOSPHATE; THOMAS SLAG"
     ]
@@ -16638,9 +16572,7 @@
     "variants": [
       "BASIC STEEL\nBasic steel.\n\nDefn: Steel produced by the basic process."
     ],
-    "references": [
-      "BASIC STEEL"
-    ]
+    "references": []
   },
   {
     "spellings": "BASIDIOMYCETES",
@@ -17179,9 +17111,7 @@
     "variants": [
       "BASKET BALL\nBas\"ket ball`.\n\nDefn: A game, usually played indoors, in which two parties of players\ncontest with each other to toss a large inflated ball into opposite\ngoals resembling baskets."
     ],
-    "references": [
-      "BASKET BALL"
-    ]
+    "references": []
   },
   {
     "spellings": "BASKETFUL",
@@ -17205,7 +17135,6 @@
       "BASKING SHARK\nBask\"ing shark`. (Zoöl.)\n\nDefn: One of the largest species of sharks (Cetorhinus maximus), so\ncalled from its habit of basking in the sun; the liver shark, or bone\nshark. It inhabits the northern seas of Europe and America, and grows\nto a length of more than forty feet. It is a harmless species."
     ],
     "references": [
-      "BASKING SHARK",
       "BONE",
       "LIVER",
       "SHARK"
@@ -17398,7 +17327,6 @@
       "BASS DRUM\nBass` drum\". (Mus.)\n\nDefn: The largest of the different kinds of drums, having two heads,\nand emitting a deep, grave sound. See Bass, a."
     ],
     "references": [
-      "BASS DRUM",
       "DRUM",
       "SNARE"
     ]
@@ -17425,7 +17353,6 @@
       "BASSET HORN\nBas\"set horn`. Etym: [See Basset, a.] (Mus.)\n\nDefn: An instrument blown with a reed, and resembling a clarinet, but\nof much greater compass, embracing nearly four octaves."
     ],
     "references": [
-      "BASSET HORN",
       "CORNO DI BASSETTO"
     ]
   },
@@ -17434,9 +17361,7 @@
     "variants": [
       "BASSET HOUND\nBas\"set hound`. Etym: [F. basset.] (Zoöl.)\n\nDefn: A small kind of hound with a long body and short legs, used as\nan earth dog."
     ],
-    "references": [
-      "BASSET HOUND"
-    ]
+    "references": []
   },
   {
     "spellings": "BASSETING",
@@ -17461,9 +17386,7 @@
     "variants": [
       "BASS HORN\nBass\" horn\". (Mus.)\n\nDefn: A modification of the bassoon, much deeper in tone."
     ],
-    "references": [
-      "BASS HORN"
-    ]
+    "references": []
   },
   {
     "spellings": "BASSINET",
@@ -17553,7 +17476,6 @@
     "references": [
       "BASE VIOL",
       "BASSETTO",
-      "BASS VIOL",
       "CONTRABASSO",
       "VIOL",
       "VIOLONCELLO"
@@ -18410,9 +18332,7 @@
     "variants": [
       "BAT PRINTING\nBat\" print`ing. (Ceramics)\n\nDefn: A mode of printing on glazed ware."
     ],
-    "references": [
-      "BAT PRINTING"
-    ]
+    "references": []
   },
   {
     "spellings": "BATRACHIA",
@@ -18660,9 +18580,7 @@
     "variants": [
       "BATTERING TRAIN\nBat\"ter*ing train`. (Mil.)\n\nDefn: A train of artillery for siege operations."
     ],
-    "references": [
-      "BATTERING TRAIN"
-    ]
+    "references": []
   },
   {
     "spellings": "BATTERY",
@@ -19030,7 +18948,6 @@
       "BATTLE RANGE\nBat\"tle range`. (Mil.)\n\nDefn: The range within which the fire of small arms is very\ndestructive. With the magazine rifle, this is six hundred yards."
     ],
     "references": [
-      "BATTLE RANGE",
       "DISARRAY"
     ]
   },
@@ -19040,7 +18957,6 @@
       "BATTLE SHIP\nBattle ship. (Nav.)\n\nDefn: An armor-plated man-of-war built of steel and heavily armed,\ngenerally having from ten thousand to fifteen thousand tons\ndisplacement, and intended to be fit to meet the heaviest ships in\nline of battle."
     ],
     "references": [
-      "BATTLE SHIP",
       "LINE",
       "LINER"
     ]
@@ -19681,9 +19597,7 @@
     "variants": [
       "BAYEUX TAPESTRY\nBa`yeux\" tap\"es*try.\n\nDefn: A piece of linen about 1 ft. 8 in. wide by 213 ft. long,\ncovered with embroidery representing the incidents of William the\nConqueror's expedition to England, preserved in the town museum of\nBayeux in Normandy. It is probably of the 11th century, and is\nattributed by tradition to Matilda, the Conqueror's wife."
     ],
-    "references": [
-      "BAYEUX TAPESTRY"
-    ]
+    "references": []
   },
   {
     "spellings": "BAY ICE",
@@ -19691,7 +19605,6 @@
       "BAY ICE\nBay\" ice`.\n\nDefn: See under Ice."
     ],
     "references": [
-      "BAY ICE",
       "ICE"
     ]
   },
@@ -19701,8 +19614,7 @@
       "BAY LEAF\nBay\" leaf`.\n\nDefn: See under 3d Bay."
     ],
     "references": [
-      "BAY",
-      "BAY LEAF"
+      "BAY"
     ]
   },
   {
@@ -19752,18 +19664,14 @@
     "variants": [
       "BAYOU STATE\nBay\"ou State`.\n\nDefn: Mississippi; -- a nickname, from its numerous bayous."
     ],
-    "references": [
-      "BAYOU STATE"
-    ]
+    "references": []
   },
   {
     "spellings": "BAY RUM",
     "variants": [
       "BAY RUM\nBay\" rum\".\n\nDefn: A fragrant liquid, used for cosmetic and medicinal purposes.\n\nNote: The original bay rum, from the West Indies, is prepared, it is\nbelieved, by distillation from the leaves of the bayberry (Myrcia\nacris). The bay rum of the Pharmacopoeia (spirit of myrcia) is\nprepared from oil of myrcia (bayberry), oil of orange peel, oil of\npimento, alcohol, and water."
     ],
-    "references": [
-      "BAY RUM"
-    ]
+    "references": []
   },
   {
     "spellings": "BAYS; BAYZE",
@@ -19789,18 +19697,14 @@
     "variants": [
       "BAY SALT\nBay\" salt`.\n\nDefn: Salt which has been obtained from sea water, by evaporation in\nshallow pits or basins, by the heat of the sun; the large crystalline\nsalt of commerce. Bacon. Ure."
     ],
-    "references": [
-      "BAY SALT"
-    ]
+    "references": []
   },
   {
     "spellings": "BAY STATE",
     "variants": [
       "BAY STATE\nBay State.\n\nDefn: Massachusetts, which had been called the Colony of\nMassachusetts Bay; -- a nickname."
     ],
-    "references": [
-      "BAY STATE"
-    ]
+    "references": []
   },
   {
     "spellings": "BAY TREE",
@@ -19810,7 +19714,6 @@
     "references": [
       "BAY",
       "BAYBERRY",
-      "BAY TREE",
       "FAT",
       "LAURIC"
     ]
@@ -19822,7 +19725,6 @@
     ],
     "references": [
       "ANGLE",
-      "BAY WINDOW",
       "BOW",
       "CAROL; CARROL",
       "COMPASS",
@@ -19834,9 +19736,7 @@
     "variants": [
       "BAY YARN\nBay\" yarn`.\n\nDefn: Woolen yarn. [Prov. Eng.] Wright."
     ],
-    "references": [
-      "BAY YARN"
-    ]
+    "references": []
   },
   {
     "spellings": "BAZAAR; BAZAR",
@@ -24941,9 +24841,7 @@
     "variants": [
       "BEACH COMBER\nBeach\" comb`er.\n\nDefn: A long, curling wave rolling in from the ocean. See Comber.\n[Amer.]"
     ],
-    "references": [
-      "BEACH COMBER"
-    ]
+    "references": []
   },
   {
     "spellings": "BEACHED",
@@ -25085,9 +24983,7 @@
     "variants": [
       "BEAD PROOF\nBead\" proof`.\n\n1. Among distillers, a certain degree of strength in alcoholic\nliquor, as formerly ascertained by the floating or sinking of glass\nglobules of different specific gravities thrown into it; now\nascertained by more accurate meters.\n\n2. A degree of strength in alcoholic liquor as shown by beads or\nsmall bubbles remaining on its surface, or at the side of the glass,\nwhen shaken."
     ],
-    "references": [
-      "BEAD PROOF"
-    ]
+    "references": []
   },
   {
     "spellings": "BEADROLL",
@@ -25633,7 +25529,6 @@
       "BEAM TREE\nBeam\" tree`. Etym: [AS. beám a tree. See Beam.] (Bot.)\n\nDefn: A tree (Pyrus aria) related to the apple."
     ],
     "references": [
-      "BEAM TREE",
       "WHITEBEAM"
     ]
   },
@@ -25757,7 +25652,6 @@
       "BEAN CAPER\nBean\" ca`per. (Bot.)\n\nDefn: A deciduous plant of warm climates, generally with fleshy\nleaves and flowers of a yellow or whitish yellow color, of the genus\nZygophyllum."
     ],
     "references": [
-      "BEAN CAPER",
       "CAPER"
     ]
   },
@@ -25766,9 +25660,7 @@
     "variants": [
       "BEAN TREFOIL\nBean\" tre\"foil. (Bot.)\n\nDefn: A leguminous shrub of southern Europe, with trifoliate leaves\n(Anagyris foetida)."
     ],
-    "references": [
-      "BEAN TREFOIL"
-    ]
+    "references": []
   },
   {
     "spellings": "BEAR",
@@ -27156,9 +27048,7 @@
     "variants": [
       "BEARING CLOTH\nBear\"ing cloth`.\n\nDefn: A cloth with which a child is covered when carried to be\nbaptized. Shak."
     ],
-    "references": [
-      "BEARING CLOTH"
-    ]
+    "references": []
   },
   {
     "spellings": "BEARING REIN",
@@ -27166,7 +27056,6 @@
       "BEARING REIN\nBear\"ing rein`.\n\nDefn: A short rein looped over the check hook or the hames to keep\nthe horse's head up; -- called in the United States a checkrein."
     ],
     "references": [
-      "BEARING REIN",
       "CHECKREIN",
       "UNBEAR"
     ]
@@ -27176,9 +27065,7 @@
     "variants": [
       "BEARING RING\nBear\"ing ring`.\n\nDefn: In a balloon, the braced wooden ring attached to the suspension\nropes at the bottom, functionally analogous to the keel of a ship."
     ],
-    "references": [
-      "BEARING RING"
-    ]
+    "references": []
   },
   {
     "spellings": "BEARISH",
@@ -27255,18 +27142,14 @@
     "variants": [
       "BEAR STATE\nBear State.\n\nDefn: Arkansas; -- a nickname, from the many bears once inhabiting\nits forests."
     ],
-    "references": [
-      "BEAR STATE"
-    ]
+    "references": []
   },
   {
     "spellings": "BEAR-TRAP DAM",
     "variants": [
       "BEAR-TRAP DAM\nBear\"-trap` dam. (Engin.)\n\nDefn: A kind of movable dam, in one form consisting of two leaves\nresting against each other at the top when raised and folding down\none over the other when lowered, for deepening shallow parts in a\nriver."
     ],
-    "references": [
-      "BEAR-TRAP DAM"
-    ]
+    "references": []
   },
   {
     "spellings": "BEARWARD",
@@ -28554,9 +28437,7 @@
     "variants": [
       "BEAUFORT'S SCALE\nBeau\"fort's scale`. (Meteor.)\n\nDefn: A scale of wind force devised by Sir F. Beaufort, R. N., in\n1805, in which the force is indicated by numbers from 0 to 12.\n\n The full scale is as follows: -- 0, calm; 1, light air; 2, light\nbreeze; 3, gentle breeze; 4, moderate breeze; 5, fresh breeze; 6,\nstrong breeze; 7, moderate gale; 8, fresh gale; 9, strong gale; 10,\nwhole gale; 11, storm; 12, hurricane."
     ],
-    "references": [
-      "BEAUFORT'S SCALE"
-    ]
+    "references": []
   },
   {
     "spellings": "BEAU IDEAL",
@@ -28564,7 +28445,6 @@
       "BEAU IDEAL\nBeau\" i*de\"al. Etym: [F. beau beautiful + idéal ideal.]\n\nDefn: A conception or image of consummate beauty, moral or physical,\nformed in the mind, free from all the deformities, defects, and\nblemishes seen in actual existence; an ideal or faultless standard or\nmodel."
     ],
     "references": [
-      "BEAU IDEAL",
       "IDEAL"
     ]
   },
@@ -28581,7 +28461,6 @@
       "BEAU MONDE\nBeau` monde\". Etym: [F. beau fine + monde world.]\n\nDefn: The fashionable world; people of fashion and gayety. Prior."
     ],
     "references": [
-      "BEAU MONDE",
       "MONDE"
     ]
   },
@@ -29192,9 +29071,7 @@
     "variants": [
       "BEAVER STATE\nBea\"ver State.\n\nDefn: Oregon; -- a nickname."
     ],
-    "references": [
-      "BEAVER STATE"
-    ]
+    "references": []
   },
   {
     "spellings": "BEAVERTEEN",
@@ -30280,9 +30157,7 @@
     "variants": [
       "BECCHI'S TEST\nBec\"chi's test. [After E. Becchi, Italian chemist.] (Chem.)\n\nDefn: A qualitative test for cottonseed oil, based on the fact this\noil imparts a maroon color to an alcoholic solution of silver\nnitrate."
     ],
-    "references": [
-      "BECCHI'S TEST"
-    ]
+    "references": []
   },
   {
     "spellings": "BECHAMEL",
@@ -30314,9 +30189,7 @@
     "variants": [
       "BECHE DE MER\nBêche` de mer\". Etym: [F., lit., a sea spade.] (Zoöl.)\n\nDefn: The trepang."
     ],
-    "references": [
-      "BECHE DE MER"
-    ]
+    "references": []
   },
   {
     "spellings": "BECHIC",
@@ -30406,9 +30279,7 @@
     "variants": [
       "BECK'S SCALE\nBeck's scale.\n\nDefn: A hydrometer scale on which the zero point corresponds to sp.\ngr. 1.00, and the 30º-point to sp. gr. 0.85. From these points the\nscale is extended both ways, all the degrees being of equal length."
     ],
-    "references": [
-      "BECK'S SCALE"
-    ]
+    "references": []
   },
   {
     "spellings": "BECLAP",
@@ -31543,9 +31414,7 @@
     "variants": [
       "BECQUEREL RAYS\nBecque`rel\" rays\". (Physics)\n\nDefn: Radiations first observed by the French physicist Henri\nBecquerel, in working with uranium and its compounds. They consist of\na mixture of alpha, beta, and gamma rays."
     ],
-    "references": [
-      "BECQUEREL RAYS"
-    ]
+    "references": []
   },
   {
     "spellings": "BECRIPPLE",
@@ -31559,9 +31428,7 @@
     "variants": [
       "BECUIBA; BECUIBA NUT\nBe*cui\"ba, n., Be*cui\"ba nut`. [Native name.] (Bot.)\n\nDefn: The nut of the Brazilian tree Myristica Bicuhyba, which yields\na medicinal balsam used for rheumatism."
     ],
-    "references": [
-      "BECUIBA; BECUIBA NUT"
-    ]
+    "references": []
   },
   {
     "spellings": "BECUNA",
@@ -32397,9 +32264,7 @@
     "variants": [
       "BED ROCK\nBed\" rock\". (Mining)\n\nDefn: The solid rock underlying superficial formations. Also Fig."
     ],
-    "references": [
-      "BED ROCK"
-    ]
+    "references": []
   },
   {
     "spellings": "BEDROOM",
@@ -32433,9 +32298,7 @@
     "variants": [
       "BED SCREW\nBed\" screw`.\n\n1. (Naut.) A form of jack screw for lifting large bodies, and\nassisting in launching.\n\n2. A long screw formerly used to fasten a bedpost to one of the\nadjacent side pieces."
     ],
-    "references": [
-      "BED SCREW"
-    ]
+    "references": []
   },
   {
     "spellings": "BEDSIDE",
@@ -32504,9 +32367,7 @@
     "variants": [
       "BED STEPS\nBed\" steps`.\n\nDefn: Steps for mounting a bed of unusual height."
     ],
-    "references": [
-      "BED STEPS"
-    ]
+    "references": []
   },
   {
     "spellings": "BEDSTOCK",
@@ -32775,7 +32636,6 @@
     "references": [
       "BEECH",
       "BEECHNUT",
-      "BEECH TREE",
       "BUCK",
       "BUCKWHEAT"
     ]
@@ -32961,7 +32821,6 @@
       "BEE LARKSPUR\nBee\" lark`spur.\n\nDefn: (Bot.) See Larkspur."
     ],
     "references": [
-      "BEE LARKSPUR",
       "LARKSPUR"
     ]
   },
@@ -32980,8 +32839,7 @@
       "BEE LINE\nBee\" line`.\n\nDefn: The shortest line from one place to another, like that of a bee\nto its hive when loaded with honey; an air line. \"A bee line for the\nbrig.\" Kane."
     ],
     "references": [
-      "AIR",
-      "BEE LINE"
+      "AIR"
     ]
   },
   {
@@ -35002,7 +34860,6 @@
       "BEETLE BROW\nBee\"tle brow`.\n\nDefn: An overhanging brow."
     ],
     "references": [
-      "BEETLE BROW",
       "BLOBBER"
     ]
   },
@@ -35041,9 +34898,7 @@
     "variants": [
       "BEET RADISH\nBeet\" rad`ish.\n\nDefn: Same as Beetrave."
     ],
-    "references": [
-      "BEET RADISH"
-    ]
+    "references": []
   },
   {
     "spellings": "BEETRAVE",
@@ -37141,7 +36996,6 @@
       "BEGGAR'S LICE\nBeg\"gar's lice`. (Bot.)\n\nDefn: The prickly fruit or seed of certain plants (as some species of\nEchinospermum and Cynoglossum) which cling to the clothing of those\nwho brush by them."
     ],
     "references": [
-      "BEGGAR'S LICE",
       "BORAGINACEOUS"
     ]
   },
@@ -37151,7 +37005,6 @@
       "BEGGAR'S TICKS\nBeg\"gar's ticks`.\n\nDefn: The bur marigold (Bidens) and its achenes, which are armed with\nbarbed awns, and adhere to clothing and fleeces with unpleasant\ntenacity."
     ],
     "references": [
-      "BEGGAR'S TICKS",
       "BUR MARIGOLD",
       "STICK-TIGHT"
     ]
@@ -44087,7 +43940,6 @@
       "BELAYING PIN\nBe*lay\"ing pin`. (Naut.)\n\nDefn: A strong pin in the side of a vessel, or by the mast, round\nwhich ropes are wound when they are fastened or belayed."
     ],
     "references": [
-      "BELAYING PIN",
       "FIFE",
       "PIN",
       "TACK"
@@ -44234,9 +44086,7 @@
     "variants": [
       "BELGIAN BLOCK\nBelgian block.\n\nDefn: A nearly cubical block of some tough stone, esp. granite, used\nas a material for street pavements. Its usual diameter is 5 to 7\ninches."
     ],
-    "references": [
-      "BELGIAN BLOCK"
-    ]
+    "references": []
   },
   {
     "spellings": "BELGIC",
@@ -44928,9 +44778,7 @@
     "variants": [
       "BELL ANIMALCULE\nBell\" an`i*mal\"cule. (Zoöl.)\n\nDefn: An infusorian of the family Vorticellidæ, common in fresh-water\nponds."
     ],
-    "references": [
-      "BELL ANIMALCULE"
-    ]
+    "references": []
   },
   {
     "spellings": "BELLARMINE",
@@ -44944,9 +44792,7 @@
     "variants": [
       "BELL BEARER\nBell\" bear`er. (Zoöl.)\n\nDefn: A Brazilian leaf hopper (Bocydium tintinnabuliferum),\nremarkable for the four bell-shaped appendages of its thorax."
     ],
-    "references": [
-      "BELL BEARER"
-    ]
+    "references": []
   },
   {
     "spellings": "BELLBIRD",
@@ -44963,7 +44809,6 @@
       "BELL CRANK\nBell\" crank`.\n\nDefn: A lever whose two arms form a right angle, or nearly a right\nangle, having its fulcrum at the apex of the angle. It is used in\nbell pulls and in changing the direction of bell wires at angles of\nrooms, etc., and also in machinery."
     ],
     "references": [
-      "BELL CRANK",
       "CRANK"
     ]
   },
@@ -44997,9 +44842,7 @@
     "variants": [
       "BELLEEK WARE\nBel*leek\" ware.\n\nDefn: A porcelainlike kind of decorative pottery with a high gloss,\nwhich is sometimes iridescent. A very fine kind is made at Belleek in\nIreland."
     ],
-    "references": [
-      "BELLEEK WARE"
-    ]
+    "references": []
   },
   {
     "spellings": "BELLE-LETTRIST",
@@ -45170,7 +45013,6 @@
     ],
     "references": [
       "BELL",
-      "BELL JAR",
       "JAR",
       "RECEIVER"
     ]
@@ -45191,7 +45033,6 @@
     ],
     "references": [
       "ANTIMONY",
-      "BELL METAL",
       "BRONZE",
       "COPPER",
       "METAL"
@@ -45309,7 +45150,6 @@
       "BELLOWS FISH\nBel\"lows fish`. (Zoöl.)\n\nDefn: A European fish (Centriscus scolopax), distinguished by a long\ntubular snout, like the pipe of a bellows; -- called also trumpet\nfish, and snipe fish."
     ],
     "references": [
-      "BELLOWS FISH",
       "CENTRISCOID",
       "SEA SNIPE",
       "SNIPEFISH",
@@ -45323,7 +45163,6 @@
       "BELL PEPPER\nBell\" pep`per. (Bot.)\n\nDefn: A species of Capsicum, or Guinea pepper (C. annuum). It is the\nred pepper of the gardens."
     ],
     "references": [
-      "BELL PEPPER",
       "CAPSICUM",
       "PEPPER"
     ]
@@ -45334,7 +45173,6 @@
       "BELL PROCESS\nBell process. (Iron Metal.)\n\nDefn: The process of washing molten pig iron by adding iron oxide,\nproposed by I. Lowthian Bell of England about 1875."
     ],
     "references": [
-      "BELL PROCESS",
       "KRUPP PROCESS"
     ]
   },
@@ -45372,7 +45210,6 @@
       "BELL'S PALSY\nBell's palsy.\n\nDefn: Paralysis of the facial nerve, producing distortion of one side\nof the face."
     ],
     "references": [
-      "BELL'S PALSY",
       "PALSY"
     ]
   },
@@ -45381,9 +45218,7 @@
     "variants": [
       "BELL SYSTEM OF CONTROL\nBell system of control. (Aëronautics)\n\nDefn: See Cloche."
     ],
-    "references": [
-      "BELL SYSTEM OF CONTROL"
-    ]
+    "references": []
   },
   {
     "spellings": "BELLUINE",
@@ -47796,7 +47631,6 @@
       "BEN; BEN NUT\nBen, Ben\" nut`. Etym: [Ar. ban, name of the tree.] (Bot.)\n\nDefn: The seed of one or more species of moringa; as, oil of ben. See\nMoringa."
     ],
     "references": [
-      "BEN; BEN NUT",
       "MORINGA"
     ]
   },
@@ -47903,8 +47737,7 @@
       "BENCH MARK\nBench mark. (Leveling)\n\nDefn: Any permanent mark to which other levels may be referred.\nSpecif. : A horizontal mark at the water's edge with reference to\nwhich the height of tides and floods may be measured."
     ],
     "references": [
-      "BENCH",
-      "BENCH MARK"
+      "BENCH"
     ]
   },
   {
@@ -47913,7 +47746,6 @@
       "BENCH WARRANT\nBench\" war`rant. (Law)\n\nDefn: A process issued by a presiding judge or by a court against a\nperson guilty of some contempt, or indicted for some crime; -- so\ncalled in distinction from a justice's warrant."
     ],
     "references": [
-      "BENCH WARRANT",
       "WARRANT"
     ]
   },
@@ -49287,7 +49119,6 @@
       "BENEFIT SOCIETY\nBenefit society.\n\nDefn: A society or association formed for mutual insurance, as among\ntradesmen or in labor unions, to provide for relief in sickness, old\nage, and for the expenses of burial. Usually called friendly society\nin Great Britain."
     ],
     "references": [
-      "BENEFIT SOCIETY",
       "CALCULATED"
     ]
   },
@@ -49313,7 +49144,6 @@
       "BENE PLACITO\nBe`ne plac\"i*to. Etym: [It. beneplacito pleasure, fr. L. bene well +\nplacitus pleasing.]\n\n1. At or during pleasure.\nFor our English judges there never was . . . any bene placito as\ntheir tenure. F. Harrison.\n\n2. (Mus.)\n\nDefn: At pleasure; ad libitum."
     ],
     "references": [
-      "BENE PLACITO",
       "DURANTE"
     ]
   },
@@ -49873,7 +49703,6 @@
     ],
     "references": [
       "AGROSTIS",
-      "BENT GRASS",
       "FIORIN"
     ]
   },
@@ -49922,9 +49751,7 @@
     "variants": [
       "BENTING TIME\nBent\"ing time\".\n\nDefn: The season when pigeons are said to feed on bents, before peas\nare ripe.\nBare benting times . . . may come. Dryden."
     ],
-    "references": [
-      "BENTING TIME"
-    ]
+    "references": []
   },
   {
     "spellings": "BENTY",
@@ -50500,7 +50327,6 @@
       "BERENICE'S HAIR\nBer`e*ni\"ce's Hair`. [See Berenice's, Locks, in Dictionary of Noted\nNames in Fiction.] (Astron.)\n\nDefn: See Coma Berenices, under Coma."
     ],
     "references": [
-      "BERENICE'S HAIR",
       "COMA"
     ]
   },
@@ -50649,9 +50475,7 @@
     "variants": [
       "BERING SEA CONTROVERSY\nBe\"ring Sea Controversy.\n\nDefn: A controversy (1886 --93) between Great Britain and the United\nStates as to the right of Canadians not licensed by the United States\nto carry on seal fishing in the Bering Sea, over which the United\nStates claimed jurisdiction as a mare clausum. A court of\narbitration, meeting in Paris in 1893, decided against the claim of\nthe United States, but established regulations for the preservation\nof the fur seal."
     ],
-    "references": [
-      "BERING SEA CONTROVERSY"
-    ]
+    "references": []
   },
   {
     "spellings": "BERKELEIAN",
@@ -50694,7 +50518,6 @@
       "BERMUDA GRASS\nBer*mu\"da grass`. (Bot.)\n\nDefn: A kind of grass (Cynodon Dactylon) esteemed for pasture in the\nSouthern United States. It is a native of Southern Europe, but is now\nwide-spread in warm countries; -- called also scutch grass, and in\nBermuda, devil grass."
     ],
     "references": [
-      "BERMUDA GRASS",
       "GRASS",
       "SCUTCH GRASS"
     ]
@@ -50705,7 +50528,6 @@
       "BERMUDA LILY\nBer*mu\"da lil\"y. (Bot.)\n\nDefn: The large white lily (Lilium longiflorum eximium, syn. L.\nHarrisii) which is extensively cultivated in Bermuda."
     ],
     "references": [
-      "BERMUDA LILY",
       "EASTER LILY"
     ]
   },
@@ -50724,9 +50546,7 @@
     "variants": [
       "BERNA FLY\nBer\"na fly`. (Zoöl.)\n\nDefn: A Brazilian dipterous insect of the genus Trypeta, which lays\nits eggs in the nostrils or in wounds of man and beast, where the\nlarvæ do great injury."
     ],
-    "references": [
-      "BERNA FLY"
-    ]
+    "references": []
   },
   {
     "spellings": "BERNARDINE",
@@ -50980,9 +50800,7 @@
     "variants": [
       "BERTILLON SYSTEM\nBer`til`lon\" sys\"tem. [After Alphonse Bertillon, French\nanthropologist.]\n\nDefn: A system for the identification of persons by a physical\ndescription based upon anthropometric measurements, notes of\nmarkings, deformities, color, impression of thumb lines, etc."
     ],
-    "references": [
-      "BERTILLON SYSTEM"
-    ]
+    "references": []
   },
   {
     "spellings": "BERTRAM",
@@ -51933,7 +51751,6 @@
       "BESSEMER STEEL\nBes\"se*mer steel` (.\n\nDefn: Steel made directly from cast iron, by burning out a portion of\nthe carbon and other impurities that the latter contains, through the\nagency of a blast of air which is forced through the molten metal; --\nso called from Sir Henry Bessemer, an English engineer, the inventor\nof the process."
     ],
     "references": [
-      "BESSEMER STEEL",
       "IRON",
       "SPIEGEL IRON",
       "STEEL"
@@ -52729,7 +52546,6 @@
       "BETA RAYS\nBe\"ta rays. (Physics)\n\nDefn: Penetrating rays readily deflected by a magnetic or electric\nfield, emitted by radioactive substances, as radium. They consist of\nnegatively charged particles or electrons, apparently the same in\nkind as those of the cathode rays, but having much higher velocities\n(about 35,000 to 180,000 miles per second)."
     ],
     "references": [
-      "BETA RAYS",
       "RADIUM"
     ]
   },
@@ -52800,7 +52616,6 @@
       "ARECA",
       "ARECOLINE; ARECOLIN",
       "BETEL",
-      "BETEL NUT",
       "PENANG NUT"
     ]
   },
@@ -52809,18 +52624,14 @@
     "variants": [
       "BETE NOIRE\nBête\" noire\". Etym: [Fr., lit. black beast.]\n\nDefn: Something especially hated or dreaded; a bugbear."
     ],
-    "references": [
-      "BETE NOIRE"
-    ]
+    "references": []
   },
   {
     "spellings": "BETHABARA WOOD",
     "variants": [
       "BETHABARA WOOD\nBeth*ab\"a*ra wood`. (Bot.)\n\nDefn: A highly elastic wood, used for fishing rods, etc. The tree is\nunknown, but it is thought to be East Indian."
     ],
-    "references": [
-      "BETHABARA WOOD"
-    ]
+    "references": []
   },
   {
     "spellings": "BETHEL",
@@ -55533,7 +55344,6 @@
       "BEVEL GEAR\nBev\"el gear`. (Mech.)\n\nDefn: A kind of gear in which the two wheels working together lie in\ndifferent planes, and have their teeth cut at right angles to the\nsurfaces of two cones whose apices coincide with the point where the\naxes of the wheels would meet."
     ],
     "references": [
-      "BEVEL GEAR",
       "GEAR",
       "MITER; MITRE",
       "SKEW",
@@ -57905,9 +57715,7 @@
     "variants": [
       "BICKFORD FUSE; BICKFORD FUZE; BICKFORD MATCH\nBick\"ford fuse, Bick\"ford fuze, Bick\"ford match.\n\nDefn: A fuse used in blasting, consisting of a long cylinder of\nexplosive material inclosed in a varnished wrapping of rope or hose.\nIt burns from 2 to 4 feet a minute."
     ],
-    "references": [
-      "BICKFORD FUSE; BICKFORD FUZE; BICKFORD MATCH"
-    ]
+    "references": []
   },
   {
     "spellings": "BICOLLIGATE",
@@ -58275,9 +58083,7 @@
     "variants": [
       "BIDDERY WARE\nBid\"der*y ware`. Etym: [From Beder or Bidar a town in India.]\n\nDefn: A kind of metallic ware made in India. The material is a\ncomposition of zinc, tin, and lead, in which ornaments of gold and\nsilver are inlaid or damascened. [Spelt also bidry, bidree, bedery,\nbeder.]"
     ],
-    "references": [
-      "BIDDERY WARE"
-    ]
+    "references": []
   },
   {
     "spellings": "BIDDING",
@@ -58305,9 +58111,7 @@
     "variants": [
       "BIDDING PRAYER\nBid\"ding prayer`.\n\n1. (R. C. Ch.)\n\nDefn: The prayer for the souls of benefactors, said before the\nsermon.\n\n2. (Angl. Ch.)\n\nDefn: The prayer before the sermon, with petitions for various\nspecified classes of persons."
     ],
-    "references": [
-      "BIDDING PRAYER"
-    ]
+    "references": []
   },
   {
     "spellings": "BIDDY",
@@ -58387,8 +58191,7 @@
       "BIELA'S COMET\nBie\"la's com\"et. (Astron.)\n\nDefn: A periodic coment, discovered by Biela in 1826, which revolves\naround the sun in 6.6 years. The November meteors (Andromedes or\nBielids) move in its orbit, and may be fragments of the comet."
     ],
     "references": [
-      "ANDROMEDE; ANDROMED",
-      "BIELA'S COMET"
+      "ANDROMEDE; ANDROMED"
     ]
   },
   {
@@ -58871,9 +58674,7 @@
     "variants": [
       "BIG BEND STATE\nBig Bend State.\n\nDefn: Tennessee; -- a nickname."
     ],
-    "references": [
-      "BIG BEND STATE"
-    ]
+    "references": []
   },
   {
     "spellings": "BIGEMINATE",
@@ -59959,9 +59760,7 @@
     "variants": [
       "BILL BOOK\nBill\" book`. (Com.)\n\nDefn: A book in which a person keeps an account of his notes, bills,\nbills of exchange, etc., thus showing all that he issues and\nreceives."
     ],
-    "references": [
-      "BILL BOOK"
-    ]
+    "references": []
   },
   {
     "spellings": "BILL BROKER",
@@ -59969,7 +59768,6 @@
       "BILL BROKER\nBill\" bro`ker.\n\nDefn: One who negotiates the discount of bills."
     ],
     "references": [
-      "BILL BROKER",
       "BROKER",
       "DISCOUNT"
     ]
@@ -60045,9 +59843,7 @@
     "variants": [
       "BILL HOLDER\nBill\" hold`er.\n\n1. A person who holds a bill or acceptance.\n\n2. A device by means of which bills, etc., are held."
     ],
-    "references": [
-      "BILL HOLDER"
-    ]
+    "references": []
   },
   {
     "spellings": "BILLHOOK",
@@ -60222,18 +60018,14 @@
     "variants": [
       "BILLYCOCK; BILLYCOCK HAT\nBil\"ly*cock, n., or Bil\"ly*cock hat`. [Perh. from bully + cock; that\nis, cocked like the hats of the bullies.]\n\nDefn: A round, low-crowned felt hat; a wideawake. \"The undignified\nbillycocks and pantaloons of the West.\"  B. H. Chamberlain.\n\nLittle acquiesced, and Ransome disguised him in a beard, and a loose\nset of clothes, and a billicock hat.\nCharles Reade."
     ],
-    "references": [
-      "BILLYCOCK; BILLYCOCK HAT"
-    ]
+    "references": []
   },
   {
     "spellings": "BILLY GOAT",
     "variants": [
       "BILLY GOAT\nBil\"ly goat`.\n\nDefn: A male goat. [Colloq.]"
     ],
-    "references": [
-      "BILLY GOAT"
-    ]
+    "references": []
   },
   {
     "spellings": "BILOBATE",
@@ -60914,9 +60706,7 @@
     "variants": [
       "BINDING POST\nBind\"ing post`. (Elec.)\n\nDefn: A metallic post attached to electrical apparatus for\nconvenience in making connections."
     ],
-    "references": [
-      "BINDING POST"
-    ]
+    "references": []
   },
   {
     "spellings": "BINDING SCREW",
@@ -60924,7 +60714,6 @@
       "BINDING SCREW\nBind\"ing screw`.\n\nDefn: A set screw used to bind parts together, esp. one for making a\nconnection in an electrical circuit."
     ],
     "references": [
-      "BINDING SCREW",
       "TERMINAL"
     ]
   },
@@ -62628,7 +62417,6 @@
       "BIRD CAGE; BIRDCAGE\nBird\" cage\", or Bird\"cage`, n.\n\nDefn: A cage for confining birds."
     ],
     "references": [
-      "BIRD CAGE; BIRDCAGE",
       "VOLERY"
     ]
   },
@@ -62665,7 +62453,6 @@
       "BIRD CHERRY\nBird\" cher`ry. (Bot.)\n\nDefn: A shrub (Prunus Padus ) found in Northern and Central Europe.\nIt bears small black cherries."
     ],
     "references": [
-      "BIRD CHERRY",
       "CHERRY",
       "HAGBERRY"
     ]
@@ -62690,7 +62477,6 @@
       "BIRD FANCIER\nBird\" fan`ci*er.\n\n1. One who takes pleasure in rearing or collecting rare or curious\nbirds.\n\n2. One who has for sale the various kinds of birds which are kept in\ncages."
     ],
     "references": [
-      "BIRD FANCIER",
       "FANCIER"
     ]
   },
@@ -62780,7 +62566,6 @@
     ],
     "references": [
       "APOD; APODE",
-      "BIRD OF PARADISE",
       "KING",
       "MANUCODE",
       "PARADISE",
@@ -62793,9 +62578,7 @@
     "variants": [
       "BIRD PEPPER\nBird\" pep`per.\n\nDefn: A species of capsicum (Capsicum baccatum), whose small,\nconical, coral-red fruit is among the most piquant of all red\npeppers."
     ],
-    "references": [
-      "BIRD PEPPER"
-    ]
+    "references": []
   },
   {
     "spellings": "BIRD'S-BEAK",
@@ -62831,7 +62614,6 @@
     ],
     "references": [
       "BIRD'S-EYE",
-      "BIRD'S-EYE MAPLE",
       "MAPLE"
     ]
   },
@@ -62857,7 +62639,6 @@
       "BIRD'S NEST; BIRD'S-NEST\nBird's\" nest`, or Bird's-nest, n.\n\n1. The nest in which a bird lays eggs and hatches her young.\n\n2. (Cookery)\n\nDefn: The nest of a small swallow (Collocalia nidifica and several\nallied species), of China and the neighboring countries, which is\nmixed with soups.\n\nNote: The nests are found in caverns and fissures of cliffs on rocky\ncoasts, and are composed in part of algæ. They are of the size of a\ngoose egg, and in substance resemble isinglass. See Illust. under\nEdible.\n\n3. (Bot.)\n\nDefn: An orchideous plant with matted roots, of the genus Neottia (N.\nnidus-avis.) Bird's-nest pudding, a pudding containing apples whose\ncores have been replaces by sugar.\n -- Yellow bird's nest, a plant, the Monotropa hypopitys."
     ],
     "references": [
-      "BIRD'S NEST; BIRD'S-NEST",
       "BIRD'S-NESTING",
       "CHANCE",
       "EDIBLE",
@@ -63419,7 +63200,6 @@
       "BISA ANTELOPE\nBi\"sa an\"te*lope. (Zoöl.)\n\nDefn: See Oryx."
     ],
     "references": [
-      "BISA ANTELOPE",
       "ORYX"
     ]
   },
@@ -63840,7 +63620,6 @@
       "BISHOP'S CAP\nBish\"op's cap`. (Bot.)\n\nDefn: A plant of the genus Mitella; miterwort. Longfellow."
     ],
     "references": [
-      "BISHOP'S CAP",
       "MITERWORT"
     ]
   },
@@ -63849,18 +63628,14 @@
     "variants": [
       "BISHOP SLEEVE\nBish\"op sleeve`.\n\nDefn: A wide sleeve, once worn by women."
     ],
-    "references": [
-      "BISHOP SLEEVE"
-    ]
+    "references": []
   },
   {
     "spellings": "BISHOP'S LENGTH",
     "variants": [
       "BISHOP'S LENGTH\nBish\"op's length`.\n\nDefn: A canvas for a portrait measuring 58 by 94 inches. The half\nbishop measures 45 of 56."
     ],
-    "references": [
-      "BISHOP'S LENGTH"
-    ]
+    "references": []
   },
   {
     "spellings": "BISHOP-STOOL",
@@ -63915,8 +63690,7 @@
       "BISKARA BOIL; BISKARA BUTTON\nBis\"ka*ra boil`, Bis\"ka*ra but\"ton . [Named after the town Biskara,\nin Algeria.] (Med.)\n\nDefn: Same as Aleppo boil."
     ],
     "references": [
-      "ALEPPO BOIL; ALEPPO BUTTON; ALEPPO EVIL",
-      "BISKARA BOIL; BISKARA BUTTON"
+      "ALEPPO BOIL; ALEPPO BUTTON; ALEPPO EVIL"
     ]
   },
   {
@@ -64068,9 +63842,7 @@
     "variants": [
       "BISSELL TRUCK\nBis\"sell truck.\n\nDefn: A truck for railroad rolling stock, consisting of two ordinary\naxle boxes sliding in guides attached to a triangular frame; --\ncalled also pony truck."
     ],
-    "references": [
-      "BISSELL TRUCK"
-    ]
+    "references": []
   },
   {
     "spellings": "BISSEXTILE",
@@ -64546,7 +64318,6 @@
       "BITING IN\nBit\"ing in\". (Etching.)\n\nDefn: The process of corroding or eating into metallic plates, by\nmeans of an acid. See Etch. G. Francis."
     ],
     "references": [
-      "BITING IN",
       "FRUIT",
       "PUNGENT",
       "SCINIPH"
@@ -64571,9 +64342,7 @@
     "variants": [
       "BITO; BITO TREE\nBi\"to, n., Bi\"to tree`. [Etym. uncertain.] (Bot.)\n\nDefn: A small scrubby tree (Balanites Ægyptiaca) growing in dry\nregions of tropical Africa and Asia.\n\n The hard yellowish white wood is made into plows in Abyssinia; the\nbark is used in Farther India to stupefy fish; the ripe fruit is\nedible, when green it is an anthelmintic; the fermented juice is used\nas a beverage; the seeds yield a medicinal oil called zachun. The\nAfrican name of the tree is hajilij."
     ],
-    "references": [
-      "BITO; BITO TREE"
-    ]
+    "references": []
   },
   {
     "spellings": "BITSTOCK",
@@ -65042,7 +64811,6 @@
       "BITTER SPAR\nBit\"ter spar\".\n\nDefn: A common name of dolomite; -- so called because it contains\nmagnesia, the soluble salts of which are bitter. See Dolomite."
     ],
     "references": [
-      "BITTER SPAR",
       "DOLOMITE"
     ]
   },
@@ -65175,9 +64943,7 @@
     "variants": [
       "BITUMEN PROCESS\nBi*tu\"men proc\"ess. (Photog.)\n\nDefn: Any process in which  advantage is taken of the fact that\nprepared bitumen is rendered insoluble by exposure to light, as in\nphotolithography."
     ],
-    "references": [
-      "BITUMEN PROCESS"
-    ]
+    "references": []
   },
   {
     "spellings": "BITUMINATE",
@@ -66531,7 +66297,6 @@
     ],
     "references": [
       "ART",
-      "BLACK ART",
       "MAGICIAN",
       "NECROMANCY",
       "WITCH",
@@ -66567,7 +66332,6 @@
     ],
     "references": [
       "BASS",
-      "BLACK BASS",
       "CHUB",
       "GROWLER",
       "PERCH",
@@ -66645,9 +66409,7 @@
     "variants": [
       "BLACK BOOK\nBlack\" book`.\n\n1. One of several books of a political character, published at\ndifferent times and for different purposes; -- so called either from\nthe color of the binding, or from the character of the contents.\n\n2. A book compiled in the twelfth century, containing a description\nof the court of exchequer of England, an official statement of the\nrevenues of the crown, etc.\n\n3. A book containing details of the enormities practiced in the\nEnglish monasteries and religious houses, compiled by order of their\nvisitors under Henry VIII., to hasten their dissolution.\n\n4. A book of admiralty law, of the highest authority, compiled in the\nreign of Edw. III. Bouvier. Wharton.\n\n5. A book kept for the purpose of registering the names of persons\nliable to censure or punishment, as in the English universities, or\nthe English armies.\n\n6. Any book which treats of necromancy."
     ],
-    "references": [
-      "BLACK BOOK"
-    ]
+    "references": []
   },
   {
     "spellings": "BLACK-BROWED",
@@ -66662,7 +66424,6 @@
       "BLACKBURNIAN WARBLER\nBlack*bur\"ni*an war\"bler. Etym: [Named from Mrs. Blackburn, an\nEnglish lady.] (Zoöl.)\n\nDefn: A beautiful warbler of the United States (Dendroica\nBlackburniæ). The male is strongly marked with orange, yellow, and\nblack on the head and neck, and has an orange-yellow breast."
     ],
     "references": [
-      "BLACKBURNIAN WARBLER",
       "WARBLER"
     ]
   },
@@ -66704,7 +66465,6 @@
       "BLACK DEATH\nBlack\" death`.\n\nDefn: A pestilence which ravaged Europe and Asia in the fourteenth\ncentury."
     ],
     "references": [
-      "BLACK DEATH",
       "DEATH"
     ]
   },
@@ -66764,7 +66524,6 @@
       "BLACK-EYED SUSAN\nBlack\"-eyed` Su\"san. (Bot.)\n (a) The coneflower, or yellow daisy (Rudbeckia hirta).\n (b) The bladder ketmie."
     ],
     "references": [
-      "BLACK-EYED SUSAN",
       "RUDBECKIA"
     ]
   },
@@ -66820,9 +66579,7 @@
     "variants": [
       "BLACK FLAGS\nBlack Flags.\n\nDefn: An organization composed originally of Chinese rebels that had\nbeen driven into Tonkin by the suppression of the Taiping rebellion,\nbut later increased by bands of pirates and adventurers. It took a\nprominent part in fighting the French during their hostilities with\nAnam, 1873-85."
     ],
-    "references": [
-      "BLACK FLAGS"
-    ]
+    "references": []
   },
   {
     "spellings": "BLACKFOOT",
@@ -66837,7 +66594,6 @@
       "BLACK FRIAR\nBlack\" fri`ar. (Eccl.)\n\nDefn: A friar of the Dominican order; -- called also predicant and\npreaching friar; in France, Jacobin. Also, sometimes, a Benedictine."
     ],
     "references": [
-      "BLACK FRIAR",
       "DOMINICAN",
       "FRIAR"
     ]
@@ -66847,9 +66603,7 @@
     "variants": [
       "BLACK FRIDAY\nBlack Friday.\n\nDefn: Any Friday on which a public disaster has occurred, as: In\nEngland, December 6, 1745, when the news of the landing of the\nPretender reached London, or May 11, 1866,  when a financial panic\ncommenced. In the United States, September 24, 1869, and September\n18, 1873, on which financial panics began."
     ],
-    "references": [
-      "BLACK FRIDAY"
-    ]
+    "references": []
   },
   {
     "spellings": "BLACKGUARD",
@@ -66886,8 +66640,7 @@
       "BLACK HAMBURG\nBlack Ham\"burg.\n\nDefn: A sweet and juicy variety of European grape, of a dark purplish\nblack color, much grown under glass in northern latitudes."
     ],
     "references": [
-      "BLACK",
-      "BLACK HAMBURG"
+      "BLACK"
     ]
   },
   {
@@ -66895,9 +66648,7 @@
     "variants": [
       "BLACK HAND\nBlack Hand. [A trans. of Sp. mano negra.]\n\n1.\n\nDefn: A Spanish anarchistic society, many of the members of which\nwere imprisoned in 1883.\n\n2.  A lawless or blackmailing secret society, esp. among Italians.\n[U. S.]"
     ],
-    "references": [
-      "BLACK HAND"
-    ]
+    "references": []
   },
   {
     "spellings": "BLACKHEAD",
@@ -66932,9 +66683,7 @@
     "variants": [
       "BLACK HOLE\nBlack\" hole`.\n\nDefn: A dungeon or dark cell in a prison; a military lock-up or\nguardroom; -- now commonly with allusion to the cell (the Black Hole)\nin a fort at Calcutta, into which 146 English prisoners were thrust\nby the nabob Suraja Dowla on the night of June 20, 17656, and in\nwhich 123 of the prisoners died before morning from lack of air.\nA discipline of unlimited autocracy, upheld by rods, and ferules, and\nthe black hole. H. Spencer."
     ],
-    "references": [
-      "BLACK HOLE"
-    ]
+    "references": []
   },
   {
     "spellings": "BLACKING",
@@ -67037,7 +66786,6 @@
     ],
     "references": [
       "ALLOTROPISM; ALLOTROPY",
-      "BLACK LEAD",
       "BLACKLEAD",
       "CHALK",
       "GRAPHITE",
@@ -67075,7 +66823,6 @@
     ],
     "references": [
       "A",
-      "BLACK LETTER",
       "BLACK-LETTER",
       "GENEVA",
       "TYPE"
@@ -67146,9 +66893,7 @@
     "variants": [
       "BLACK MONDAY\nBlack\" Mon`day.\n\n1. Easter Monday, so called from the severity of that day in 1360,\nwhich was so unusual that many of Edward III.'s soldiers, then before\nParis, died from the cold. Stow.\nThen it was not for nothing that may nose fell a bleeding on Black\nMonday last. Shak.\n\n2. The first Monday after the holidays; -- so called by English\nschoolboys. Halliwell."
     ],
-    "references": [
-      "BLACK MONDAY"
-    ]
+    "references": []
   },
   {
     "spellings": "BLACK MONK",
@@ -67157,7 +66902,6 @@
     ],
     "references": [
       "BENEDICTINE",
-      "BLACK MONK",
       "LOUTOU"
     ]
   },
@@ -67214,7 +66958,6 @@
       "BLACK PUDDING\nBlack\" pud\"ding.\n\nDefn: A kind of sausage made of blood, suet, etc., thickened with\nmeal.\nAnd fat black puddings, -- proper food, For warriors that delight in\nblood. Hudibras."
     ],
     "references": [
-      "BLACK PUDDING",
       "PUDDING"
     ]
   },
@@ -67224,7 +66967,6 @@
       "BLACK ROD\nBlack\" Rod`.\n(a) the usher to the Chapter of the Garter, so called from the black\nrod which he carries. He is of the king's chamber, and also usher to\nthe House of Lords. [Eng.]\n(b) An usher in the legislature of British colonies. Cowell.\nCommitted to the custody of the Black Rod. Macaulay."
     ],
     "references": [
-      "BLACK ROD",
       "CHAMBERLAIN",
       "GENTLEMAN",
       "ROD",
@@ -67266,8 +67008,7 @@
       "BLACK SALTS\nBlack\" salts`.\n\nDefn: Crude potash. De Colange."
     ],
     "references": [
-      "BLACKSALTER",
-      "BLACK SALTS"
+      "BLACKSALTER"
     ]
   },
   {
@@ -67289,7 +67030,6 @@
       "BLACK SNAKE; BLACKSNAKE\nBlack\" snake` or Black\"snake, n. (Zoöl.)\n\nDefn: A snake of a black color, of which two species are common in\nthe United States, the Bascanium constrictor, or racer, sometimes six\nfeet long, and the Scotophis Alleghaniensis, seven or eight feet\nlong.\n\nNote: The name is also applied to various other black serpents, as\nNatrix atra of Jamaica."
     ],
     "references": [
-      "BLACK SNAKE; BLACKSNAKE",
       "PILOT",
       "RACER"
     ]
@@ -67299,9 +67039,7 @@
     "variants": [
       "BLACK SPANISH\nBlack Spanish.\n\nDefn: One of an old and well-known Mediterranean breed of domestic\nfowls with glossy black plumage, blue legs and feet, bright red comb\nand wattles, and white face. They are remarkable as egg layers."
     ],
-    "references": [
-      "BLACK SPANISH"
-    ]
+    "references": []
   },
   {
     "spellings": "BLACKSTRAP",
@@ -67337,7 +67075,6 @@
       "BLACK VOMIT\nBlack\" vom\"it. (Med.)\n\nDefn: A copious vomiting of dark-colored matter; or the substance so\ndischarged; -- one of the most fatal symptoms in yellow fever."
     ],
     "references": [
-      "BLACK VOMIT",
       "VOMIT",
       "VOMITO",
       "YELLOW"
@@ -67348,18 +67085,14 @@
     "variants": [
       "BLACK WASH; BLACKWASH\nBlack\" wash` or Black\"wash, n.\n\n1. (Med.)\n\nDefn: A lotion made by mixing calomel and lime water.\n\n2. A wash that blackens, as opposed to whitewash; hence,\nfiguratively, calumny.\nTo remove as far as he can the modern layers of black wash, and let\nthe man himself, fair or foul, be seen. C. Kingsley."
     ],
-    "references": [
-      "BLACK WASH; BLACKWASH"
-    ]
+    "references": []
   },
   {
     "spellings": "BLACKWATER STATE",
     "variants": [
       "BLACKWATER STATE\nBlack\"wa`ter State.\n\nDefn: Nebraska; -- a nickname alluding to the dark color of the water\nof its rivers, due to the presence of a black vegetable mold in the\nsoil."
     ],
-    "references": [
-      "BLACKWATER STATE"
-    ]
+    "references": []
   },
   {
     "spellings": "BLACKWOOD",
@@ -67995,7 +67728,6 @@
       "BLANCHARD LATHE\nBlan\"chard lathe. [After Thomas Blanchard, American inventor.]\n(Mach.)\n\nDefn: A kind of wood-turning lathe for making noncircular and\nirregular forms, as felloes, gun stocks, lasts, spokes, etc., after a\ngiven pattern. The pattern and work rotate on parallel spindles in\nthe same direction with the same speed, and the work is shaped by a\nrapidly rotating cutter whose position is varied by the pattern\nacting as a cam upon a follower wheel traversing slowly along the\npattern."
     ],
     "references": [
-      "BLANCHARD LATHE",
       "LATHE"
     ]
   },
@@ -68016,7 +67748,6 @@
       "BLANCH HOLDING\nBlanch\" hold`ing. (Scots Law)\n\nDefn: A mode of tenure by the payment of a small duty in white rent\n(silver) or otherwise."
     ],
     "references": [
-      "BLANCH HOLDING",
       "BLENCH HOLDING"
     ]
   },
@@ -68240,9 +67971,7 @@
     "variants": [
       "BLANKET CLAUSE\nBlan\"ket clause`. (Law)\n\nDefn: A clause, as in a blanket mortgage or policy, that includes a\ngroup or class of things, rather than a number mentioned individually\nand having the burden, loss, or the like, apportioned among them."
     ],
-    "references": [
-      "BLANKET CLAUSE"
-    ]
+    "references": []
   },
   {
     "spellings": "BLANKETING",
@@ -68260,8 +67989,7 @@
       "BLANKET MORTGAGE; BLANKET POLICY\nBlan\"ket mortgage or Blan\"ket policy .\n\nDefn: One that covers a group or class of things or properties\ninstead of one or more things mentioned individually, as where a\nmortgage secures various debts as a group, or subjects a group or\nclass of different pieces of property to one general lien."
     ],
     "references": [
-      "BLANKET CLAUSE",
-      "BLANKET MORTGAGE; BLANKET POLICY"
+      "BLANKET CLAUSE"
     ]
   },
   {
@@ -68269,9 +67997,7 @@
     "variants": [
       "BLANKET STITCH\nBlanket stitch.\n\nDefn: A buttonhole stitch worked wide apart on the edge of material,\nas blankets, too thick to hem."
     ],
-    "references": [
-      "BLANKET STITCH"
-    ]
+    "references": []
   },
   {
     "spellings": "BLANKLY",
@@ -68607,9 +68333,7 @@
     "variants": [
       "BLAST LAMP\nBlast lamp.\n\nDefn: A lamp provided with some arrangement for intensifying\ncombustion by means of a blast."
     ],
-    "references": [
-      "BLAST LAMP"
-    ]
+    "references": []
   },
   {
     "spellings": "BLASTMENT",
@@ -68766,7 +68490,6 @@
     ],
     "references": [
       "BLAST",
-      "BLAST PIPE",
       "VARIABLE"
     ]
   },
@@ -69480,9 +69203,7 @@
     "variants": [
       "BLENCH HOLDING\nBlench\" hold`ing. (Law)\n\nDefn: See Blanch holding."
     ],
-    "references": [
-      "BLENCH HOLDING"
-    ]
+    "references": []
   },
   {
     "spellings": "BLEND",
@@ -69594,7 +69315,6 @@
       "BLENHEIM SPANIEL\nBlen\"heim span\"iel. Etym: [So called from Blenheim House, the seat of\nthe duke of Marlborough, in England.]\n\nDefn: A small variety of spaniel, kept as a pet."
     ],
     "references": [
-      "BLENHEIM SPANIEL",
       "SPANIEL"
     ]
   },
@@ -69827,7 +69547,6 @@
       "BLESSED THISTLE\nBless\"ed this\"tle.\n\nDefn: See under Thistle."
     ],
     "references": [
-      "BLESSED THISTLE",
       "HOLY",
       "THISTLE"
     ]
@@ -70253,7 +69972,6 @@
       "BLINDMAN'S BUFF\nBlind\"man's buff\" (. Etym: [See Buff a buffet.]\n\nDefn: A play in which one person is blindfolded, and tries to catch\nsome one of the company and tell who it is.\nSurely he fancies I play at blindman's buff with him, for he thinks I\nnever have my eyes open. Stillingfleet."
     ],
     "references": [
-      "BLINDMAN'S BUFF",
       "HOODMAN-BLIND"
     ]
   },
@@ -70262,9 +69980,7 @@
     "variants": [
       "BLINDMAN'S HOLIDAY\nBlind`man's hol\"i*day.\n\nDefn: The time between daylight and candle light. [Humorous]"
     ],
-    "references": [
-      "BLINDMAN'S HOLIDAY"
-    ]
+    "references": []
   },
   {
     "spellings": "BLINDNESS",
@@ -70309,9 +70025,7 @@
     "variants": [
       "BLIND READER\nBlind reader.\n\nDefn: A post-office clerk whose duty is to decipher obscure\naddresses."
     ],
-    "references": [
-      "BLIND READER"
-    ]
+    "references": []
   },
   {
     "spellings": "BLINDSTORY",
@@ -70368,9 +70082,7 @@
     "variants": [
       "BLINK BEER\nBlink\" beer` (\n\nDefn: Beer kept unbroached until it is sharp. Crabb."
     ],
-    "references": [
-      "BLINK BEER"
-    ]
+    "references": []
   },
   {
     "spellings": "BLINKER",
@@ -70964,18 +70676,14 @@
     "variants": [
       "BLOCK BOOK\nBlock\" book` (.\n\nDefn: A book printed from engraved wooden blocks instead of movable\ntypes."
     ],
-    "references": [
-      "BLOCK BOOK"
-    ]
+    "references": []
   },
   {
     "spellings": "BLOCK CHAIN",
     "variants": [
       "BLOCK CHAIN\nBlock chain. (Mach.)\n\nDefn: A chain in which the alternate links are broad blocks connected\nby thin side links pivoted to the ends of the blocks, used with\nsprocket wheels to transmit power, as in a bicycle."
     ],
-    "references": [
-      "BLOCK CHAIN"
-    ]
+    "references": []
   },
   {
     "spellings": "BLOCKHEAD",
@@ -71066,9 +70774,7 @@
     "variants": [
       "BLOCKING COURSE\nBlock\"ing course` (. (Arch.)\n\nDefn: The finishing course of a wall showing above a cornice."
     ],
-    "references": [
-      "BLOCKING COURSE"
-    ]
+    "references": []
   },
   {
     "spellings": "BLOCKISH",
@@ -71096,9 +70802,7 @@
     "variants": [
       "BLOCK SIGNAL\nBlock signal. (Railroads)\n\nDefn: One of the danger signals or safety signals which guide the\nmovement of trains in a block system. The signal is often so coupled\nwith a switch that act of opening or closing the switch operates the\nsignal also."
     ],
-    "references": [
-      "BLOCK SIGNAL"
-    ]
+    "references": []
   },
   {
     "spellings": "BLOCK SYSTEM",
@@ -71108,7 +70812,6 @@
     "references": [
       "BLOCK",
       "BLOCK SIGNAL",
-      "BLOCK SYSTEM",
       "SYSTEM"
     ]
   },
@@ -71118,7 +70821,6 @@
       "BLOCK TIN\nBlock\" tin` (.\n\nDefn: See under Tin."
     ],
     "references": [
-      "BLOCK TIN",
       "CRY",
       "TIN"
     ]
@@ -71178,9 +70880,7 @@
     "variants": [
       "BLOND METAL\nBlond\" met`al.\n\nDefn: A variety of clay ironstone, in Staffordshire, England, used\nfor making tools."
     ],
-    "references": [
-      "BLOND METAL"
-    ]
+    "references": []
   },
   {
     "spellings": "BLONDNESS",
@@ -72124,8 +71824,7 @@
       "BLOOD MONEY\nBlood\" mon`ey.\n\n1. Money paid to the next of kin of a person who has been killed by\nanother.\n\n2. Money obtained as the price, or at the cost, of another's life; --\nsaid of a reward for supporting a capital charge, of money obtained\nfor betraying a fugitive or for committing murder, or of money\nobtained from the sale of that which will destroy the purchaser."
     ],
     "references": [
-      "BLOOD",
-      "BLOOD MONEY"
+      "BLOOD"
     ]
   },
   {
@@ -72270,7 +71969,6 @@
       "ANGIOPATHY",
       "ANGIOTOMY",
       "BLOOD",
-      "BLOOD VESSEL",
       "BONE",
       "BURST",
       "CAPILLARY",
@@ -72441,7 +72139,6 @@
       "BLOODY FLUX\nBlood\"y flux`.\n\nDefn: The dysentery, a disease in which the flux or discharge from\nthe bowels has a mixture of blood. Arbuthnot."
     ],
     "references": [
-      "BLOODY FLUX",
       "FLUX",
       "TABASHEER"
     ]
@@ -72453,7 +72150,6 @@
     ],
     "references": [
       "BLOODY",
-      "BLOODY HAND",
       "RED-HAND; RED-HANDED"
     ]
   },
@@ -72471,7 +72167,6 @@
     ],
     "references": [
       "BLOODY",
-      "BLOODY SWEAT",
       "STIGMA"
     ]
   },
@@ -72835,7 +72530,6 @@
     ],
     "references": [
       "BLOT",
-      "BLOTTING PAPER",
       "MACULATURE"
     ]
   },
@@ -73359,9 +73053,7 @@
     "variants": [
       "BLOW VALVE\nBlow\" valve` (. (Mach.)\n\nDefn: See Snifting valve."
     ],
-    "references": [
-      "BLOW VALVE"
-    ]
+    "references": []
   },
   {
     "spellings": "BLOWY",
@@ -74032,7 +73724,6 @@
       "BLUE BONNET; BLUE-BONNET\nBlue\" bon`net or Blue\"-bon`net, n.\n\n1. A broad, flat Scottish cap of blue woolen, or one waring such cap;\na Scotchman.\n\n2. (Bot.)\n\nDefn: A plant. Same as Bluebottle.\n\n3. (Zoöl.)\n\nDefn: The European blue titmouse (Parus coeruleus); the bluecap."
     ],
     "references": [
-      "BLUE BONNET; BLUE-BONNET",
       "BLUECAP",
       "BONNET"
     ]
@@ -74042,9 +73733,7 @@
     "variants": [
       "BLUE BOOK\nBlue\" book`.\n\n1. A parliamentary publication, so called from its blue paper covers.\n[Eng.]\n\n2. The United States official \"Biennial Register.\""
     ],
-    "references": [
-      "BLUE BOOK"
-    ]
+    "references": []
   },
   {
     "spellings": "BLUEBOTTLE",
@@ -74107,9 +73796,7 @@
     "variants": [
       "BLUE-EYED GRASS\nBlue-eyed grass (Bot.)\n\nDefn: a grasslike plant (Sisyrinchium anceps), with small flowers of\na delicate blue color."
     ],
-    "references": [
-      "BLUE-EYED GRASS"
-    ]
+    "references": []
   },
   {
     "spellings": "BLUEFIN",
@@ -74154,7 +73841,6 @@
     ],
     "references": [
       "ANCIPITAL; ANCIPITOUS",
-      "BLUE GRASS",
       "GRASS",
       "JUNE",
       "KENTUCKY",
@@ -74167,18 +73853,14 @@
     "variants": [
       "BLUE-GRASS STATE\nBlue-grass State.\n\nDefn: The Sate of Kentucky; -- a nickname alluding to the blue-grass\nregion, where fine horses are bred."
     ],
-    "references": [
-      "BLUE-GRASS STATE"
-    ]
+    "references": []
   },
   {
     "spellings": "BLUE HEN STATE",
     "variants": [
       "BLUE HEN STATE\nBlue Hen State.\n\nDefn: The State of Delaware; -- a popular sobriquet. It is said,\nthough the story lacks proof, to have taken its origin from the\ninsistence of a Delaware Revolutionary captain, named Caldwell, that\nno cock could be truly game unless the mother was a blue hen, whence\nBlue Hen's Chickens came to be a nickname for the people of Delaware."
     ],
-    "references": [
-      "BLUE HEN STATE"
-    ]
+    "references": []
   },
   {
     "spellings": "BLUE JAY",
@@ -74186,7 +73868,6 @@
       "BLUE JAY\nBlue\" jay`. (Zoöl.)\n\nDefn: The common jay of the United States (Cyanocitta, or Cyanura,\ncristata). The predominant color is bright blue."
     ],
     "references": [
-      "BLUE JAY",
       "JAY"
     ]
   },
@@ -75058,7 +74739,6 @@
     ],
     "references": [
       "BOA",
-      "BOA CONSTRICTOR",
       "CONSTRICTOR"
     ]
   },
@@ -76020,7 +75700,6 @@
       "BOAT BUG\nBoat\" bug` (. (Zoöl.)\n\nDefn: An aquatic hemipterous insect of the genus Notonecta; -- so\ncalled from swimming on its back, which gives it the appearance of a\nlittle boat. Called also boat fly, boat insect, boatman, and water\nboatman."
     ],
     "references": [
-      "BOAT BUG",
       "BOATMAN",
       "WATER BOATMAN"
     ]
@@ -76099,7 +75778,6 @@
       "BOAT SHELL\nBoat\" shell` (. (Zoöl.)\n(a) A marine gastropod of the genus Crepidula. The species are\nnumerous. It is so named from its form and interior deck.\n(b) A marine univalve shell of the genus Cymba."
     ],
     "references": [
-      "BOAT SHELL",
       "HALF-DECK",
       "SLIPPER",
       "SWEETMEAT",
@@ -76351,8 +76029,7 @@
       "BOB WIG\nBob\" wig` (.\n\nDefn: A short wig with bobs or short curls; -- called also bobtail\nwig. Spectator."
     ],
     "references": [
-      "BOB",
-      "BOB WIG"
+      "BOB"
     ]
   },
   {
@@ -76398,9 +76075,7 @@
     "variants": [
       "BOCK BEER\nBock\" beer` (. Etym: [G. bockbier; bock a buck + bier beer; -- said\nto be so named from its tendency to cause the drinker to caper like a\ngoat.]\n\nDefn: A strong beer, originally made in Bavaria. [Also written buck\nbeer.]"
     ],
-    "references": [
-      "BOCK BEER"
-    ]
+    "references": []
   },
   {
     "spellings": "BOCKELET",
@@ -76692,9 +76367,7 @@
     "variants": [
       "BOD VEAL\nBod veal.\n\nDefn: Veal too immature to be suitable for food."
     ],
-    "references": [
-      "BOD VEAL"
-    ]
+    "references": []
   },
   {
     "spellings": "BODY",
@@ -79356,9 +79029,7 @@
     "variants": [
       "BOGIE ENGINE\nBo\"gie en\"gine. (Railroads)\n\nDefn: A switching engine the running gear and driving gear of which\nare on a bogie, or truck."
     ],
-    "references": [
-      "BOGIE ENGINE"
-    ]
+    "references": []
   },
   {
     "spellings": "BOGLE",
@@ -79496,7 +79167,6 @@
       "BOHUN UPAS\nBo\"hun u\"pas.\n\nDefn: See Upas."
     ],
     "references": [
-      "BOHUN UPAS",
       "UPAS"
     ]
   },
@@ -80009,7 +79679,6 @@
     ],
     "references": [
       "BODOCK",
-      "BOIS D'ARC",
       "OSAGE ORANGE"
     ]
   },
@@ -80018,9 +79687,7 @@
     "variants": [
       "BOIS DURCI\nBois\" dur`ci\". Etym: [F., hardened wood.]\n\nDefn: A hard, highly polishable composition, made of fine sawdust\nfrom hard wood (as rosewood) mixed with blood, and pressed."
     ],
-    "references": [
-      "BOIS DURCI"
-    ]
+    "references": []
   },
   {
     "spellings": "BOIST",
@@ -80105,9 +79772,7 @@
     "variants": [
       "BOJANUS ORGAN\nBo*ja\"nus or\"gan. Etym: [From Bojanus, the discoverer.] (Zoöl.)\n\nDefn: A glandular organ of bivalve mollusca, serving in part as a\nkidney."
     ],
-    "references": [
-      "BOJANUS ORGAN"
-    ]
+    "references": []
   },
   {
     "spellings": "BOKADAM",
@@ -80326,7 +79991,6 @@
       "BOLD EAGLE\nBold eagle, (Zoöl.)\n\nDefn: an Australian eagle (Aquila audax), which destroys lambs and\neven the kangaroo.\n -- To make bold, to take liberties or the liberty; to venture.\n\nSyn.\n -- Courageous; daring; brave; intrepid; fearless; dauntless;\nvaliant; manful; audacious; stouthearted; high-spirited; adventurous;\nconfident; strenuous; forward; impudent."
     ],
     "references": [
-      "BOLD EAGLE",
       "EAGLE",
       "WEDGE-TAILED"
     ]
@@ -81342,7 +81006,6 @@
       "BONA FIDE\nBo\"na fi\"de. Etym: [L.]\n\nDefn: In or with good faith; without fraud or deceit; real or really;\nactual or actually; genuine or genuinely; as, you must proceed bona\nfide; a bona fide purchaser or transaction."
     ],
     "references": [
-      "BONA FIDE",
       "BONA FIDES"
     ]
   },
@@ -81351,9 +81014,7 @@
     "variants": [
       "BONA FIDES\nBo\"na fi\"des (bo\"na fi\"dez). [L.]\n\nDefn: Good faith; honesty; freedom from fraud or deception."
     ],
-    "references": [
-      "BONA FIDES"
-    ]
+    "references": []
   },
   {
     "spellings": "BONAIR",
@@ -81397,18 +81058,14 @@
     "variants": [
       "BONA PERITURA\nBo\"na per`i*tu\"ra. Etym: [L.] (Law)\n\nDefn: Perishable goods. Bouvier."
     ],
-    "references": [
-      "BONA PERITURA"
-    ]
+    "references": []
   },
   {
     "spellings": "BONA ROBA",
     "variants": [
       "BONA ROBA\nBo\"na ro\"ba. Etym: [It., prop. \"good stuff.\"]\n\nDefn: A showy wanton; a courtesan. Shak"
     ],
-    "references": [
-      "BONA ROBA"
-    ]
+    "references": []
   },
   {
     "spellings": "BONASUS; BONASSUS",
@@ -81710,7 +81367,6 @@
       "BOND SERVANT\nBond\" serv`ant.\n\nDefn: A slave; one who is bound to service without wages.\nIf thy brother . . . be waxen poor, and be sold unto thee; thou shalt\nnot compel him to serve as a bond servant: but as an hired servant.\nLev. xxv. 39, 40."
     ],
     "references": [
-      "BOND SERVANT",
       "BOND SERVICE",
       "SLAVE"
     ]
@@ -81721,8 +81377,7 @@
       "BOND SERVICE\nBond\" serv`ice.\n\nDefn: The condition of a bond servant; sevice without wages; slavery.\nTheir children . . . upon those did Solomon levy a tribute of bond\nservice. 1 Kings ix. 21."
     ],
     "references": [
-      "BONDAGE",
-      "BOND SERVICE"
+      "BONDAGE"
     ]
   },
   {
@@ -82504,9 +82159,7 @@
     "variants": [
       "BONNE BOUCHE\nBonne\" bouche\"; pl. Bonnes bouches (. Etym: [F. bon, fem. bonne, good\n+ bouche mouth.]\n\nDefn: A delicious morsel or mouthful; a tidbit."
     ],
-    "references": [
-      "BONNE BOUCHE"
-    ]
+    "references": []
   },
   {
     "spellings": "BONNET",
@@ -82567,9 +82220,7 @@
     "variants": [
       "BONNET ROUGE\nBon`net\" rouge\". [F.]\n\nDefn: The red cap adopted by the extremists in the French Revolution,\nwhich became a sign of patriotism at that epoch; hence, a\nrevolutionist; a Red Republican."
     ],
-    "references": [
-      "BONNET ROUGE"
-    ]
+    "references": []
   },
   {
     "spellings": "BONNIBEL",
@@ -82643,9 +82294,7 @@
     "variants": [
       "BON SILENE\nBon\" Si`lène\". Etym: [F.] (Bot.)\n\nDefn: A very fragrant tea rose with petals of various shades of pink."
     ],
-    "references": [
-      "BON SILENE"
-    ]
+    "references": []
   },
   {
     "spellings": "BONSPIEL",
@@ -82669,7 +82318,6 @@
       "BON TON\nBon\" ton\". Etym: [F., good tone, manner.]\n\nDefn: The height of the fashion; fashionable society."
     ],
     "references": [
-      "BON TON",
       "TON"
     ]
   },
@@ -82702,9 +82350,7 @@
     "variants": [
       "BON VIVANT\nBon\" vi`vant\"; pl. Bons vivants. Etym: [F. bon good + vivant, p. pr.\nof vivre to live.]\n\nDefn: A good fellow; a jovial companion; a free liver."
     ],
-    "references": [
-      "BON VIVANT"
-    ]
+    "references": []
   },
   {
     "spellings": "BONY",
@@ -83636,9 +83282,7 @@
     "variants": [
       "BOOKING CLERK\nBook\"ing clerk`.\n\nDefn: A clerk who registers passengers, baggage, etc., for\nconveyance, as by railway or steamship, or who sells passage tickets\nat a booking office."
     ],
-    "references": [
-      "BOOKING CLERK"
-    ]
+    "references": []
   },
   {
     "spellings": "BOOKING OFFICE",
@@ -83646,8 +83290,7 @@
       "BOOKING OFFICE\nBook\"ing of`fice.\n\n1. An office where passengers, baggage, etc., are registered for\nconveyance, as by railway or steamship.\n\n2. An office where passage tickets are sold. [Eng.]"
     ],
     "references": [
-      "BOOKING CLERK",
-      "BOOKING OFFICE"
+      "BOOKING CLERK"
     ]
   },
   {
@@ -83762,7 +83405,6 @@
       "BOOK MUSLIN\nBook\" mus`lin.\n\n1. A kind of muslin used for the covers of books.\n\n2. A kind of thin white muslin for ladies' dresses."
     ],
     "references": [
-      "BOOK MUSLIN",
       "BUKE MUSLIN"
     ]
   },
@@ -84663,9 +84305,7 @@
     "variants": [
       "BORDEAUX MIXTURE\nBor*deaux\" mix\"ture. (Hort.)\n\nDefn: A fungicidal mixture composed of blue vitriol, lime, and water.\nThe formula in common use is: blue vitriol, 6 lbs.; lime, 4 lbs.;\nwater, 35 -- 50 gallons."
     ],
-    "references": [
-      "BORDEAUX MIXTURE"
-    ]
+    "references": []
   },
   {
     "spellings": "BORDEL; BORDELLO",
@@ -84910,9 +84550,7 @@
     "variants": [
       "BORD SERVICE\nBord\" serv`ice. Etym: [Bordar (or perh. bord a board) + service.] (O.\nEng. Law)\n\nDefn: Service due from a bordar; bordage."
     ],
-    "references": [
-      "BORD SERVICE"
-    ]
+    "references": []
   },
   {
     "spellings": "BORDURE",
@@ -86479,7 +86117,6 @@
       "BOTANY BAY\nBot\"a*ny Bay\".\n\nDefn: A harbor on the east coast of Australia, and an English convict\nsettlement there; -- so called from the number of new plants found on\nits shore at its discovery by Cook in 1770.\n\nNote: Hence, any place to which desperadoes resort. Botany Bay kino\n(Med.), an astringent, reddish substance consisting of the\ninspissated juice of several Australian species of Eucalyptus.\n -- Botany Bay resin (Med.), a resin of reddish yellow color,\nresembling gamboge, the product of different Australian species of\nXanthorrhæa, esp. the grass three (X. hastilis.)"
     ],
     "references": [
-      "BOTANY BAY",
       "KINO",
       "TEA"
     ]
@@ -87710,7 +87347,6 @@
       "BO TREE\nBo\" tree`. (Bot.)\n\nDefn: The peepul tree; esp., the very ancient tree standing at\nAnurajahpoora in Ceylon, grown from a slip of the tree under which\nGautama is said to have received the heavenly light and so to have\nbecome Buddha.\nThe sacred bo tree of the Buddhists (Ficus religiosa), which is\nplanted close to every temple, and attracts almost as much veneration\nas the status of the god himself. . . . It differs from the banyan\n(Ficus Indica) by sending down no roots from its branches. Tennent."
     ],
     "references": [
-      "BO TREE",
       "PEEPUL TREE"
     ]
   },
@@ -87889,9 +87525,7 @@
     "variants": [
       "BOTTLE GREEN\nBot\"tle green`\n\nDefn: A dark shade of green, like that of bottle glass.\n -- Bot\"tle-green`, a."
     ],
-    "references": [
-      "BOTTLE GREEN"
-    ]
+    "references": []
   },
   {
     "spellings": "BOTTLEHEAD",
@@ -87914,9 +87548,7 @@
     "variants": [
       "BOTTLE-NECK FRAME\nBot\"tle-neck` frame\". (Automobiles)\n\nDefn: An inswept frame. [Colloq.]"
     ],
-    "references": [
-      "BOTTLE-NECK FRAME"
-    ]
+    "references": []
   },
   {
     "spellings": "BOTTLE-NOSE",
@@ -88274,9 +87906,7 @@
     "variants": [
       "BOTTOM FERMENTATION\nBot\"tom fer`men*ta\"tion.\n\nDefn: A slow alcoholic fermentation during which the yeast cells\ncollect at the bottom of the fermenting liquid. It takes place at a\ntemperature of 4º - 10º C. (39º - 50ºF.). It is used in making lager\nbeer and wines of low alcohol content but fine bouquet."
     ],
-    "references": [
-      "BOTTOM FERMENTATION"
-    ]
+    "references": []
   },
   {
     "spellings": "BOTTOMLESS",
@@ -88548,9 +88178,7 @@
     "variants": [
       "BOUGIE DECIMALE\nBou*gie\" dé`ci`male\". [F., lit., decimal candle.]\n\nDefn: A photometric standard used in France, having the value of one\ntwentieth of the Violle platinum standard, or slightly less than a\nBritish standard candle. Called also decimal candle."
     ],
-    "references": [
-      "BOUGIE DECIMALE"
-    ]
+    "references": []
   },
   {
     "spellings": "BOUILLI",
@@ -89357,9 +88985,7 @@
     "variants": [
       "BOURBON WHISKY\nBour\"bon whis\"ky.\n\nDefn: See under Whisky."
     ],
-    "references": [
-      "BOURBON WHISKY"
-    ]
+    "references": []
   },
   {
     "spellings": "BOURD",
@@ -89612,9 +89238,7 @@
     "variants": [
       "BOVEY COAL\nBo\"vey coal`. (Min.)\n\nDefn: A kind of mineral coal, or brown lignite, burning with a weak\nflame, and generally a disagreeable odor; -- found at Bovey Tracey,\nDevonshire, England. It is of geological age of the oölite, and not\nof the true coal era."
     ],
-    "references": [
-      "BOVEY COAL"
-    ]
+    "references": []
   },
   {
     "spellings": "BOVID",
@@ -90061,9 +89685,7 @@
     "variants": [
       "BOWER-BARFF PROCESS\nBow\"er-Barff\" proc`ess . (Metal.)\n\nDefn: A certain process for producing upon articles of iron or steel\nan adherent coating of the magnetic oxide of iron (which is not\nliable to corrosion by air, moisture, or ordinary acids). This is\naccomplished by producing, by oxidation at about 1600º F. in a closed\nspace, a coating containing more or less of the ferric oxide (Fe2O3)\nand the subsequent change of this in a reduced atmosphere to the\nmagnetic oxide (Fe2O4)."
     ],
-    "references": [
-      "BOWER-BARFF PROCESS"
-    ]
+    "references": []
   },
   {
     "spellings": "BOWER BIRD",
@@ -90071,7 +89693,6 @@
       "BOWER BIRD\nBow\"er bird`. (Zoöl.)\n\nDefn: An Australian bird (Ptilonorhynchus violaceus or holosericeus),\nallied to the starling, which constructs singular bowers or\nplayhouses of twigs and decorates them with brightcolored objects;\nthe satin bird.\n\nNote: The name is also applied to other related birds of the same\nregion, having similar habits; as, the spotted bower bird\n(Chalmydodera maculata), and the regent bird (Sericulus melinus)."
     ],
     "references": [
-      "BOWER BIRD",
       "SATIN"
     ]
   },
@@ -90135,7 +89756,6 @@
       "BOW HAND\nBow\" hand`.\n\n1. (Archery)\n\nDefn: The hand that holds the bow, i. e., the left hand.\nSurely he shoots wide on the bow hand. Spenser.\n\n2. (Mus.)\n\nDefn: The hand that draws the bow, i. e., the right hand."
     ],
     "references": [
-      "BOW HAND",
       "WIDE"
     ]
   },
@@ -90157,7 +89777,6 @@
       "BOWIE KNIFE\nBow\"ie knife`.\n\nDefn: A knife with a strong blade from ten to fifteen inches long,\nand double-edged near the point; -- used as a hunting knife, and\nformerly as a weapon in the southwestern part of the United States.\nIt was named from its inventor, Colonel James Bowie. Also, by\nextension, any large sheath knife."
     ],
     "references": [
-      "BOWIE KNIFE",
       "DAGGER"
     ]
   },
@@ -90429,7 +90048,6 @@
       "BOW NET\nBow\" net`\n\nDefn: .\n\n1. A trap for lobsters, being a wickerwork cylinder with a funnel-\nshaped entrance at one end.\n\n2. A net for catching birds. J. H. Walsh."
     ],
     "references": [
-      "BOW NET",
       "FYKE"
     ]
   },
@@ -90440,8 +90058,7 @@
     ],
     "references": [
       "BOW",
-      "BOWMAN",
-      "BOW OAR"
+      "BOWMAN"
     ]
   },
   {
@@ -91020,9 +90637,7 @@
     "variants": [
       "BOXING DAY\nBox\"ing day`.\n\nDefn: The first week day after Christmas, a legal holiday on which\nChristmas boxes are given to postmen, errand boys, employees, etc.\nThe night of this day is boxing night. [Eng.]"
     ],
-    "references": [
-      "BOXING DAY"
-    ]
+    "references": []
   },
   {
     "spellings": "BOX-IRON",
@@ -91044,7 +90659,6 @@
       "BOX KITE\nBox kite.\n\nDefn: A kite, invented by Lawrence Hargrave, of Sydney, Australia,\nwhich consist of two light rectangular boxes, or cells open on two\nsides, and fastened together horizontally. Called also Hargrave, or\ncellular, kite."
     ],
     "references": [
-      "BOX KITE",
       "BOX TAIL"
     ]
   },
@@ -91053,9 +90667,7 @@
     "variants": [
       "BOX TAIL\nBox tail. (Aëronautics)\n\nDefn: In a flying machine, a tail or rudder, usually fixed,\nresembling a box kite."
     ],
-    "references": [
-      "BOX TAIL"
-    ]
+    "references": []
   },
   {
     "spellings": "BOXTHORN",
@@ -91372,7 +90984,6 @@
       "BOYLE'S LAW\nBoyle's\" law`.\n\nDefn: See under Law."
     ],
     "references": [
-      "BOYLE'S LAW",
       "LAW",
       "MARIOTTE'S LAW"
     ]
@@ -91382,9 +90993,7 @@
     "variants": [
       "BOY SCOUT\nBoy scout.\n\nDefn: Orig., a member of the \"Boy Scouts,\" an organization of boys\nfounded in 1908, by Sir R. S. S. Baden-Powell, to promote good\ncitizenship by creating in them a spirit of civic duty and of\nusefulness to others, by stimulating their interest in wholesome\nmental, moral, industrial, and physical activities, etc. Hence, a\nmember of any of the other similar organizations, which are now\nworldwide. In \"The Boy Scouts of America\" the local councils are\ngenerally under a scout commissioner, under whose supervision are\nscout masters, each in charge of a troop of two or more patrols of\neight scouts each, who are of three classes, tenderfoot, second-class\nscout, and first-class scout."
     ],
-    "references": [
-      "BOY SCOUT"
-    ]
+    "references": []
   },
   {
     "spellings": "BOZA",
@@ -92072,7 +91681,6 @@
       "BRAD AWL\nBrad\" awl`.\n\nDefn: A straight awl with chisel edge, used to make holes for brads,\netc. Weale."
     ],
     "references": [
-      "BRAD AWL",
       "BROG"
     ]
   },
@@ -92799,7 +92407,6 @@
       "BRAMAH PRESS\nBra\"mah press`.\n\nDefn: A hydrostatic press of immense power, invented by Joseph Bramah\nof London. See under Hydrostatic."
     ],
     "references": [
-      "BRAMAH PRESS",
       "HYDROSTATIC; HYDROSTATICAL"
     ]
   },
@@ -92832,7 +92439,6 @@
       "BRAMBLE BUSH\nBram\"ble bush`. (Bot.)\n\nDefn: The bramble, or a collection of brambles growing together.\nHe jumped into a bramble bush And scratched out both his eyes. Mother\nGoose."
     ],
     "references": [
-      "BRAMBLE BUSH",
       "HIP",
       "THRID"
     ]
@@ -92849,9 +92455,7 @@
     "variants": [
       "BRAMBLE NET\nBram\"ble net`.\n\nDefn: A net to catch birds."
     ],
-    "references": [
-      "BRAMBLE NET"
-    ]
+    "references": []
   },
   {
     "spellings": "BRAMBLING",
@@ -93656,9 +93260,7 @@
     "variants": [
       "BRANCH PILOT\nBranch\" pi`lot.\n\nDefn: A pilot who has a branch or commission, as from Trinity House,\nEngland, for special navigation."
     ],
-    "references": [
-      "BRANCH PILOT"
-    ]
+    "references": []
   },
   {
     "spellings": "BRANCHY",
@@ -93741,7 +93343,6 @@
       "BRAND GOOSE\nBrand\" goose`. Etym: [Prob. fr. 1st brand + goose: cf. Sw. brandgås.\nCf. Brant.] (Zoöl.)\n\nDefn: A species of wild goose (Branta bernicla) usually called in\nAmerica brant. See Brant."
     ],
     "references": [
-      "BRAND GOOSE",
       "BRANT"
     ]
   },
@@ -93760,7 +93361,6 @@
     "references": [
       "BRAND",
       "BRANDER",
-      "BRANDING IRON",
       "BRAND IRON"
     ]
   },
@@ -93769,9 +93369,7 @@
     "variants": [
       "BRAND IRON\nBrand\" i`ron.\n\n1. A branding iron.\n\n2. A trivet to set a pot on. Huloet.\n\n3. The horizontal bar of an andiron."
     ],
-    "references": [
-      "BRAND IRON"
-    ]
+    "references": []
   },
   {
     "spellings": "BRANDISH",
@@ -93833,9 +93431,7 @@
     "variants": [
       "BRAND SPORE\nBrand\" spore`. (Bot.)\n\nDefn: One of several spores growing in a series or chain, and\nproduced by one of the fungi called brand."
     ],
-    "references": [
-      "BRAND SPORE"
-    ]
+    "references": []
   },
   {
     "spellings": "BRANDY",
@@ -94976,7 +94572,6 @@
       "BRAZIL NUT\nBra*zil\" nut`. (Bot.)\n\nDefn: An oily, three-sided nut, the seed of the Bertholletia excelsa;\nthe cream nut.\n\nNote: From eighteen to twenty-four of the seed or \"nuts\" grow in a\nhard and nearly globular shell."
     ],
     "references": [
-      "BRAZIL NUT",
       "CREAM",
       "JUVIA",
       "LID",
@@ -94991,7 +94586,6 @@
     "references": [
       "BRAZILETTO",
       "BRAZILIN",
-      "BRAZIL WOOD",
       "DROP",
       "INK",
       "NICARAGUA WOOD",
@@ -95915,7 +95509,6 @@
       "BREAKBONE FEVER\nBreak\"bone` fe`ver. (Med.)\n\nDefn: See Dengue."
     ],
     "references": [
-      "BREAKBONE FEVER",
       "DENGUE"
     ]
   },
@@ -96828,8 +96421,7 @@
       "BREECH ACTION\nBreech action.\n\nDefn: The breech mechanism in breech-loading small arms and certain\nspecial guns, as automatic and machine guns; --used frequently in\nreferring to the method by which the movable barrels of breech-\nloading shotguns are locked, unlocked, or rotated to loading\nposition."
     ],
     "references": [
-      "ACTION",
-      "BREECH ACTION"
+      "ACTION"
     ]
   },
   {
@@ -96943,9 +96535,7 @@
     "variants": [
       "BREECH PIN; BREECH SCREW\nBreech\" pin`, Breech\" screw`.\n\nDefn: A strong iron or steel plug screwed into the breech of a musket\nor other firearm, to close the bottom of the bore."
     ],
-    "references": [
-      "BREECH PIN; BREECH SCREW"
-    ]
+    "references": []
   },
   {
     "spellings": "BREECH SIGHT",
@@ -96953,7 +96543,6 @@
       "BREECH SIGHT\nBreech\" sight`.\n\nDefn: A device attached to the breech of a firearm, to guide the eye,\nin conjunction with the front sight, in taking aim."
     ],
     "references": [
-      "BREECH SIGHT",
       "HAUSSE",
       "TANGENT"
     ]
@@ -97245,7 +96834,6 @@
       "BREEZE; BREEZE FLY\nBreeze, Breeze\" fly` (, n. Etym: [OE. brese, AS. briósa; perh. akin\nto OHG. brimissa, G. breme, bremse, D. brems, which are akin to G.\nbrummen to growl, buzz, grumble, L. fremere to murmur; cf. G.\nbrausen, Sw. brusa, Dan. bruse, to roar, rush.] (Zoöl.)\n\nDefn: A fly of various species, of the family Tabanidæ, noted for\nbuzzing about animals, and tormenting them by sucking their blood; --\ncalled also horsefly, and gadfly. They are among the largest of two-\nwinged or dipterous insects. The name is also given to different\nspecies of botflies. [Written also breese and brize.]"
     ],
     "references": [
-      "BREEZE; BREEZE FLY",
       "BRIZE",
       "HORSEFLY",
       "WHAME"
@@ -97376,18 +96964,14 @@
     "variants": [
       "BRELAN CARRE\nBre*lan\" car`re\". [F. carré square.] (Card Playing)\n\nDefn: In French games, a double pair royal."
     ],
-    "references": [
-      "BRELAN CARRE"
-    ]
+    "references": []
   },
   {
     "spellings": "BRELAN FAVORI",
     "variants": [
       "BRELAN FAVORI\nBre*lan\" fa`vo`ri\". [F. favori favorite.] (Card Playing)\n\nDefn: In French games, a pair royal composed of 2 cards in the hand\nand the card turned."
     ],
-    "references": [
-      "BRELAN FAVORI"
-    ]
+    "references": []
   },
   {
     "spellings": "BRELOQUE",
@@ -97477,9 +97061,7 @@
     "variants": [
       "BREQUET CHAIN\nBreq\"uet chain`.\n\nDefn: A watch-guard."
     ],
-    "references": [
-      "BREQUET CHAIN"
-    ]
+    "references": []
   },
   {
     "spellings": "BRERE",
@@ -98236,7 +97818,6 @@
       "BRIC-A BRAC; BRIC-A-BRAC; BRIC A BRAC\nBric\"-a brac`, n. Etym: [F.]\n\nDefn: Miscellaneous curiosities and works of decorative art,\nconsidered collectively. A piece of bric-a-brac, any curious or\nantique article of virtu, as a piece of antiquated furniture or metal\nwork, or an odd knickknack."
     ],
     "references": [
-      "BRIC-A BRAC; BRIC-A-BRAC; BRIC A BRAC",
       "CRAZE",
       "ICONOMANIA",
       "TAG"
@@ -98904,7 +98485,6 @@
       "BRIDLE IRON\nBri\"dle i`ron. (Arch.)\n\nDefn: A strong flat bar of iron, so bent as to support, as in a\nstirrup, one end of a floor timber, etc., where no sufficient bearing\ncan be had; -- called also stirrup and hanger."
     ],
     "references": [
-      "BRIDLE IRON",
       "HANGER",
       "STIRRUP"
     ]
@@ -98931,9 +98511,7 @@
     "variants": [
       "BRIE CHEESE\nBrie\" cheese\".\n\nDefn: A kind of soft French cream cheese; -- so called from the\ndistrict in France where it is made; --called also fromage de Brie."
     ],
-    "references": [
-      "BRIE CHEESE"
-    ]
+    "references": []
   },
   {
     "spellings": "BRIEF",
@@ -99214,7 +98792,6 @@
     "references": [
       "ADJUTANT",
       "BRIGADE",
-      "BRIGADIER GENERAL",
       "COLONEL",
       "COMMODORE",
       "ENGINEER CORPS; CORPS OF ENGINEERS",
@@ -99439,7 +99016,6 @@
       "BRIGHT'S DISEASE\nBright's\" dis*ease\". Etym: [From Dr. Bright of London, who first\ndescribed it.] (Med.)\n\nDefn: An affection of the kidneys, usually inflammatory in character,\nand distinguished by the occurrence of albumin and renal casts in the\nurine. Several varieties of Bright's disease are now recognized,\ndiffering in the part of the kidney involved, and in the intensity\nand course of the morbid process."
     ],
     "references": [
-      "BRIGHT'S DISEASE",
       "URINE"
     ]
   },
@@ -101857,7 +101433,6 @@
       "BRITTLE STAR\nBrit\"tle star`.\n\nDefn: Any species of ophiuran starfishes. See Ophiuroidea."
     ],
     "references": [
-      "BRITTLE STAR",
       "OPHIURIOIDEA; OPHIUROIDEA",
       "SAND",
       "SEA STAR",
@@ -102297,7 +101872,6 @@
       "BROAD CHURCH\nBroad\" Church`. (Eccl.)\n\nDefn: A portion of the Church of England, consisting of persons who\nclaim to hold a position, in respect to doctrine and fellowship,\nintermediate between the High Church party and the Low Church, or\nevangelical, party. The term has been applied to otherbodies of men\nholding liberal or comprehensive views of Christian doctrine and\nfellowship.\nSide by side with these various shades of High and Low Church,\nanother party of a different character has always existed in the\nChurch of England. It is called by different names: Moderate,\nCatholic, or Broad Church, by its friends; Latitudinarian or\nIndifferent, by its enemies. Its distinctive character is the desire\nof comprehension. Its watch words are charity and toleration.\nConybeare."
     ],
     "references": [
-      "BROAD CHURCH",
       "CHURCH",
       "HIGH"
     ]
@@ -102333,9 +101907,7 @@
     "variants": [
       "BROAD GAUGE\nBroad\" gauge`. (Railroad)\n\nDefn: A wider distance between the rails than the \"standard\" gauge of\nfour feet eight inches and a half. See Gauge."
     ],
-    "references": [
-      "BROAD GAUGE"
-    ]
+    "references": []
   },
   {
     "spellings": "BROAD-HORNED",
@@ -102429,7 +102001,6 @@
       "BROAD SEAL\nBroad\" seal`.\n\nDefn: The great seal of England; the public seal of a country or\nstate."
     ],
     "references": [
-      "BROAD SEAL",
       "BROADSEAL"
     ]
   },
@@ -102624,9 +102195,7 @@
     "variants": [
       "BROCKEN SPECTER; BROCKEN SPECTRE\nBrock\"en spec\"ter or Brock\"en spec\"tre. [Trans. of G.\nBrockengespenst.]\n\nDefn: A mountain specter (which see), esp. that observed on the\nBrocken, in the Harz Mountains."
     ],
-    "references": [
-      "BROCKEN SPECTER; BROCKEN SPECTRE"
-    ]
+    "references": []
   },
   {
     "spellings": "BROCKET",
@@ -103158,9 +102727,7 @@
     "variants": [
       "BROKEN BREAST\nBro\"ken breast`.\n\nDefn: Abscess of the mammary gland."
     ],
-    "references": [
-      "BROKEN BREAST"
-    ]
+    "references": []
   },
   {
     "spellings": "BROKEN-HEARTED",
@@ -103194,7 +102761,6 @@
       "BROKEN WIND\nBro\"ken wind`. (Far.)\n\nDefn: The heaves."
     ],
     "references": [
-      "BROKEN WIND",
       "HEAVES"
     ]
   },
@@ -103372,7 +102938,6 @@
       "BROME GRASS\nBrome\" grass`. Etym: [L. bromos a kind of oats, Gr. (Bot.)\n\nDefn: A genus (Bromus) of grasses, one species of which is the chess\nor cheat."
     ],
     "references": [
-      "BROME GRASS",
       "CHESS",
       "DRAKE"
     ]
@@ -103424,9 +102989,7 @@
     "variants": [
       "BROMIDE PAPER; BROMID PAPER\nBromide paper or Bromid paper. (Photog.)\n\nDefn: A sensitized paper coated with gelatin impregnated with bromide\nof silver, used in contact printing and in enlarging."
     ],
-    "references": [
-      "BROMIDE PAPER; BROMID PAPER"
-    ]
+    "references": []
   },
   {
     "spellings": "BROMIDIOM",
@@ -103862,9 +103425,7 @@
     "variants": [
       "BRONZE STEEL\nBronze steel.\n\nDefn: A hard tough alloy of tin, copper, and iron, which can be used\nfor guns."
     ],
-    "references": [
-      "BRONZE STEEL"
-    ]
+    "references": []
   },
   {
     "spellings": "BRONZEWING",
@@ -104090,9 +103651,7 @@
     "variants": [
       "BROOK MINT\nBrook\" mint`. (Bot.)\n\nDefn: See Water mint."
     ],
-    "references": [
-      "BROOK MINT"
-    ]
+    "references": []
   },
   {
     "spellings": "BROOKSIDE",
@@ -104176,7 +103735,6 @@
     "references": [
       "ANDROPOGON",
       "BROOM",
-      "BROOM CORN",
       "INDIAN",
       "RIPPLE",
       "WHISK"
@@ -104189,7 +103747,6 @@
     ],
     "references": [
       "APHYLLOUS",
-      "BROOM RAPE",
       "RAPE"
     ]
   },
@@ -104468,7 +104025,6 @@
       "BROTHER GERMAN\nBroth\"er ger\"man. (Law)\n\nDefn: A brother by both the father's and mother's side, in\ncontradistinction to a uterine brother, one by the mother only.\nBouvier."
     ],
     "references": [
-      "BROTHER GERMAN",
       "GERMAN"
     ]
   },
@@ -105148,9 +104704,7 @@
     "variants": [
       "BROWN BILL\nBrown\" bill`. Etym: [Brown + bill cutting tool.]\n\nDefn: A bill or halberd of the 16th and 17th centuries. See 4th Bill.\nMany time, but for a sallet, my brainpan had been cleft with a brown\nbill. Shak.\n\nNote: The black, or as it is sometimes called, the brown bill, was a\nkind of halberd, the cutting part hooked like a woodman's bill, from\nthe back of which projected a spike, and another from the head.\nGrose."
     ],
-    "references": [
-      "BROWN BILL"
-    ]
+    "references": []
   },
   {
     "spellings": "BROWNIAN",
@@ -105517,7 +105071,6 @@
       "BROWN RACE\nBrown race.\n\nDefn: The Malay or Polynesian race; -- loosely so called."
     ],
     "references": [
-      "BROWN RACE",
       "RACE"
     ]
   },
@@ -105536,7 +105089,6 @@
       "BROWN THRUSH\nBrown\" thrush\". (Zoöl.)\n\nDefn: A common American singing bird (Harporhynchus rufus), allied to\nthe mocking bird; -- also called brown thrasher."
     ],
     "references": [
-      "BROWN THRUSH",
       "MOCKING",
       "THRASHER; THRESHER",
       "THRUSH"
@@ -105840,9 +105392,7 @@
     "variants": [
       "BRUNSWICK BLACK\nBruns\"wick black`.\n\nDefn: See Japan black."
     ],
-    "references": [
-      "BRUNSWICK BLACK"
-    ]
+    "references": []
   },
   {
     "spellings": "BRUNSWICK GREEN",
@@ -105850,7 +105400,6 @@
       "BRUNSWICK GREEN\nBruns\"wick green`. Etym: [G. Braunschweiger grün, first made at\nBrunswick, in Germany.]\n\nDefn: An oxychloride of copper, used as a green pigment; also, a\ncarbonate of copper similarly employed."
     ],
     "references": [
-      "BRUNSWICK GREEN",
       "GREEN"
     ]
   },
@@ -105997,7 +105546,6 @@
       "BRUSH TURKEY\nBrush\" tur`key. (Zoöl.)\n\nDefn: A large, edible, gregarious bird of Australia (Talegalla\nLathami) of the family Megapodidæ. Also applied to several allied\nspecies of New Guinea.\n\nNote: The brush turkeys live in the \"brush,\" and construct a common\nnest by collecting a large heap of decaying vegetable matter, which\ngenerates heat sufficient to hatch the numerous eggs (sometimes half\na bushel) deposited in it by the females of the flock."
     ],
     "references": [
-      "BRUSH TURKEY",
       "JUNGLE",
       "TALEGALLA",
       "VULTERN",
@@ -106011,7 +105559,6 @@
       "BRUSH WHEEL\nBrush\" wheel`.\n\n1. A wheel without teeth, used to turn a similar one by the friction\nof bristles or something brushlike or soft attached to the\ncircumference.\n\n2. A circular revolving brush used by turners, lapidaries,\nsilversmiths, etc., for polishing."
     ],
     "references": [
-      "BRUSH WHEEL",
       "GIN"
     ]
   },
@@ -106550,7 +106097,6 @@
       "BUBBLE SHELL\nBub\"ble shell`. (Zoöl.)\n\nDefn: A marine univalve shell of the genus Bulla and allied genera,\nbelonging to the Tectibranchiata."
     ],
     "references": [
-      "BUBBLE SHELL",
       "BULLA",
       "TECTIBRANCHIATA"
     ]
@@ -106561,7 +106107,6 @@
       "BUBBLING JOCK\nBub\"bling Jock` (Zoöl.)\n\nDefn: The male wild turkey, the gobbler; -- so called in allusion to\nits notes."
     ],
     "references": [
-      "BUBBLING JOCK",
       "GOBBLER"
     ]
   },
@@ -106841,7 +106386,6 @@
     ],
     "references": [
       "BOG",
-      "BUCK BEAN",
       "WATER TREFOIL"
     ]
   },
@@ -106907,9 +106451,7 @@
     "variants": [
       "BUCKET SHOP\nBuck\"et shop`.\n\nDefn: An office or a place where facilities are given for betting\nsmall sums on current prices of stocks, petroleum, etc. [Slang, U.S.]"
     ],
-    "references": [
-      "BUCKET SHOP"
-    ]
+    "references": []
   },
   {
     "spellings": "BUCKETY",
@@ -106939,9 +106481,7 @@
     "variants": [
       "BUCK FEVER\nBuck fever.\n\nDefn: Intense excitement at the sight of deer or other game, such as\noften unnerves a novice in hunting. [Colloq.]"
     ],
-    "references": [
-      "BUCK FEVER"
-    ]
+    "references": []
   },
   {
     "spellings": "BUCKHOUND",
@@ -107451,9 +106991,7 @@
     "variants": [
       "BUDE BURNER\nBude\" burn`er. Etym: [See Bude light.]\n\nDefn: A burner consisting of two or more concentric Argand burners\n(the inner rising above the outer) and a central tube by which oxygen\ngas or common air is supplied."
     ],
-    "references": [
-      "BUDE BURNER"
-    ]
+    "references": []
   },
   {
     "spellings": "BUDE LIGHT",
@@ -107461,8 +106999,7 @@
       "BUDE LIGHT\nBude\" light`. Etym: [From Bude, in Cornwall, the residence of Sir\nG.Gurney, the inventor.]\n\nDefn: A light in which high illuminating power is obtained by\nintroducing a jet of oxygen gas or of common air into the center of a\nflame fed with coal gas or with oil."
     ],
     "references": [
-      "BUDE BURNER",
-      "BUDE LIGHT"
+      "BUDE BURNER"
     ]
   },
   {
@@ -107624,7 +107161,6 @@
       "BUFFEL DUCK\nBuf\"fel duck. Etym: [See Buffalo.] (Zoöl.)\n\nDefn: A small duck (Charitonetta albeola); the spirit duck, or\nbutterball. The head of the male is covered with numerous elongated\nfeathers, and thus appears large. Called also bufflehead."
     ],
     "references": [
-      "BUFFEL DUCK",
       "BUFFLEHEAD",
       "BUTTERBALL",
       "DIPPER",
@@ -107711,8 +107247,7 @@
       "BUFFING APPARATUS\nBuff\"ing ap`pa*ra\"tus.\n\nDefn: See Buffer, 1."
     ],
     "references": [
-      "BUFFER",
-      "BUFFING APPARATUS"
+      "BUFFER"
     ]
   },
   {
@@ -108090,7 +107625,6 @@
     ],
     "references": [
       "BLAST",
-      "BUGLE HORN",
       "WILDGRAVE"
     ]
   },
@@ -108919,9 +108453,7 @@
     "variants": [
       "BUKE MUSLIN\nBuke\" mus\"lin.\n\nDefn: See Book muslin."
     ],
-    "references": [
-      "BUKE MUSLIN"
-    ]
+    "references": []
   },
   {
     "spellings": "BUKSHISH",
@@ -109529,9 +109061,7 @@
     "variants": [
       "BULL BRIER\nBull\" bri`er. (Bot.)\n\nDefn: A species of Smilax (S. Pseudo-China) growing from New Jersey\nto the Gulf of Mexico, which has very large tuberous and farinaceous\nrootstocks, formerly used by the Indians for a sort of bread, and by\nthe negroes as an ingredient in making beer; -- called also bamboo\nbrier and China brier."
     ],
-    "references": [
-      "BULL BRIER"
-    ]
+    "references": []
   },
   {
     "spellings": "BULLCOMBER",
@@ -109706,9 +109236,7 @@
     "variants": [
       "BULL FLY; BULLFLY\nBull\" fly` or Bull\"fly`, n. (Zoöl.)\n\nDefn: Any large fly troublesome to cattle, as the gadflies and breeze\nflies."
     ],
-    "references": [
-      "BULL FLY; BULLFLY"
-    ]
+    "references": []
   },
   {
     "spellings": "BULLFROG",
@@ -109802,9 +109330,7 @@
     "variants": [
       "BULL MOOSE\nBull Moose. (U. S. Politics)\n (a) A follower of Theodore Roosevelt in the presidential campaign of\n1912; -- a sense said to have originated from a remark made by\nRoosevelt on a certain occasion that he felt \"like a bull moose.\"\n[Cant]\n (b) The figure of a bull moose used as the party symbol of the\nProgressive party in the presidential campaign of 1912. -- Bull\nMooser. [Cant]"
     ],
-    "references": [
-      "BULL MOOSE"
-    ]
+    "references": []
   },
   {
     "spellings": "BULL-NECKED",
@@ -109889,9 +109415,7 @@
     "variants": [
       "BULL TERRIER\nBull\" ter\"ri*er. (Zoöl.)\n\nDefn: A breed of dogs obtained by crossing the bulldog and the\nterrier."
     ],
-    "references": [
-      "BULL TERRIER"
-    ]
+    "references": []
   },
   {
     "spellings": "BULL TROUT",
@@ -109899,7 +109423,6 @@
       "BULL TROUT\nBull\" trout`. (Zoöl.)\n(a) In England, a large salmon trout of several species, as Salmo\ntrutta and S. Cambricus, which ascend rivers; -- called also sea\ntrout.\n(b) Salvelinus malma of California and Oregon; -- called also Dolly\nVarden trout and red-spotted trout.\n(c) The huso or salmon of the Danube."
     ],
     "references": [
-      "BULL TROUT",
       "DOLLY VARDEN",
       "HUCH; HUCHEN",
       "MALMA",
@@ -109952,7 +109475,6 @@
       "BULLET-PROOF",
       "BULLIRAG",
       "BULLOCK",
-      "BULLY; BULLY BEEF",
       "BULLYROCK",
       "BULLY TREE",
       "CHICLE; CHICLE GUM",
@@ -110000,7 +109522,6 @@
       "BALATA",
       "BULLACE",
       "BULLET-PROOF",
-      "BULLY TREE",
       "CHICLE; CHICLE GUM"
     ]
   },
@@ -110405,7 +109926,6 @@
       "BUNCH GRASS\nBunch\" grass`. (Bot.)\n\nDefn: A grass growing in bunches and affording pasture. In\nCalifornia, Atropis tenuifolia, Festuca scabrella, and several kinds\nof Stipa are favorite bunch grasses. In Utah, Eriocoma cuspidata is a\ngood bunch grass."
     ],
     "references": [
-      "BUNCH GRASS",
       "GRASS"
     ]
   },
@@ -110746,9 +110266,7 @@
     "variants": [
       "BUNSEN CELL\nBun\"sen cell. (Elec.)\n\nDefn: A zinc-carbon cell in which the zinc (amalgamated) is\nsurrounded by dilute sulphuric acid, and the carbon by nitric acid or\na chromic acid mixture, the two plates being separated by a porous\ncup."
     ],
-    "references": [
-      "BUNSEN CELL"
-    ]
+    "references": []
   },
   {
     "spellings": "BUNSEN'S BATTERY; BUNSEN'S BURNER",
@@ -110756,7 +110274,6 @@
       "BUNSEN'S BATTERY; BUNSEN'S BURNER\nBun\"sen's bat\"ter*y, Bun\"sen's burn`er.\n\nDefn: See under Battery, and Burner."
     ],
     "references": [
-      "BUNSEN'S BATTERY; BUNSEN'S BURNER",
       "BURNER"
     ]
   },
@@ -111402,7 +110919,6 @@
     ],
     "references": [
       "BALLOON FISH",
-      "BUR FISH",
       "GYMNODONT",
       "PORGY",
       "SWELLFISH"
@@ -112549,7 +112065,6 @@
     ],
     "references": [
       "BEGGAR'S TICKS",
-      "BUR MARIGOLD",
       "MARIGOLD",
       "WATER AGRIMONY"
     ]
@@ -113358,36 +112873,28 @@
     "variants": [
       "BURREL FLY\nBur\"rel fly`. Etym: [From its reddish color. See 1st Burrel.] (Zoöl.)\n\nDefn: The botfly or gadfly of cattle (Hypoderma bovis). See Gadfly."
     ],
-    "references": [
-      "BURREL FLY"
-    ]
+    "references": []
   },
   {
     "spellings": "BURREL SHOT",
     "variants": [
       "BURREL SHOT\nBur\"rel shot`. Etym: [Either from annoying the enemy like a burrel\nfly, or, less probably, fr. F. bourreler to sting, torture.] (Gun.)\n\nDefn: A mixture of shot, nails, stones, pieces of old iron, etc.,\nfired from a cannon at short range, in an emergency. [R.]"
     ],
-    "references": [
-      "BURREL SHOT"
-    ]
+    "references": []
   },
   {
     "spellings": "BURRING MACHINE",
     "variants": [
       "BURRING MACHINE\nBurr\"ing ma*chine\".\n\nDefn: A machine for cleansing wool of burs, seeds, and other\nsubstances."
     ],
-    "references": [
-      "BURRING MACHINE"
-    ]
+    "references": []
   },
   {
     "spellings": "BURR MILLSTONE",
     "variants": [
       "BURR MILLSTONE\nBurr\" mill\"stone`.\n\nDefn: See Buhrstone."
     ],
-    "references": [
-      "BURR MILLSTONE"
-    ]
+    "references": []
   },
   {
     "spellings": "BURRO",
@@ -113918,7 +113425,6 @@
       "BURYING GROUND; BURYING PLACE\nBur\"y*ing ground`, Bur\"y*ing place.\n\nDefn: The ground or place for burying the dead; burial place."
     ],
     "references": [
-      "BURYING GROUND; BURYING PLACE",
       "CHURCHYARD",
       "LAIR",
       "LICH"
@@ -115379,7 +114885,6 @@
     "references": [
       "BOX",
       "BROOM",
-      "BUTCHER'S BROOM",
       "KNEE"
     ]
   },
@@ -119941,8 +119446,7 @@
       "BUTT HINGE\nButt\" hinge`.\n\nDefn: See 1st Butt, 10."
     ],
     "references": [
-      "BUTT; BUT",
-      "BUTT HINGE"
+      "BUTT; BUT"
     ]
   },
   {
@@ -119972,9 +119476,7 @@
     "variants": [
       "BUTTING JOINT\nBut\"ting joint`.\n\nDefn: A joint between two pieces of timber or wood, at the end of one\nor both, and either at right angles or oblique to the grain, as the\njoints which the struts and braces form with the truss posts; --\nsometimes called abutting joint."
     ],
-    "references": [
-      "BUTTING JOINT"
-    ]
+    "references": []
   },
   {
     "spellings": "BUTT JOINT",
@@ -119983,7 +119485,6 @@
     ],
     "references": [
       "BUTT; BUT",
-      "BUTT JOINT",
       "JUMP",
       "JUNCTION",
       "RIVETING",
@@ -120181,7 +119682,6 @@
       "BUTT SHAFT\nButt\" shaft`\n\nDefn: An arrow without a barb, for shooting at butts; an arrow. [Also\nbut shaft.] Shak."
     ],
     "references": [
-      "BUTT SHAFT",
       "ROVER"
     ]
   },
@@ -120192,7 +119692,6 @@
     ],
     "references": [
       "BUTT; BUT",
-      "BUTT WELD",
       "BUTTWELD",
       "JAM",
       "JUMP"

--- a/output/wordDisplayData#C.json
+++ b/output/wordDisplayData#C.json
@@ -3081,9 +3081,7 @@
     "variants": [
       "CAEN STONE\nCa\"en stone\",\n\nDefn: A cream-colored limestone for building, found near Caen,\nFrance."
     ],
-    "references": [
-      "CAEN STONE"
-    ]
+    "references": []
   },
   {
     "spellings": "CAESAR",
@@ -3376,9 +3374,7 @@
     "variants": [
       "CAHINCA ROOT\nCa*hin\"ca root`. [Written also cainca root.] [See Cahincic.] (Bot.)\n\nDefn: The root of an American shrub (Chiococca racemosa), found as\nfar north as Florida Keys, from which cahincic acid is obtained;\nalso, the root of the South American Chiococca anguifuga, a\ncelebrated antidote for snake poison."
     ],
-    "references": [
-      "CAHINCA ROOT"
-    ]
+    "references": []
   },
   {
     "spellings": "CAHINCIC",
@@ -3437,9 +3433,7 @@
     "variants": [
       "CA IRA\nÇa\"i*ra\". Etym: [F. ça ira, ça ira, les aristocrates à la lanterne,\nit shall go on, it shall go on, [hang]the arictocrats to the lantern\n(lamp-post).]\n\nDefn: The refrain of a famous song of the French Revolution."
     ],
-    "references": [
-      "CA IRA"
-    ]
+    "references": []
   },
   {
     "spellings": "CAIRD",
@@ -3493,9 +3487,7 @@
     "variants": [
       "CAISSON DISEASE\nCais\"son dis*ease\". (Med.)\n\nDefn: A disease frequently induced by remaining for some time in an\natmosphere of high pressure, as in caissons, diving bells, etc. It is\ncharacterized by neuralgic pains and paralytic symptoms. It is\nvariously explained, most probably as due to congestion of internal\norgans with subsequent stasis of the blood."
     ],
-    "references": [
-      "CAISSON DISEASE"
-    ]
+    "references": []
   },
   {
     "spellings": "CAITIFF",
@@ -3728,7 +3720,6 @@
       "CAKING COAL\nCak\"ing coal`.\n\nDefn: See Coal."
     ],
     "references": [
-      "CAKING COAL",
       "COAL"
     ]
   },
@@ -4017,7 +4008,6 @@
       "CALAMANDER WOOD\nCal\"a*man`der wood.\n\nDefn: A valuable furniture wood from India and Ceylon, of a hazel-\nbrown color, with black stripes, very hard in texture. It is a\nspecies of ebony, and is obtained from the Diospyros qusesita. Called\nalso Coromandel wood."
     ],
     "references": [
-      "CALAMANDER WOOD",
       "COROMANDEL"
     ]
   },
@@ -4255,9 +4245,7 @@
     "variants": [
       "CALAVERAS SKULL\nCa`la*ve\"ras skull.\n\nDefn: A human skull reported, by Prof. J. D. Whitney, as found in\n1886 in a Tertiary auriferous gravel deposit, lying below a bed of\nblack lava, in Calaveras County, California. It is regarded as very\ndoubtful whether the skull really belonged to the deposit in which it\nwas found. If it did, it indicates an unprecedented antiquity for\nhuman beings of an advanced type."
     ],
-    "references": [
-      "CALAVERAS SKULL"
-    ]
+    "references": []
   },
   {
     "spellings": "CALAVERITE",
@@ -5688,7 +5676,6 @@
       "CALIFORNIA JACK\nCal`i*for\"ni*a jack\".\n\nDefn: A game at cards, a modification of seven-up, or all fours."
     ],
     "references": [
-      "CALIFORNIA JACK",
       "SHASTA SAM"
     ]
   },
@@ -5825,7 +5812,6 @@
       "CALISAYA BARK\nCal`i*sa\"ya bark.\n\nDefn: A valuable kind of Peruvian bark obtained from the Cinchona\nCalisaya, and other closely related species."
     ],
     "references": [
-      "CALISAYA BARK",
       "YELLOW"
     ]
   },
@@ -7723,7 +7709,6 @@
       "CAMARA; CAMARA DOS PARES; CAMARADOS DEPUTADOS\nCa\"ma*ra, Ca\"ma*ra dos pares, Ca\"ma*ra*dos deputados, n. [Pg.]\n\nDefn: Chamber; house; -- used in Ca\"ma*ra dos Pa\"res, and Ca\"ma*ra\ndos De`pu*ta\"dos. See Legislature."
     ],
     "references": [
-      "CAMARA; CAMARA DOS PARES; CAMARADOS DEPUTADOS",
       "COMRADE"
     ]
   },
@@ -8327,9 +8312,7 @@
     "variants": [
       "CAMEMBERT; CAMEMBERT CHEESE\nCa`mem`bert\", n., or Camembert cheese.\n\nDefn: A kind of soft, unpressed cream cheese made in the vicinity of\nCamembert, near Argentan, France; also, any cheese of the same type,\nwherever made."
     ],
-    "references": [
-      "CAMEMBERT; CAMEMBERT CHEESE"
-    ]
+    "references": []
   },
   {
     "spellings": "CAMEO",
@@ -8423,7 +8406,6 @@
       "CAMERA LUCIDA\nCam\"e*ra lu\"ci*da. Etym: [L. camera chamber + L. lucidus, lucida,\nlucid, light.] (Opt.)\n\nDefn: An instrument which by means of a prism of a peculiar form, or\nan arrangement of mirrors, causes an apparent image of an external\nobject or objects to appear as if projected upon a plane surface, as\nof paper or canvas, so that the outlines may conveniently traced. It\nis generally used with the microscope."
     ],
     "references": [
-      "CAMERA LUCIDA",
       "TELEMETROGRAPH"
     ]
   },
@@ -8434,7 +8416,6 @@
     ],
     "references": [
       "CAMERA",
-      "CAMERA OBSCURA",
       "SCIOPTIC",
       "TELEGRAPHOSCOPE"
     ]
@@ -8890,7 +8871,6 @@
       "CAMPEACHY WOOD\nCam*peach\"y Wood`. Etym: [From the bay of Campeachy, in Mexico.]\n\nDefn: Logwood."
     ],
     "references": [
-      "CAMPEACHY WOOD",
       "LOGWOOD"
     ]
   },
@@ -11032,9 +11012,7 @@
     "variants": [
       "CANAL COAL\nCan\"al coal`.\n\nDefn: See Cannel coal."
     ],
-    "references": [
-      "CANAL COAL"
-    ]
+    "references": []
   },
   {
     "spellings": "CANALICULATE; CANALICULATED",
@@ -11073,9 +11051,7 @@
     "variants": [
       "CANAPE CONFIDENT\nCa`na`pé\" con`fi`dent\".\n\nDefn: A sofa having a seat at each end at right angles to the main\nseats."
     ],
-    "references": [
-      "CANAPE CONFIDENT"
-    ]
+    "references": []
   },
   {
     "spellings": "CANARD",
@@ -11135,7 +11111,6 @@
     ],
     "references": [
       "CANARY",
-      "CANARY BIRD",
       "FINCH"
     ]
   },
@@ -11154,8 +11129,7 @@
       "CAN BUOY\nCan\" buoy`.\n\nDefn: See under Buoy, n."
     ],
     "references": [
-      "BUOY",
-      "CAN BUOY"
+      "BUOY"
     ]
   },
   {
@@ -11704,7 +11678,6 @@
     ],
     "references": [
       "BAYBERRY",
-      "CANDLEBERRY TREE",
       "WAXBERRY"
     ]
   },
@@ -11720,9 +11693,7 @@
     "variants": [
       "CANDLE COAL\nCan\"dle coal`.\n\nDefn: See Cannel coal."
     ],
-    "references": [
-      "CANDLE COAL"
-    ]
+    "references": []
   },
   {
     "spellings": "CANDLEFISH",
@@ -11741,9 +11712,7 @@
     "variants": [
       "CANDLE FOOT\nCandle foot. (Photom.)\n\nDefn: The illumination produced by a British standard candle at a\ndistance of one foot; --used as a unit of illumination."
     ],
-    "references": [
-      "CANDLE FOOT"
-    ]
+    "references": []
   },
   {
     "spellings": "CANDLEHOLDER",
@@ -11782,9 +11751,7 @@
     "variants": [
       "CANDLE METER\nCandle meter. (Photom.)\n\nDefn: The illumination given by a standard candle at a distance of\none meter; -- used as a unit of illumination, except in Great\nBritain."
     ],
-    "references": [
-      "CANDLE METER"
-    ]
+    "references": []
   },
   {
     "spellings": "CANDLENUT",
@@ -11807,7 +11774,6 @@
     ],
     "references": [
       "CANDLE",
-      "CANDLE POWER",
       "TUNGSTEN LAMP"
     ]
   },
@@ -12047,9 +12013,7 @@
     "variants": [
       "CAN HOOK\nCan\" hook`.\n\nDefn: A device consisting of a short rope with flat hooks at each\nend, for hoisting casks or barrels by the ends of the staves."
     ],
-    "references": [
-      "CAN HOOK"
-    ]
+    "references": []
   },
   {
     "spellings": "CANICULA; CANNICULA",
@@ -12209,18 +12173,14 @@
     "variants": [
       "CANKER BLOOM\nCan\"ker bloom`.\n\nDefn: The bloom or blossom of the wild rose or dog-rose."
     ],
-    "references": [
-      "CANKER BLOOM"
-    ]
+    "references": []
   },
   {
     "spellings": "CANKER BLOSSOM",
     "variants": [
       "CANKER BLOSSOM\nCan\"ker blos`som.\n\nDefn: That which blasts a blossom as a canker does. [Obs.]\nO me! you juggler! you canker blossom! You thief of Love! Shak."
     ],
-    "references": [
-      "CANKER BLOSSOM"
-    ]
+    "references": []
   },
   {
     "spellings": "CANKERED",
@@ -12244,9 +12204,7 @@
     "variants": [
       "CANKER FLY\nCan\"ker fly`.\n\nDefn: A fly that preys on fruit."
     ],
-    "references": [
-      "CANKER FLY"
-    ]
+    "references": []
   },
   {
     "spellings": "CANKEROUS",
@@ -12261,7 +12219,6 @@
       "CANKER RASH\nCan\"ker rash\". (Med.)\n\nDefn: A form of scarlet fever characterized by ulcerated or putrid\nsore throat."
     ],
     "references": [
-      "CANKER RASH",
       "RASH"
     ]
   },
@@ -12344,7 +12301,6 @@
     "references": [
       "CANAL COAL",
       "CANDLE COAL",
-      "CANNEL COAL",
       "COAL",
       "HEPTANE",
       "KENNEL COAL",
@@ -12628,7 +12584,6 @@
       "CANNON BONE\nCan\"non bone. (Anat.)\n\nDefn: See Canon Bone."
     ],
     "references": [
-      "CANNON BONE",
       "SPLINT"
     ]
   },
@@ -12896,9 +12851,7 @@
     "variants": [
       "CANON BIT\nCan\"on bit`. Etym: [F. canon, fr. L. canon a rule.]\n\nDefn: That part of a bit which is put in a horse's mouth."
     ],
-    "references": [
-      "CANON BIT"
-    ]
+    "references": []
   },
   {
     "spellings": "CANON BONE",
@@ -12906,8 +12859,7 @@
       "CANON BONE\nCan\"on bone`. Etym: [F. canon, fr. L. canon a rule. See canon.]\n(Anat.)\n\nDefn: The shank bone, or great bone above the fetlock, in the fore\nand hind legs of the horse and allied animals, corresponding to the\nmiddle metacarpal or metatarsal bone of most mammals. See Horse."
     ],
     "references": [
-      "CANNON BONE",
-      "CANON BONE"
+      "CANNON BONE"
     ]
   },
   {
@@ -13472,7 +13424,6 @@
       "CANT HOOK\nCant\" hook`.\n\nDefn: A wooden lever with a movable iron hook. hear the end; -- used\nfor canting or turning over heavy logs, etc. [U. S.] Bartlett."
     ],
     "references": [
-      "CANT HOOK",
       "PEAVEY; PEAVY",
       "SWAMP"
     ]
@@ -13684,7 +13635,6 @@
       "CANTON CRAPE\nCan\"ton crape\".\n\nDefn: A soft, white or colored silk fabric, of a gauzy texture and\nwavy appearance, used for ladies' scarfs, shawls, bonnet trimmings,\netc.; -- called also Oriental crape. De Colange."
     ],
     "references": [
-      "CANTON CRAPE",
       "CRAPE"
     ]
   },
@@ -13704,7 +13654,6 @@
       "CANTON FLANNEL\nCan\"ton flan\"nel.\n\nDefn: See Cotton flannel."
     ],
     "references": [
-      "CANTON FLANNEL",
       "COTTON",
       "FLANNEL"
     ]
@@ -16235,8 +16184,7 @@
       "CAPER BUSH; CAPER TREE\nCa\"per bush`, Ca\"per tree`.\n\nDefn: See Capper, a plant, 2."
     ],
     "references": [
-      "CAPER",
-      "CAPER BUSH; CAPER TREE"
+      "CAPER"
     ]
   },
   {
@@ -16590,9 +16538,7 @@
     "variants": [
       "CAPITAN PASHA; CAPITAN PACHA\nCa`pi*tan` Pa*sha` or Pa*cha`. Etym: [See capitan.]\n\nDefn: The chief admiral of the Turkish fleet."
     ],
-    "references": [
-      "CAPITAN PASHA; CAPITAN PACHA"
-    ]
+    "references": []
   },
   {
     "spellings": "CAPITATE",
@@ -16904,9 +16850,7 @@
     "variants": [
       "CAPO TASTO\nCa\"po tas\"to. [It. capotasto.] (Music)\n\nDefn: A sort of bar or movable nut, attached to the finger board of a\nguitar or other  fretted instrument for the purpose of raising\nuniformly the pitch of all the strings."
     ],
-    "references": [
-      "CAPO TASTO"
-    ]
+    "references": []
   },
   {
     "spellings": "CAPOTE",
@@ -16973,9 +16917,7 @@
     "variants": [
       "CAPPING PLANE\nCap\"ping plane`. (Join.)\n\nDefn: A plane used for working the upper surface of staircase rails."
     ],
-    "references": [
-      "CAPPING PLANE"
-    ]
+    "references": []
   },
   {
     "spellings": "CAPRA",
@@ -19366,9 +19308,7 @@
     "variants": [
       "CARBON PROCESS\nCar\"bon process. (Photog.)\n\nDefn: A printing process depending on the effect of light on\nbichromatized gelatin. Paper coated with a mixture of the gelatin and\na pigment is called carbon paper or carbon tissue. This is exposed\nunder a negative and the film is transferred from the paper to some\nother support and developed by washing (the unexposed portions being\ndissolved away). If the process stops here it is called single\ntransfer; if the image is afterward transferred in order to give an\nunreversed print, the method is called double transfer."
     ],
-    "references": [
-      "CARBON PROCESS"
-    ]
+    "references": []
   },
   {
     "spellings": "CARBON STEEL",
@@ -19376,7 +19316,6 @@
       "CARBON STEEL\nCarbon steel.\n\nDefn: Steel deriving its qualities from carbon chiefly, without the\npresence of other alloying elements; --opposed to alloy steel."
     ],
     "references": [
-      "CARBON STEEL",
       "HARVEY PROCESS"
     ]
   },
@@ -19385,9 +19324,7 @@
     "variants": [
       "CARBON TRANSMITTER\nCarbon transmitter.\n\nDefn: A telephone transmitter in which a carbon contact is used."
     ],
-    "references": [
-      "CARBON TRANSMITTER"
-    ]
+    "references": []
   },
   {
     "spellings": "CARBONYL",
@@ -19417,9 +19354,7 @@
     "variants": [
       "CARBORUNDUM CLOTH; CARBORUNDUM PAPER\nCarborundum cloth or paper.\n\nDefn: Cloth or paper covered with powdered carborundum."
     ],
-    "references": [
-      "CARBORUNDUM CLOTH; CARBORUNDUM PAPER"
-    ]
+    "references": []
   },
   {
     "spellings": "CARBOSTYRIL",
@@ -19648,9 +19583,7 @@
     "variants": [
       "CARCEL LAMP\nCar\"cel lamp`. Etym: [Named after Carcel, the inventor.]\n\nDefn: A French mechanical lamp, for lighthouses, in which a\nsuperbundance of oil is pumped to the wick tube by clockwork."
     ],
-    "references": [
-      "CARCEL LAMP"
-    ]
+    "references": []
   },
   {
     "spellings": "CARCERAL",
@@ -19941,9 +19874,7 @@
     "variants": [
       "CARDIGAN JACKET\nCar\"di*gan jack`et. Etym: [From the Earl of Cardigan, who was famous\nin the Crimean campaign of 1854-55.]\n\nDefn: A warm jacket of knit worsted with or without sleeves."
     ],
-    "references": [
-      "CARDIGAN JACKET"
-    ]
+    "references": []
   },
   {
     "spellings": "CARDINAL",
@@ -21452,9 +21383,7 @@
     "variants": [
       "CARLINE THISTLE\nCar\"line this`tle. Etym: [F. carline, It., Sp., & Pg., carline, Said\nto be so called from the Emperor Charlemagne, whose army is reputed\nto have used it as a remedy for pestilence.] (Bot.)\n\nDefn: A prickly plant of the genus Carlina (C. vulgaris), found in\nEurope and Asia."
     ],
-    "references": [
-      "CARLINE THISTLE"
-    ]
+    "references": []
   },
   {
     "spellings": "CARLINGS",
@@ -21528,7 +21457,6 @@
       "CAR MILE\nCar mile. (Railroads)\n\nDefn: A mile traveled by a single car, taken as a unit of\ncomputation, as in computing the average travel of each car of a\nsystem during a given period."
     ],
     "references": [
-      "CAR MILE",
       "CAR MILEAGE"
     ]
   },
@@ -21537,9 +21465,7 @@
     "variants": [
       "CAR MILEAGE\nCar mileage. (Railroads)\n (a) Car miles collectively.\n (b) The amount paid by one road the use of cars of another road."
     ],
-    "references": [
-      "CAR MILEAGE"
-    ]
+    "references": []
   },
   {
     "spellings": "CARMINATED",
@@ -22010,9 +21936,7 @@
     "variants": [
       "CARNOT'S CYCLE\nCar`not's\" cy\"cle. [After N. L. S. Carnot, French physicist.]\n(Thermodynamics)\n\nDefn: An ideal heat-engine cycle in which the working fluid goes\nthrough the following four successive operations: (1) Isothermal\nexpansion to a desired point; (2) adiabatic expansion to a desired\npoint; (3) isothermal compression to such a point that (4) adiabatic\ncompression brings it back to its initial state."
     ],
-    "references": [
-      "CARNOT'S CYCLE"
-    ]
+    "references": []
   },
   {
     "spellings": "CAROB",
@@ -22090,7 +22014,6 @@
       "CAROLINA PINK\nCar`o*li\"na pink`. (Bot.)\n\nDefn: See Pinkboot."
     ],
     "references": [
-      "CAROLINA PINK",
       "PINKROOT"
     ]
   },
@@ -23179,9 +23102,7 @@
     "variants": [
       "CARRON OIL\nCar\"ron oil.\n\nDefn: A lotion of linseed oil and lime water, used as an application\nto burns and scalds; -- first used at the Carron iron works in\nScotland."
     ],
-    "references": [
-      "CARRON OIL"
-    ]
+    "references": []
   },
   {
     "spellings": "CARROT",
@@ -24032,7 +23953,6 @@
       "CARTE BLANCHE\nCarte` blanche\". Etym: [F., fr. OF. carte paper + -blanc, blanche,\nwhite. See 1st Card.]\n\nDefn: A blank paper, with a person's signature, etc., at the bottom,\ngiven to another person, with permission to superscribe what\nconditions he pleases. Hence: Unconditional terms; unlimited\nauthority."
     ],
     "references": [
-      "CARTE BLANCHE",
       "CHAMADE"
     ]
   },
@@ -24043,8 +23963,7 @@
     ],
     "references": [
       "CABINET",
-      "CARTE",
-      "CARTE DE VISITE"
+      "CARTE"
     ]
   },
   {
@@ -24060,9 +23979,7 @@
     "variants": [
       "CARTE QUARTE\nCarte. Quarte, n. Etym: [F. quarte, prop., a fourth. Cf. Quart.]\n(Fencing)\n\nDefn: A position in thrusting or parrying, with the inside of the\nhand turned upward and the point of the weapon toward the adversary's\nright breast."
     ],
-    "references": [
-      "CARTE QUARTE"
-    ]
+    "references": []
   },
   {
     "spellings": "CARTER",
@@ -24704,7 +24621,6 @@
       "CAR WHEEL\nCar\" wheel`,\n\nDefn: A flanged wheel of a railway car or truck."
     ],
     "references": [
-      "CAR WHEEL",
       "CHILL",
       "CONE",
       "FLANGE",
@@ -24829,9 +24745,7 @@
     "variants": [
       "CASCADE METHOD\nCas*cade\" meth\"od. (Physics)\n\nDefn: A method of attaining successively lower temperatures by\nutilizing the cooling effect of the expansion of one gas in\ncondensing another less easily liquefiable, and so on."
     ],
-    "references": [
-      "CASCADE METHOD"
-    ]
+    "references": []
   },
   {
     "spellings": "CASCADE SYSTEM",
@@ -24839,7 +24753,6 @@
       "CASCADE SYSTEM\nCascade system. (Elec.)\n\nDefn: A system or method of connecting and operating two induction\nmotors so that the primary circuit of one is connected to the\nsecondary circuit of the other, the primary circuit of the latter\nbeing connected to the source of supply; also, a system of electric\ntraction in which motors so connected are employed. The cascade\nsystem is also called tandem, or concatenated, system; the connection\na cascade, tandem, or concatenated, connection, or a concatenation;\nand the control of the motors so obtained a tandem, or concatenation,\ncontrol. In the cascade system of traction the cascade connection is\nused for starting and for low speeds up to half speed. For full speed\nthe short-circuited motor is cut loose from the other motor and is\neither left idle or (commonly) connected direct to the line."
     ],
     "references": [
-      "CASCADE SYSTEM",
       "TANDEM SYSTEM"
     ]
   },
@@ -24856,7 +24769,6 @@
       "CASCARA BUCKTHORN\nCas\"ca*ra buck\"thorn`. (Bot.)\n\nDefn: The buckthorn (Rhamnus Purshiana) of the Pacific coast of the\nUnited States, which yields cascara sagrada."
     ],
     "references": [
-      "CASCARA BUCKTHORN",
       "WAHOO"
     ]
   },
@@ -24867,7 +24779,6 @@
     ],
     "references": [
       "CASCARA BUCKTHORN",
-      "CASCARA SAGRADA",
       "HOLY"
     ]
   },
@@ -25653,9 +25564,7 @@
     "variants": [
       "CASE KNIFE\nCase\" knife`.\n\n1. A knife carried in a sheath or case. Addison.\n\n2. A large table knife; -- so called from being formerly kept in a\ncase."
     ],
-    "references": [
-      "CASE KNIFE"
-    ]
+    "references": []
   },
   {
     "spellings": "CASEMATE",
@@ -25737,7 +25646,6 @@
     ],
     "references": [
       "CANISTER",
-      "CASE SHOT",
       "FLYING",
       "ROCKET",
       "SHRAPNEL"
@@ -25748,9 +25656,7 @@
     "variants": [
       "CASE SYSTEM\nCase system. (Law)\n\nDefn: The system of teaching law in which the instruction is\nprimarily a historical and inductive study of leading or selected\ncases, with or without the use of textbooks for reference and\ncollateral reading."
     ],
-    "references": [
-      "CASE SYSTEM"
-    ]
+    "references": []
   },
   {
     "spellings": "CASEUM",
@@ -25861,9 +25767,7 @@
     "variants": [
       "CASHIER'S CHECK\nCash*ier's\" check. (Banking)\n\nDefn: A check drawn by a bank upon its own funds, signed by the\ncashier."
     ],
-    "references": [
-      "CASHIER'S CHECK"
-    ]
+    "references": []
   },
   {
     "spellings": "CASHMERE",
@@ -25903,18 +25807,14 @@
     "variants": [
       "CASH RAILWAY\nCash railway.\n\nDefn: A form of cash carrier in which a small carrier or car travels\nupon a kind of track."
     ],
-    "references": [
-      "CASH RAILWAY"
-    ]
+    "references": []
   },
   {
     "spellings": "CASH REGISTER",
     "variants": [
       "CASH REGISTER\nCash register.\n\nDefn: A device for recording the amount of cash received, usually\nhaving an automatic adding machine and a money drawer and exhibiting\nthe amount of the sale."
     ],
-    "references": [
-      "CASH REGISTER"
-    ]
+    "references": []
   },
   {
     "spellings": "CASING",
@@ -26179,27 +26079,21 @@
     "variants": [
       "CASSAVA WOOD\nCas\"sa*va wood`. (Bot.)\n\nDefn: A West Indian tree (Turpinia occidentalis) of the family\nStaphyleaceæ."
     ],
-    "references": [
-      "CASSAVA WOOD"
-    ]
+    "references": []
   },
   {
     "spellings": "CASSEL BROWN; CASSEL EARTH",
     "variants": [
       "CASSEL BROWN; CASSEL EARTH\nCas\"sel brown, Cas\"sel earth .\n\nDefn: A brown pigment of varying permanence, consisting of impure\nlignite. It was found originally near Cassel (now Kassel), Germany."
     ],
-    "references": [
-      "CASSEL BROWN; CASSEL EARTH"
-    ]
+    "references": []
   },
   {
     "spellings": "CASSE PAPER",
     "variants": [
       "CASSE PAPER\nCas\"se Pa\"per. Etym: [F. papier cassé. See Cass.]\n\nDefn: Broken paper; the outside quires of a ream."
     ],
-    "references": [
-      "CASSE PAPER"
-    ]
+    "references": []
   },
   {
     "spellings": "CASSEROLE",
@@ -26285,9 +26179,7 @@
     "variants": [
       "CASSINIAN OVALS\nCas*sin\"i*an o\"vals. (Math.)\n\nDefn: See under Oval."
     ],
-    "references": [
-      "CASSINIAN OVALS"
-    ]
+    "references": []
   },
   {
     "spellings": "CASSINO",
@@ -26948,7 +26840,6 @@
       "CASTILE SOAP\nCas\"tile soap\". Etym: [From Castile, or Castilia, a province in\nSpain, from which it originally came.]\n\nDefn: A kind of fine, hard, white or mottled soap, made with olive\nand soda; also, a soap made in imitation of the above-described soap."
     ],
     "references": [
-      "CASTILE SOAP",
       "SOAP",
       "VENETIAN"
     ]
@@ -27071,7 +26962,6 @@
       "BESSEMER STEEL",
       "BLOOMERY",
       "BLOOMING",
-      "CAST IRON",
       "CAST-IRON",
       "CHILL",
       "FINERY",
@@ -27329,7 +27219,6 @@
     "references": [
       "BETWEEN",
       "CASTOR; CASTORITE",
-      "CASTOR AND POLLUX",
       "GEMINI",
       "SAINT"
     ]
@@ -27340,7 +27229,6 @@
       "CASTOR BEAN\nCas\"tor bean\". (Bot.)\n\nDefn: The bean or seed of the castor-oil plant (Ricinus communis, or\nPalma Christi.)"
     ],
     "references": [
-      "CASTOR BEAN",
       "OILSEED",
       "SECUNDINE"
     ]
@@ -27368,7 +27256,6 @@
       "CASTOR OIL\nCas\"tor oil.\n\nDefn: A mild cathartic oil, expressed or extracted from the seeds of\nthe Ricinus communis, or Palma Christi. When fresh the oil is\ninodorus and insipid. Castor-oil plant. Same as Palma Christi."
     ],
     "references": [
-      "CASTOR OIL",
       "ELAIODIC",
       "MACASSAR OIL",
       "OENANTHOL",
@@ -27463,7 +27350,6 @@
       "CAST STEEL\nCast\" steel\".\n\nDefn: See Cast steel, under Steel."
     ],
     "references": [
-      "CAST STEEL",
       "CRUCIBLE STEEL",
       "MANGANESE STEEL",
       "NICKEL STEEL",
@@ -28795,7 +28681,6 @@
       "CATCH CROP\nCatch crop.\n\nDefn: Any crop grown between the rows of another crop or intermediate\nbetween two crops in ordinary rotation in point of time. -- Catch\"-\ncrop`ping, n.\n\nRadishes . . . are often grown as a catch crop with other vegetables.\nL. H. Bailey."
     ],
     "references": [
-      "CATCH CROP",
       "COVER CROP",
       "INTERCROP"
     ]
@@ -28975,9 +28860,7 @@
     "variants": [
       "CATCH TITLE\nCatch title.\n\nDefn: A short expressive title used for abbreviated book lists, etc."
     ],
-    "references": [
-      "CATCH TITLE"
-    ]
+    "references": []
   },
   {
     "spellings": "CATCHUP; CATSUP",
@@ -29563,7 +29446,6 @@
       "CATHARINE WHEEL\nCath\"a*rine wheel`.\n\nDefn: See catherine wheel."
     ],
     "references": [
-      "CATHARINE WHEEL",
       "CATHERINE WHEEL"
     ]
   },
@@ -29788,7 +29670,6 @@
     ],
     "references": [
       "CATHARINE WHEEL",
-      "CATHERINE WHEEL",
       "ROSE"
     ]
   },
@@ -30186,8 +30067,7 @@
       "CAT O' NINE TAILS\nCat\" o' nine\" tails`.\n\nDefn: See under Cat."
     ],
     "references": [
-      "CAT",
-      "CAT O' NINE TAILS"
+      "CAT"
     ]
   },
   {
@@ -30288,9 +30168,7 @@
     "variants": [
       "CATSKILL PERIOD\nCats\"kill pe`ri*od. (Geol.)\n\nDefn: The closing subdivision of the Devonian age in America. The\nrocks of this period are well developed in the Catskill mountains,\nand extend south and west under the Carboniferous formation. See the\nDiagram under Geology."
     ],
-    "references": [
-      "CATSKILL PERIOD"
-    ]
+    "references": []
   },
   {
     "spellings": "CATSO",
@@ -30717,9 +30595,7 @@
     "variants": [
       "CAUDA GALLI\nCau\"da gal*li, (. Etym: [L., tail of a cock.] (Paleon.)\n\nDefn: A plume-shaped fossil, supposed to be a seaweed, characteristic\nof the lower Devonian rocks; as, the cauda galli grit. Gauda galli\nepoch (Geol.), an epoch at the begining of the Devonian age in\neastern America, so named from the characteristic gritty sandstone\nmarked with impressions of cauda galli. See the Diagram under\nGeology."
     ],
-    "references": [
-      "CAUDA GALLI"
-    ]
+    "references": []
   },
   {
     "spellings": "CAUDAL",
@@ -32910,9 +32786,7 @@
     "variants": [
       "CAUTIONARY BLOCK\nCau\"tion*a*ry block. (Railroads)\n\nDefn: A block in which two or more trains are permitted to travel,\nunder restrictions imposed by a caution card or the like."
     ],
-    "references": [
-      "CAUTIONARY BLOCK"
-    ]
+    "references": []
   },
   {
     "spellings": "CAUTIONER",
@@ -33901,9 +33775,7 @@
     "variants": [
       "CC IRA\nÇa\" i*ra\". [F. ça ira, ça ira, les aristocrates à la lanterne, it\nshall go on, it shall go on, [hang]the arictocrats to the lantern\n(lamp-post).]\n\nDefn: The refrain of a famous song of the French Revolution."
     ],
-    "references": [
-      "CC IRA"
-    ]
+    "references": []
   },
   {
     "spellings": "CEASE",
@@ -35656,9 +35528,7 @@
     "variants": [
       "CEMENT STEEL\nCe*ment\" steel.\n\nDefn: Steel produced by cementation; blister steel."
     ],
-    "references": [
-      "CEMENT STEEL"
-    ]
+    "references": []
   },
   {
     "spellings": "CEMETERIAL",
@@ -36242,9 +36112,7 @@
     "variants": [
       "CENTENNIAL STATE\nCentennial State.\n\nDefn: Colorado; -- a nickname alluding to the fact that it was\nadmitted to the Union in the centennial year, 1876."
     ],
-    "references": [
-      "CENTENNIAL STATE"
-    ]
+    "references": []
   },
   {
     "spellings": "CENTER",
@@ -36636,9 +36504,7 @@
     "variants": [
       "CENTERFIRE CARTRIDGE\nCen\"ter*fire` car\"tridge.\n\nDefn: See under Cartridge."
     ],
-    "references": [
-      "CENTERFIRE CARTRIDGE"
-    ]
+    "references": []
   },
   {
     "spellings": "CENTERING",
@@ -37232,9 +37098,7 @@
     "variants": [
       "CENTRIFUGAL FILTER\nCen*trif\"u*gal fil\"ter.\n\nDefn: A filter, as for sugar, in which a cylinder with a porous or\nforaminous periphery is rapidly rotated so as to drive off liquid by\ncentrifugal action."
     ],
-    "references": [
-      "CENTRIFUGAL FILTER"
-    ]
+    "references": []
   },
   {
     "spellings": "CENTRIFUGENCE",
@@ -42983,9 +42847,7 @@
     "variants": [
       "CHAGRES FEVER\nCha\"gres fe\"ver. (Med.)\n\nDefn: A form of malarial fever occurring along the Chagres River,\nPanama."
     ],
-    "references": [
-      "CHAGRES FEVER"
-    ]
+    "references": []
   },
   {
     "spellings": "CHAGRIN",
@@ -43239,7 +43101,6 @@
     ],
     "references": [
       "CHAIN",
-      "CHAIN PUMP",
       "CHAIN WHEEL",
       "CHAPELET",
       "PALLET",
@@ -43254,7 +43115,6 @@
     ],
     "references": [
       "CHAIN",
-      "CHAIN STITCH",
       "CHAINWORK",
       "STITCH"
     ]
@@ -43264,9 +43124,7 @@
     "variants": [
       "CHAIN TIE\nChain tie. (Arch.)\n\nDefn: A tie consisting of a series of connected iron bars or rods."
     ],
-    "references": [
-      "CHAIN TIE"
-    ]
+    "references": []
   },
   {
     "spellings": "CHAIN WHEEL",
@@ -43275,7 +43133,6 @@
     ],
     "references": [
       "CHAIN",
-      "CHAIN WHEEL",
       "GEARING",
       "RAG",
       "SPROCKET WHEEL"
@@ -43551,9 +43408,7 @@
     "variants": [
       "CHALCID FLY\nChal\"cid fly`. Etym: [From Gr. (Zoöl.)\n\nDefn: One of a numerous family of hymenopterous insects (Chalcididæ.\nMany are gallflies, others are parasitic on insects."
     ],
-    "references": [
-      "CHALCID FLY"
-    ]
+    "references": []
   },
   {
     "spellings": "CHALCIDIAN",
@@ -44510,9 +44365,7 @@
     "variants": [
       "CHAMPLAIN PERIOD\nCham*plain\" pe\"ri*od. (Geol.)\n\nDefn: A subdivision of the Quaternary age immediately following the\nGlacial period; -- so named from beds near Lake Champlain.\n\nNote: The earlier deposits of this period are diluvial in character,\nas if formed in connection with floods attending the melting of the\nglaciers, while the later deposits are of finer material in more\nquiet waters, as the alluvium."
     ],
-    "references": [
-      "CHAMPLAIN PERIOD"
-    ]
+    "references": []
   },
   {
     "spellings": "CHAMPLEVE",
@@ -45572,7 +45425,6 @@
       "CHANGE GEAR\nChange gear. (Mach.)\n\nDefn: A gear by means of which the speed of machinery or of a vehicle\nmay be changed while that of the propelling engine or motor remains\nconstant; -- called also change-speed gear."
     ],
     "references": [
-      "CHANGE GEAR",
       "LAY SHAFT; LAYSHAFT"
     ]
   },
@@ -45581,9 +45433,7 @@
     "variants": [
       "CHANGE KEY\nChange key.\n\nDefn: A key adapted to open only one of a set of locks; --\ndistinguished from a master key."
     ],
-    "references": [
-      "CHANGE KEY"
-    ]
+    "references": []
   },
   {
     "spellings": "CHANGELESS",
@@ -45807,9 +45657,7 @@
     "variants": [
       "CHANSON DE GESTE\nChan`son\" de geste\". [F., prop., song of history.]\n\nDefn: Any Old French epic poem having for its subject events or\nexploits of early French history, real or legendary, and written\noriginally in assonant verse of ten or twelve syllables. The most\nfamous one is the Chanson de Roland.\n\nLangtoft had written in the ordinary measure of the later chansons de\ngeste.\nSaintsbury."
     ],
-    "references": [
-      "CHANSON DE GESTE"
-    ]
+    "references": []
   },
   {
     "spellings": "CHANSONNETTE",
@@ -48842,9 +48690,7 @@
     "variants": [
       "CHARGE D'AFFAIRES\nChar`gé\" d'af`faires\", n.; pl. Chargés d'affaires. Etym: [F.,\n\"charged with affairs.\"]\n\nDefn: A diplomatic representative, or minister of an inferior grade,\naccredited by the government of one state to the minister of foreign\naffairs of another; also, a substitute, ad interim, for an ambassador\nor minister plenipotentiary."
     ],
-    "references": [
-      "CHARGE D'AFFAIRES"
-    ]
+    "references": []
   },
   {
     "spellings": "CHARGEFUL",
@@ -49220,7 +49066,6 @@
     ],
     "references": [
       "CAR",
-      "CHARLES'S WAIN",
       "CHURL",
       "DIPPER",
       "PLOW; PLOUGH",
@@ -50490,9 +50335,7 @@
     "variants": [
       "CHATTER MARK\nChat\"ter mark`.\n (a) (Mach.) One of the fine undulations or ripples which are formed\non the surface of work by a cutting tool which chatters.\n (b) (Geol.) A short crack on a rock surface planed smooth by a\nglacier."
     ],
-    "references": [
-      "CHATTER MARK"
-    ]
+    "references": []
   },
   {
     "spellings": "CHATTINESS",
@@ -50638,9 +50481,7 @@
     "variants": [
       "CHAUTAUQUA SYSTEM OF EDUCATION\nChau*tau\"qua sys\"tem of education.\n\nDefn: The system of home study established in connection with the\nsummer schools assembled at Chautauqua, N. Y., by the Methodist\nEpiscopal bishop, J. H. Vincent."
     ],
-    "references": [
-      "CHAUTAUQUA SYSTEM OF EDUCATION"
-    ]
+    "references": []
   },
   {
     "spellings": "CHAUVINISM",
@@ -50686,7 +50527,6 @@
       "CHAY ROOT\nChay\" root`. Etym: [Tamil shaya.]\n\nDefn: The root of the Oldenlandia umbellata, native in India, which\nyieds a durable red dyestuff. [Written also choy root.]"
     ],
     "references": [
-      "CHAY ROOT",
       "CHOY ROOT"
     ]
   },
@@ -50696,8 +50536,7 @@
       "CHAZY EPOCH\nCha*zy\" ep\"och. (Geol.)\n\nDefn: An epoch at the close of the Canadian period of the American\nLower Silurian system; -- so named from a township in Clinton Co.,\nNew York. See the Diagram under Geology."
     ],
     "references": [
-      "CANADIAN",
-      "CHAZY EPOCH"
+      "CANADIAN"
     ]
   },
   {
@@ -51818,9 +51657,7 @@
     "variants": [
       "CHEESE CLOTH\nCheese\" cloth`.\n\nDefn: A thin, loosewoven cotton cloth, such as is used in pressing\ncheese curds."
     ],
-    "references": [
-      "CHEESE CLOTH"
-    ]
+    "references": []
   },
   {
     "spellings": "CHEESELEP",
@@ -52712,7 +52549,6 @@
       "CHEMUNG PERIOD\nChe*mung\" pe\"ri*od, (Geol.)\n\nDefn: A subdivision in the upper part of the Devonian system in\nAmerica, so named from the Chemung River, along which the rocks are\nwell developed. It includes the Portage and Chemung groups or epochs.\nSee the Diagram under Geology."
     ],
     "references": [
-      "CHEMUNG PERIOD",
       "PORTAGE GROUP"
     ]
   },
@@ -53198,9 +53034,7 @@
     "variants": [
       "CHESSY COPPER\nChes`sy\" cop\"per. (Min.)\n\nDefn: The mineral azurite, found in fine crystallization at Chessy,\nnear Lyons; called also chessylite."
     ],
-    "references": [
-      "CHESSY COPPER"
-    ]
+    "references": []
   },
   {
     "spellings": "CHEST",
@@ -53366,9 +53200,7 @@
     "variants": [
       "CHEST FOUNDER\nChest\" foun`der. (Far.)\n\nDefn: A rheumatic affection of the muscles of the breast and fore\nlegs of a horse, affecting motion and respiration."
     ],
-    "references": [
-      "CHEST FOUNDER"
-    ]
+    "references": []
   },
   {
     "spellings": "CHESTNUT",
@@ -53901,7 +53733,6 @@
       "CHICHLING; CHICHLING VETCH\nChich\"ling, Chich\"ling vetch`, n. Etym: [Chich + -ling.] (Bot.)\n\nDefn: A leguminous plant (Lathyrus sativus), with broad flattened\nseeds which are sometimes used for food."
     ],
     "references": [
-      "CHICHLING; CHICHLING VETCH",
       "VETCH"
     ]
   },
@@ -54055,7 +53886,6 @@
       "CHICKEN POX\nChick\"en pox\". (Med.)\n\nDefn: A mild, eruptive disease, generally attacking children only;\nvaricella."
     ],
     "references": [
-      "CHICKEN POX",
       "HORN",
       "POX",
       "SWINE-POX",
@@ -54112,8 +53942,7 @@
       "CHICLE; CHICLE GUM\nChic\"le, n., Chicle gum. [Amer. Sp. chicle.]\n\nDefn: A gumlike substance obtained from the bully tree (Mimusops\nglobosa) and sometimes also from the naseberry or sapodilla (Sapota\nzapotilla). It is more plastic than caoutchouc and more elastic than\ngutta-percha, as an adulterant of which it is used in England. It is\nused largely in the United States in making chewing gum."
     ],
     "references": [
-      "BALATA",
-      "CHICLE; CHICLE GUM"
+      "BALATA"
     ]
   },
   {
@@ -54707,9 +54536,7 @@
     "variants": [
       "CHIEF BARON\nChief\" bar\"on. (Eng. Law)\n\nDefn: The presiding judge of the court of exchequer."
     ],
-    "references": [
-      "CHIEF BARON"
-    ]
+    "references": []
   },
   {
     "spellings": "CHIEFEST",
@@ -54733,7 +54560,6 @@
       "CHIEF HARE\nChief\" hare`. (Zoöl.)\n\nDefn: A small rodent (Lagamys princeps) inhabiting the summits of the\nRocky Mountains; -- also called crying hare, calling hare, cony,\nAmerican pika, and little chief hare.\n\nNote: It is not a true hare or rabbit, but belongs to the curious\nfamily Lagomyidæ."
     ],
     "references": [
-      "CHIEF HARE",
       "CONY",
       "HARE",
       "LITTLE",
@@ -54746,7 +54572,6 @@
       "CHIEF JUSTICE\nChief\" jus\"tice.\n\nDefn: The presiding justice, or principal judge, of a court. Lord\nChief Justice of England, The presiding judge of the Queen's Bench\nDivision of the High Court of Justice. The highest judicial officer\nof the realm is the Lord High Chancellor.\n -- Chief Justice of the United States, the presiding judge of the\nSupreme Court, and Highest judicial officer of the republic."
     ],
     "references": [
-      "CHIEF JUSTICE",
       "CHIEF-JUSTICESHIP",
       "COMMON",
       "JUSTICE",
@@ -55510,27 +55335,21 @@
     "variants": [
       "CHIH FU\nChih\" fu`. [Chin. chih fu, lit., (He who) knows (the) prefecture.]\n\nDefn: An official administering a prefecture of China; a prefect,\nsupervising the civil business of the hsiens or districts comprised\nin his fu (which see)."
     ],
-    "references": [
-      "CHIH FU"
-    ]
+    "references": []
   },
   {
     "spellings": "CHIH HSIEN",
     "variants": [
       "CHIH HSIEN\nChih\" hsien`. [Chin. chih hsien, lit., (He who) knows (the)\ndistrict.]\n\nDefn: An official having charge of a hsien, or administrative\ndistrict, in China; a district magistrate, responsible for good order\nin his hsien (which see), and having jurisdiction in its civil and\ncriminal cases."
     ],
-    "references": [
-      "CHIH HSIEN"
-    ]
+    "references": []
   },
   {
     "spellings": "CHIH TAI",
     "variants": [
       "CHIH TAI\nChih\" tai`. [Chin. chih to govern + t\"ai an honorary title.]\n\nDefn: A Chinese governor general; a tsung tu (which see)."
     ],
-    "references": [
-      "CHIH TAI"
-    ]
+    "references": []
   },
   {
     "spellings": "CHIKARA",
@@ -56056,7 +55875,6 @@
       "CHILDERMAS DAY\nChil\"dermas day`. Etym: [AS. cildamæsse-dæg; cild child +dæg day.]\n(Eccl.)\n\nDefn: A day (December 28) observed by mass or festival in\ncommemoration of the children slain by Herod at Bethlehem; -- called\nalso Holy Innocent's Day."
     ],
     "references": [
-      "CHILDERMAS DAY",
       "HOLY",
       "INNOCENT"
     ]
@@ -56559,9 +56377,7 @@
     "variants": [
       "CHILD STUDY\nChild study.\n\nDefn: A scientific study of children, undertaken for the purpose of\ndiscovering the laws of development of the body and the mind from\nbirth to manhood."
     ],
-    "references": [
-      "CHILD STUDY"
-    ]
+    "references": []
   },
   {
     "spellings": "CHILEAN",
@@ -56578,9 +56394,7 @@
     "variants": [
       "CHILEAN PINE\nChilean pine. (Bot.)\n\nDefn: Same as Monkey-puzzle."
     ],
-    "references": [
-      "CHILEAN PINE"
-    ]
+    "references": []
   },
   {
     "spellings": "CHILI",
@@ -56880,9 +56694,7 @@
     "variants": [
       "CHILTERN HUNDREDS\nChiltern Hundreds. Etym: [AS. Chiltern the Chiltern, high hills in\nBuckinghamshire, perh. Fr. ceald cold + ern, ærn, place.]\n\nDefn: A tract of crown land in Buckinghamshire and Oxfordshire,\nEngland, to which is attached the nominal office of steward. As\nmembers of Parliament cannot resign, when they wish to go out they\naccept this stewardship, which legally vacates their seats."
     ],
-    "references": [
-      "CHILTERN HUNDREDS"
-    ]
+    "references": []
   },
   {
     "spellings": "CHIMAERA",
@@ -57409,7 +57221,6 @@
       "CHIN COUGH\nChin\" cough\". Etym: [For chink cough; cf. As. cincung long laughter,\nScot. kink a violent fit of coughing, akin to MHG. kichen to pant.\nCf. Kinknaust, Cough.]\n\nDefn: Whooping cough."
     ],
     "references": [
-      "CHIN COUGH",
       "KINKHAUST",
       "WHOOPING"
     ]
@@ -57569,9 +57380,7 @@
     "variants": [
       "CHINESE EXCLUSION ACT\nChinese Exclusion Act.\n\nDefn: Any of several acts forbidding the immigration of Chinese\nlaborers into the United States, originally from 1882 to 1892 by act\nof May 6, 1882, then from 1892 to 1902 by act May 5, 1892. By act of\nApril 29, 1902, all existing legislation on the subject was reënacted\nand continued, and made applicable to the insular possessions of the\nUnited States."
     ],
-    "references": [
-      "CHINESE EXCLUSION ACT"
-    ]
+    "references": []
   },
   {
     "spellings": "CHINK",
@@ -57672,9 +57481,7 @@
     "variants": [
       "CHINOOK STATE\nChi*nook\" State.\n\nDefn: Washington -- a nickname. See Chinook, n."
     ],
-    "references": [
-      "CHINOOK STATE"
-    ]
+    "references": []
   },
   {
     "spellings": "CHINQUAPIN",
@@ -57812,7 +57619,6 @@
       "CHIPPING BIRD\nChip\"ping bird`. (Zoöl.)\n\nDefn: The chippy."
     ],
     "references": [
-      "CHIPPING BIRD",
       "CHIPPY"
     ]
   },
@@ -57822,8 +57628,7 @@
       "CHIPPING SQUIRREL\nChip\"ping squir\"rel.\n\nDefn: See Chipmunk."
     ],
     "references": [
-      "CHIPMUNK",
-      "CHIPPING SQUIRREL"
+      "CHIPMUNK"
     ]
   },
   {
@@ -59515,7 +59320,6 @@
     "references": [
       "AFTER DAMP",
       "CARBONIC",
-      "CHOKE DAMP",
       "DAMP",
       "STYTHE"
     ]
@@ -59541,9 +59345,7 @@
     "variants": [
       "CHOKE PEAR\nChoke\" pear`.\n\n1. A kind of pear that has a rough, astringent taste, and is\nswallowed with difficulty, or which contracts the mucous membrane of\nthe mouth.\n\n2. A sarcasm by which one is put to silence; anything that can not be\nanswered. [Low] S. Richardson."
     ],
-    "references": [
-      "CHOKE PEAR"
-    ]
+    "references": []
   },
   {
     "spellings": "CHOKER",
@@ -59583,7 +59385,6 @@
       "CHOKING COIL\nChoking coil. (Elec.)\n\nDefn: A coil of small resistance and large inductance, used in an\nalternating-current circuit to impede or throttle the current, or to\nchange its phase; --called also reactance coil or reactor, these\nterms being now preferred in engineering usage."
     ],
     "references": [
-      "CHOKING COIL",
       "INDUCTANCE COIL",
       "REACTANCE COIL",
       "REACTOR"
@@ -60291,9 +60092,7 @@
     "variants": [
       "CHOP SUEY; CHOP SOOY\nChop su\"ey or Chop soo\"y . [Chin. (Cantonese) shap sui odds and ends,\nfr. shap for sap to enter the mouth + sui small bits pounded fine.]\n\nDefn: A mélange served in Chinese restaurants to be eaten with rice,\nnoodles, etc. It consists typically of bean sprouts, onions,\nmushrooms, etc., and sliced meats, fried and flavored with sesame\noil. [U. S.]"
     ],
-    "references": [
-      "CHOP SUEY; CHOP SOOY"
-    ]
+    "references": []
   },
   {
     "spellings": "CHORAGIC",
@@ -61007,8 +60806,7 @@
       "CHOY ROOT\nChoy\" root`.\n\nDefn: See Chay root."
     ],
     "references": [
-      "CHAY ROOT",
-      "CHOY ROOT"
+      "CHAY ROOT"
     ]
   },
   {
@@ -61663,7 +61461,6 @@
     "references": [
       "ANNO DOMINI",
       "CHRISTIAN",
-      "CHRISTIAN ERA",
       "EPOCH",
       "ERA",
       "GOTH",
@@ -61811,7 +61608,6 @@
       "CHRISTIAN SCIENCE\nChristian Science.\n\nDefn: A system of healing disease of mind and body which teaches that\nall cause and effect is mental, and that sin, sickness, and death\nwill be destroyed by a full understanding of the Divine Principle of\nJesus' teaching and healing. The system was founded by Rev. Mary\nBaker Glover Eddy, of Concord, N. H., in 1866, and bases its teaching\non the Scriptures as understood by its adherents."
     ],
     "references": [
-      "CHRISTIAN SCIENCE",
       "CHRISTIAN SCIENTIST",
       "IRENICS"
     ]
@@ -61821,27 +61617,21 @@
     "variants": [
       "CHRISTIAN SCIENTIST\nChristian Scientist.\n\nDefn: A believer in Christian Science; one who practices its\nteachings."
     ],
-    "references": [
-      "CHRISTIAN SCIENTIST"
-    ]
+    "references": []
   },
   {
     "spellings": "CHRISTIAN SENECA",
     "variants": [
       "CHRISTIAN SENECA\nChristian Seneca.\n\nDefn: Joseph Hall (1574 -- 1656), Bishop of Norwich, a divine eminent\nas a moralist."
     ],
-    "references": [
-      "CHRISTIAN SENECA"
-    ]
+    "references": []
   },
   {
     "spellings": "CHRISTIAN SOCIALISM",
     "variants": [
       "CHRISTIAN SOCIALISM\nChristian Socialism.\n\nDefn: Any theory or system that aims to combine the teachings of\nChrist with the teachings of socialism in their applications to life;\nChristianized socialism; esp., the principles of this nature\nadvocated by F. D. Maurice, Charles Kingsley, and others in England\nabout 1850. -- Christian socialist."
     ],
-    "references": [
-      "CHRISTIAN SOCIALISM"
-    ]
+    "references": []
   },
   {
     "spellings": "CHRISTLESS",
@@ -62117,9 +61907,7 @@
     "variants": [
       "CHROME STEEL\nChrome steel.\n\nDefn: Same as Chromium steel, under Steel."
     ],
-    "references": [
-      "CHROME STEEL"
-    ]
+    "references": []
   },
   {
     "spellings": "CHROMIC",
@@ -64063,7 +63851,6 @@
       "CHURCH MODES\nChurch\" modes`. (Mus.)\n\nDefn: The modes or scales used in ancient church music. See\nGregorian."
     ],
     "references": [
-      "CHURCH MODES",
       "DORIAN",
       "ECCLESIASTICAL",
       "GREGORIAN",
@@ -65263,7 +65050,6 @@
       "CINCINNATI EPOCH\nCin`cin*na\"ti ep\"och. (Geol.)\n\nDefn: An epoch at the close of the American lower Silurian system.\nThe rocks are well developed near Cincinnati, Ohio. The group\nincludes the Hudson River and Lorraine shales of New york."
     ],
     "references": [
-      "CINCINNATI EPOCH",
       "TRENTON PERIOD"
     ]
   },
@@ -65650,8 +65436,7 @@
       "CINQUE PORTS\nCinque\" Ports`. Etym: [Cinque + port.] (Eng. Hist.)\n\nDefn: Five English ports, to which peculiar privileges were anciently\naccorded; -- viz., Hastings, Romney, Hythe, Dover, and Sandwich;\nafterwards increased by the addition of Winchelsea, Rye, and some\nminor places. Baron of the Cinque Ports. See under Baron."
     ],
     "references": [
-      "BARON",
-      "CINQUE PORTS"
+      "BARON"
     ]
   },
   {
@@ -67793,9 +67578,7 @@
     "variants": [
       "CIRL BUNTING\nCirl\" bun`ting. Etym: [Cf. It. cirlo.] (Zoöl.)\n\nDefn: A European bunting (Emberiza cirlus)."
     ],
-    "references": [
-      "CIRL BUNTING"
-    ]
+    "references": []
   },
   {
     "spellings": "CIRQUE",
@@ -69605,9 +69388,7 @@
     "variants": [
       "CIVIL SERVICE COMMISSION\nCivil Service Commission.\n\nDefn: In the United States, a commission appointed by the President,\nconsisting of three members, not more than two of whom may be\nadherents of the same party, which has the control, through\nexaminations, of appointments and promotions in the classified civil\nservice. It was created by act of Jan, 16, 1883 (22 Stat. 403)."
     ],
-    "references": [
-      "CIVIL SERVICE COMMISSION"
-    ]
+    "references": []
   },
   {
     "spellings": "CIVIL SERVICE REFORM",
@@ -69615,8 +69396,7 @@
       "CIVIL SERVICE REFORM\nCivil Service Reform.\n\nDefn: The substitution of business principles and methods for\npolitical methods in the conduct of the civil service. esp. the merit\nsystem instead of the spoils system in making appointments to office."
     ],
     "references": [
-      "CIVIL",
-      "CIVIL SERVICE REFORM"
+      "CIVIL"
     ]
   },
   {
@@ -71187,9 +70967,7 @@
     "variants": [
       "CLASH GEAR\nClash gear. (Mach.)\n\nDefn: A change-speed gear in which the gears are changed by sliding\nendwise."
     ],
-    "references": [
-      "CLASH GEAR"
-    ]
+    "references": []
   },
   {
     "spellings": "CLASHINGLY",
@@ -71755,9 +71533,7 @@
     "variants": [
       "CLASS DAY\nClass day.\n\nDefn: In American colleges and universities, a day of the\ncommencement season on which the senior class celebrates the\ncompletion of its course by exercises conducted by the members, such\nas the reading of the class histories and poem, the delivery of the\nclass oration, the planting of the class ivy, etc."
     ],
-    "references": [
-      "CLASS DAY"
-    ]
+    "references": []
   },
   {
     "spellings": "CLASSIBLE",
@@ -72103,9 +71879,7 @@
     "variants": [
       "CLAUDE LORRAINE GLASS\nClaude\" Lor*raine\" glass`. Etym: [Its name is supposed to be derived\nfrom the similarity of the effects it gives to those of a picture by\nClaude Lorrain (often written Lorraine).]\n\nDefn: A slightly convex mirror, commonly of black glass, used as a\ntoy for viewing the reflected landscape."
     ],
-    "references": [
-      "CLAUDE LORRAINE GLASS"
-    ]
+    "references": []
   },
   {
     "spellings": "CLAUDENT",
@@ -74351,9 +74125,7 @@
     "variants": [
       "CLEOPATRA'S NEEDLE\nCle`o*pa\"tra's nee\"dle. [So named after Cleopatra, queen of Egypt.]\n\nDefn: Either of two obelisks which were moved in ancient times from\nHeliopolis to Alexandria, one of which is now on the Thames\nEmbankment in London, and the other in Central Park, in the City of\nNew York.\n\n Some writers consider that only the obelisk now in Central Park is\nproperly called Cleopatra's needle."
     ],
-    "references": [
-      "CLEOPATRA'S NEEDLE"
-    ]
+    "references": []
   },
   {
     "spellings": "CLEPE",
@@ -74940,9 +74712,7 @@
     "variants": [
       "CLICK BEETLE\nClick\" bee\"tle. (Zoöl.)\n\nDefn: See Elater."
     ],
-    "references": [
-      "CLICK BEETLE"
-    ]
+    "references": []
   },
   {
     "spellings": "CLICKER",
@@ -75095,9 +74865,7 @@
     "variants": [
       "CLIFF LIMESTONE\nCliff\" lime\"stone`. (Geol.)\n\nDefn: A series of limestone strata found in Ohio and farther west,\npresenting bluffs along the rivers and valleys, formerly supposed to\nbe of one formation, but now known to be partly Silurian and partly\nDevonian."
     ],
-    "references": [
-      "CLIFF LIMESTONE"
-    ]
+    "references": []
   },
   {
     "spellings": "CLIFFY",
@@ -80109,9 +79877,7 @@
     "variants": [
       "CLYDESDALE TERRIER\nClydesdale terrier.\n\nDefn: One of a breed of small silky-haired terriers related to, but\nsmaller than, the Skye terrier, having smaller and perfectly erect\nears."
     ],
-    "references": [
-      "CLYDESDALE TERRIER"
-    ]
+    "references": []
   },
   {
     "spellings": "CLYPEASTROID",
@@ -80181,9 +79947,7 @@
     "variants": [
       "CLYTIE KNOT\nCly\"tie knot.\n\nDefn: In hair dressing, a loose, low coil at the back of the head,\nlike the knot on the head of the bust of Clytie by G. F. Watts."
     ],
-    "references": [
-      "CLYTIE KNOT"
-    ]
+    "references": []
   },
   {
     "spellings": "CNEMIAL",
@@ -80438,7 +80202,6 @@
       "COACHWHIP SNAKE\nCoach\"whip` snake\". (Zoöl.)\n\nDefn: A large, slender, harmless snake of the southern United States\n(Masticophis flagelliformis).\n\nNote: Its long and tapering tail has the scales so arranged and\ncolored as to give it a braided appearance, whence the name."
     ],
     "references": [
-      "COACHWHIP SNAKE",
       "WHIP"
     ]
   },
@@ -81352,7 +81115,6 @@
       "CARBOLIC",
       "CHRYSENE",
       "COAL",
-      "COAL TAR",
       "COLLIDINE",
       "CORIDINE",
       "CREOSOTE",
@@ -81395,9 +81157,7 @@
     "variants": [
       "COAL WORKS\nCoal\" works.\n\nDefn: A place where coal is dug, including the machinery for raising\nthe coal."
     ],
-    "references": [
-      "COAL WORKS"
-    ]
+    "references": []
   },
   {
     "spellings": "COALY",
@@ -82193,9 +81953,7 @@
     "variants": [
       "COAST AND GEODETIC SURVEY\nCoast and Geodetic Survey.\n\nDefn: A bureau of the United States government charged with the\ntopographic and hydrographic survey of the coast and the execution of\nbelts of primary triangulation and lines of precise leveling in the\ninterior. It now belongs to the Department of Commerce and Labor."
     ],
-    "references": [
-      "COAST AND GEODETIC SURVEY"
-    ]
+    "references": []
   },
   {
     "spellings": "COASTER",
@@ -82940,7 +82698,6 @@
     ],
     "references": [
       "COBRA",
-      "COBRA DE CAPELLO",
       "HOODED",
       "SPECTACLED"
     ]
@@ -83120,7 +82877,6 @@
     ],
     "references": [
       "BITTERN",
-      "COCCULUS INDICUS",
       "INDIAN",
       "MENISPERMINE",
       "MULTUM"
@@ -83201,7 +82957,6 @@
       "COCHINEAL FIG\nCoch\"i*neal fig, (Bot.)\n\nDefn: A plant of Central and Southern Anerica, of the Cactus familly,\nextensively cultivated for the sake of the cochineal insect, which\nlives on it."
     ],
     "references": [
-      "COCHINEAL FIG",
       "FIG"
     ]
   },
@@ -83210,9 +82965,7 @@
     "variants": [
       "COCHIN FOWL\nCo\"chin fowl`, (Zoöl.)\n\nDefn: A large variety of the domestic fowl, originally from Cochin\nChina (Anam)."
     ],
-    "references": [
-      "COCHIN FOWL"
-    ]
+    "references": []
   },
   {
     "spellings": "COCHLEA",
@@ -83601,7 +83354,6 @@
       "COCKER SPANIEL\nCock\"er span\"iel.\n\nDefn: One of a breed of small or medium-sized spaniels kept for\nhunting or retrieving game or for household pets. They usually weigh\nfrom eighteen to twenty-eight pounds. They have the head of fair\nlength, with square muzzle, the ears long and set low, the legs short\nor of medium length, and the coat fine and silky, wavy but not curly.\nVarious colors are bred, as black, liver, red, black and white, black\nand tan, etc."
     ],
     "references": [
-      "COCKER SPANIEL",
       "SPANIEL"
     ]
   },
@@ -83948,9 +83700,7 @@
     "variants": [
       "COCKYOLLY BIRD; COCKYOLY BIRD\nCock`y*ol\"ly bird or Cock`y*ol\"y bird. [Cf. Cock, fowl; Yellow.]\n\nDefn: A pet name for any small bird."
     ],
-    "references": [
-      "COCKYOLLY BIRD; COCKYOLY BIRD"
-    ]
+    "references": []
   },
   {
     "spellings": "COCO; COCO PALM",
@@ -83958,7 +83708,6 @@
       "COCO; COCO PALM\nCo\"co, n. or Co\"co palm.\n\nDefn: See Cocoa."
     ],
     "references": [
-      "COCO; COCO PALM",
       "COCOA; COCOA PALM",
       "COQUILLA NUT"
     ]
@@ -83969,7 +83718,6 @@
       "COCOA; COCOA PALM\nCo\"coa, n., Co\"coa palm` Etym: [Sp. & Pg. coco cocoanut, in Sp. also,\ncocoa palm. The Portuguese name is said to have been given from the\nmonkeylike face at the base of the nut, fr. Pg. coco a bugbear, an\nugly mask to frighten children. Cf., however, Gr. (Bot.)\n\nDefn: A palm tree producing the cocoanut (Cocos nucifera). It grows\nin nearly all tropical countries, attaining a height of sixty or\neighty feet. The trunk is without branches, and has a tuft of leaves\nat the top, each being fifteen or twenty feet in length, and at the\nbase of these the nuts hang in clusters; the cocoanut tree."
     ],
     "references": [
-      "COCOA; COCOA PALM",
       "COCOANUT",
       "PALM",
       "PORCUPINE"
@@ -84088,9 +83836,7 @@
     "variants": [
       "COCUS WOOD\nCo\"cus wood`.\n\nDefn: A West Indian wood, used for making flutes and other musical\ninstruments."
     ],
-    "references": [
-      "COCUS WOOD"
-    ]
+    "references": []
   },
   {
     "spellings": "COD",
@@ -84420,9 +84166,7 @@
     "variants": [
       "COD LIVER\nCod\" liv`er, n.\n\nDefn: The liver of the common cod and allied species. Cod-liver oil,\nan oil obtained fron the liver of the codfish, and used extensively\nin medicine as a means of supplying the body with fat in cases of\nmalnutrition."
     ],
-    "references": [
-      "COD LIVER"
-    ]
+    "references": []
   },
   {
     "spellings": "CODPIECE",
@@ -85944,9 +85688,7 @@
     "variants": [
       "COHUNE; COHUNE PALM\nCo*hune\", n., or Cohune palm . [Prob. fr. a native name in Honduras.]\n\nDefn: A Central and South American pinnate-leaved palm (Attalea\ncohune), the very large and hard nuts of which are turned to make\nfancy articles, and also yield an oil used as a substitute for\ncoconut oil."
     ],
-    "references": [
-      "COHUNE; COHUNE PALM"
-    ]
+    "references": []
   },
   {
     "spellings": "COIF",
@@ -87045,7 +86787,6 @@
     ],
     "references": [
       "COLA",
-      "COLA NUT; COLA SEED",
       "KOLA; KOLA NUT"
     ]
   },
@@ -87578,9 +87319,7 @@
     "variants": [
       "COLD WAVE\nCold\" wave\". (Meteor.)\n\nDefn: In the terminology of the United States Weather Bureau, an\nunusual fall in temperature, to or below the freezing point,\nexceeding 16º in twenty-four hours or 20º in thirty-six hours,\nindependent of the diurnal range."
     ],
-    "references": [
-      "COLD WAVE"
-    ]
+    "references": []
   },
   {
     "spellings": "COLE",
@@ -88073,7 +87812,6 @@
     "references": [
       "CHUCK",
       "CLAVICLE",
-      "COLLAR BONE",
       "JUGULAR",
       "SUBCLAVIAN"
     ]
@@ -90253,7 +89991,6 @@
       "COLOGNE EARTH\nCo*logne\" earth`. Etym: [From Cologne the city.] (Min.)\n\nDefn: An earth of a deep brown color, containing more vegetable than\nmineral matter; an earthy variety of lignite, or brown coal."
     ],
     "references": [
-      "COLOGNE EARTH",
       "UMBER"
     ]
   },
@@ -91997,7 +91734,6 @@
       "COLORADO BEETLE\nCol`o*ra\"do bee\"tle. (Zoöl.)\n\nDefn: A yellowish beetle (Doryphora decemlineata), with ten\nlongitudinal, black, dorsal stripes. It has migrated eastwards from\nits original habitat in Colorado, and is very destructive to the\npotato plant; -- called also potato beetle and potato bug. See Potato\nbeetle."
     ],
     "references": [
-      "COLORADO BEETLE",
       "POTATO"
     ]
   },
@@ -92006,9 +91742,7 @@
     "variants": [
       "COLORADO GROUP\nCol`o*ra\"do group. (Geol.)\n\nDefn: A subdivision of the cretaceous formation of western North\nAmerica, especially developed in Colorado and the upper Missouri\nregion."
     ],
-    "references": [
-      "COLORADO GROUP"
-    ]
+    "references": []
   },
   {
     "spellings": "COLORADOITE",
@@ -92730,7 +92464,6 @@
       "COLOR SERGEANT\nCol\"or ser\"geant.\n\nDefn: See under Sergeant."
     ],
     "references": [
-      "COLOR SERGEANT",
       "ENSIGN",
       "SERGEANT",
       "STANDARD"
@@ -92907,18 +92640,14 @@
     "variants": [
       "COLT PISTOL\nColt pistol. (Firearms)\n\nDefn: A self-loading or semi-automatic pistol with removable magazine\nin the handle holding seven cartridges. The recoil extracts and\nejects the empty cartridge case, and reloads ready for another shot.\nCalled also Browning, and Colt-Browning, pistol."
     ],
-    "references": [
-      "COLT PISTOL"
-    ]
+    "references": []
   },
   {
     "spellings": "COLT REVOLVER",
     "variants": [
       "COLT REVOLVER\nColt revolver. (Firearms)\n\nDefn: A revolver made according to a system using a patented\nrevolving cylinder, holding six cartridges, patented by Samuel Colt,\nan American inventor, in 1835. With various modifications, it has for\nmany years been the standard for the United States army."
     ],
-    "references": [
-      "COLT REVOLVER"
-    ]
+    "references": []
   },
   {
     "spellings": "COLTSFOOT",
@@ -92938,8 +92667,7 @@
       "COLT'S TOOTH\nColt's\" tooth`.\n\nDefn: See under Colt."
     ],
     "references": [
-      "COLT",
-      "COLT'S TOOTH"
+      "COLT"
     ]
   },
   {
@@ -93038,8 +92766,7 @@
       "COLUMBATZ FLY\nCo*lum\"batz fly`. Etym: [From Kolumbatz, a mountain in Germany.]\n(Zoöl.)\n\nDefn: See Buffalo fly, under Buffalo."
     ],
     "references": [
-      "BUFFALO",
-      "COLUMBATZ FLY"
+      "BUFFALO"
     ]
   },
   {
@@ -93177,7 +92904,6 @@
       "COLUMBUS DAY\nCo*lum\"bus Day.\n\nDefn: The 12th day of October, on which day in 1492 Christopher\nColumbus discovered America, landing on one of the Bahama Islands\n(probably the one now commonly called Watling Island), and naming it\n\"San Salvador\"; -- called also Discovery Day. This day is made a\nlegal holiday in many States of The United States."
     ],
     "references": [
-      "COLUMBUS DAY",
       "DISCOVERY DAY"
     ]
   },
@@ -94720,7 +94446,6 @@
       "COMBUSTION CHAMBER\nCom*bus\"tion cham`ber. (Mech.)\n (a) A space over, or in front of , a boiler furnace where the gases\nfrom the fire become more thoroughly mixed and burnt. (b) The\nclearance space in the cylinder of an internal combustion engine\nwhere the charge is compressed and ignited."
     ],
     "references": [
-      "COMBUSTION CHAMBER",
       "MIDFEATHER",
       "SEMI-DIESEL"
     ]
@@ -97783,9 +97508,7 @@
     "variants": [
       "COMMERCE DESTROYER\nCom\"merce de*stroy\"er. (Nav.)\n\nDefn: A very fast, unarmored, lightly armed vessel designed to\ncapture or destroy merchant vessels of an enemy. Not being intended\nto fight, they may be improvised from fast passenger steamers."
     ],
-    "references": [
-      "COMMERCE DESTROYER"
-    ]
+    "references": []
   },
   {
     "spellings": "COMMERCIAL",
@@ -101533,7 +101256,6 @@
     ],
     "references": [
       "COMMON",
-      "COMMON SENSE",
       "CONTRADICTORY",
       "DYSLOGISTIC",
       "EVINCE",
@@ -102300,8 +102022,7 @@
       "COMMUTATION TICKET\nCom`mu*ta\"tion tick\"et.\n\nDefn: A ticket for transportation at a reduced rate in consideration\nof some special circumstance, as increase of travel; specif., a\nticket for a certain number of, or for daily, trips between\nneighboring places at a reduced rate, such as are commonly used by\nthose doing business in a city and living in a suburb. Commutation\ntickets are excepted from the prohibition against special rates\ncontained in the Interstate Commerce Act of Feb. 4, 1887 (24 Stat.\n379), and in 145 U. S. 263 it was held that party tickets were also\nexcepted as being \"obviously within the commuting principle.\""
     ],
     "references": [
-      "COMMUTATION",
-      "COMMUTATION TICKET"
+      "COMMUTATION"
     ]
   },
   {
@@ -108503,9 +108224,7 @@
     "variants": [
       "COMPOUND CONTROL\nCom\"pound con*trol\". (Aëronautics)\n\nDefn: A system of control in which a separate manipulation, as of a\nrudder, may be effected by either of two movements, in different\ndirections, of a single lever, etc."
     ],
-    "references": [
-      "COMPOUND CONTROL"
-    ]
+    "references": []
   },
   {
     "spellings": "COMPOUNDER",
@@ -108875,9 +108594,7 @@
     "variants": [
       "COMPRESSED YEAST\nCom*pressed\" yeast.\n\nDefn: A cake yeast made by filtering the cells from the liquid in\nwhich they are grown, subjecting to heavy pressure, and mixing with\nstarch or flour."
     ],
-    "references": [
-      "COMPRESSED YEAST"
-    ]
+    "references": []
   },
   {
     "spellings": "COMPRESSIBILITY",
@@ -108966,9 +108683,7 @@
     "variants": [
       "COMPRESSION PROJECTILE\nCom*pres\"sion pro*jec\"tile.\n\nDefn: A projectile constructed so as to take the grooves of a rifle\nby means of a soft copper band firmly attached near its base or,\nformerly, by means of an envelope of soft metal. In small arms the\nmodern projectile, having a soft core and harder jacket, is subjected\nto compression throughout the entire cylindrical part."
     ],
-    "references": [
-      "COMPRESSION PROJECTILE"
-    ]
+    "references": []
   },
   {
     "spellings": "COMPRESSIVE",
@@ -109138,9 +108853,7 @@
     "variants": [
       "COMPTE RENDU\nCompte\" ren`du. Etym: [F.]\n\nDefn: A report of an officer or agent."
     ],
-    "references": [
-      "COMPTE RENDU"
-    ]
+    "references": []
   },
   {
     "spellings": "COMPTIBLE",
@@ -112544,18 +112257,14 @@
     "variants": [
       "CONCERT OF EUROPE; EUROPEAN CONCERT\nConcert of Europe, or European concert.\n\nDefn: An agreement or understanding between the chief European powers\nto take only joint action in the (European) Eastern Question."
     ],
-    "references": [
-      "CONCERT OF EUROPE; EUROPEAN CONCERT"
-    ]
+    "references": []
   },
   {
     "spellings": "CONCERT OF THE POWERS",
     "variants": [
       "CONCERT OF THE POWERS\nConcert of the powers.\n\nDefn: An agreement or understanding between the chief European\npowers, the United States, and Japan in 1900 to take only joint\naction in the Chinese aspect of the Eastern Question."
     ],
-    "references": [
-      "CONCERT OF THE POWERS"
-    ]
+    "references": []
   },
   {
     "spellings": "CONCESSION",
@@ -113595,9 +113304,7 @@
     "variants": [
       "CONCORD BUGGY\nCon\"cord bug\"gy (kon\"kerd). [From Concord, New Hampshire, where first\nmade.]\n\nDefn: A kind of buggy having a body with low sides, and side springs."
     ],
-    "references": [
-      "CONCORD BUGGY"
-    ]
+    "references": []
   },
   {
     "spellings": "CONCORDIST",
@@ -116553,9 +116260,7 @@
     "variants": [
       "CONDUIT SYSTEM; CONDUIT RAILWAY\nCon\"duit sys\"tem. (Elec.)\n\nDefn: A system of electric traction, esp. for light railways, in\nwhich the actuating current passes along a wire or rail laid in an\nunderground conduit, from which the current is \"picked up\" by a plow\nor other device fixed to the car or electric locomotive.  Hence\nConduit railway."
     ],
-    "references": [
-      "CONDUIT SYSTEM; CONDUIT RAILWAY"
-    ]
+    "references": []
   },
   {
     "spellings": "CONDUPLICATE",
@@ -116731,9 +116436,7 @@
     "variants": [
       "CONE CLUTCH\nCone clutch. (Mach.)\n\nDefn: A friction clutch with conical bearing surfaces."
     ],
-    "references": [
-      "CONE CLUTCH"
-    ]
+    "references": []
   },
   {
     "spellings": "CONEFLOWER",
@@ -116783,7 +116486,6 @@
     ],
     "references": [
       "CONE",
-      "CONE PULLEY",
       "LIFT",
       "PULLEY",
       "SPEED",
@@ -116795,9 +116497,7 @@
     "variants": [
       "CONESTOGA WAGON; CONESTOGA WAIN\nCon`es*to\"ga wag`on, Con`es*to\"ga wain. [From Conestoga,\nPennsylvania.]\n\nDefn: A kind of large broad-wheeled wagon, usually covered, for\ntraveling in soft soil and on prairies."
     ],
-    "references": [
-      "CONESTOGA WAGON; CONESTOGA WAIN"
-    ]
+    "references": []
   },
   {
     "spellings": "CONEY",
@@ -116933,9 +116633,7 @@
     "variants": [
       "CONFECTIONERS' SUGAR\nCon*fec\"tion*ers' sug`ar.\n\nDefn: A highly refined sugar in impalpable powder, esp. suited to\nconfectioners' uses."
     ],
-    "references": [
-      "CONFECTIONERS' SUGAR"
-    ]
+    "references": []
   },
   {
     "spellings": "CONFECTIONERY",
@@ -119907,7 +119605,6 @@
       "CONGO GROUP\nCon\"go group. [From Congo red.]\n\nDefn: A group of artificial dyes with an affinity for vegetable\nfibers, so that no mordant is required. Most of them are azo\ncompounds derived from benzidine or tolidine. Called also benzidine\ndyes."
     ],
     "references": [
-      "CONGO GROUP",
       "CONGO RED"
     ]
   },
@@ -119917,8 +119614,7 @@
       "CONGO RED\nCongo red. (Chem.)\n\nDefn: An artificial red dye from which the Congo group received its\nname. It is also widely used either in aqueous solution or as test\npaper (Congo paper) for the detection of free acid, which turns it\nblue."
     ],
     "references": [
-      "CONGO GROUP",
-      "CONGO RED"
+      "CONGO GROUP"
     ]
   },
   {
@@ -119927,8 +119623,7 @@
       "CONGO SNAKE\nCon\"go snake\". (Zoöl.)\n\nDefn: An amphibian (Amphiuma means) of the order Urodela, found in\nthe southern United States. See Amphiuma."
     ],
     "references": [
-      "AMPHIUMA",
-      "CONGO SNAKE"
+      "AMPHIUMA"
     ]
   },
   {
@@ -120223,7 +119918,6 @@
       "CONGREVE ROCKET\nCon\"greve rock\"et.\n\nDefn: See under Rocket."
     ],
     "references": [
-      "CONGREVE ROCKET",
       "ROCKET"
     ]
   },
@@ -121818,9 +121512,7 @@
     "variants": [
       "CONNING TOWER\nCon\"ning tow\"er, n.\n\nDefn: The shotproof pilot house of a war vessel."
     ],
-    "references": [
-      "CONNING TOWER"
-    ]
+    "references": []
   },
   {
     "spellings": "CONNIVANCE",
@@ -124619,7 +124311,6 @@
       "COMFORTABLE",
       "COMFORTER",
       "CONSOLABLE",
-      "CONSOLATION GAME; CONSOLATION MATCH; CONSOLATION POT; CONSOLATION",
       "CONSOLATORY",
       "CONSOLER",
       "DISCONSOLATE",
@@ -124639,9 +124330,7 @@
     "variants": [
       "CONSOLATO DEL MARE\nCon`so*la\"to del ma\"re. Etym: [It., the consulate of the sea.]\n\nDefn: A collection of maritime laws of disputed origin, supposed to\nhave been first published at Barcelona early in the 14th century. It\nhas formed the basis of most of the subsequent collections of\nmaritime laws. Kent. Bouvier."
     ],
-    "references": [
-      "CONSOLATO DEL MARE"
-    ]
+    "references": []
   },
   {
     "spellings": "CONSOLATOR",
@@ -127328,18 +127017,14 @@
     "variants": [
       "CONSUMER'S GOODS\nCon*sum\"er's goods. (Polit. Econ.)\n\nDefn: Economic goods that directly satisfy human wants or desires,\nsuch as food, clothes, pictures, etc.; -- called also consumption\ngoods, or goods of the first order, and opposed to producer's goods."
     ],
-    "references": [
-      "CONSUMER'S GOODS"
-    ]
+    "references": []
   },
   {
     "spellings": "CONSUMER'S SURPLUS",
     "variants": [
       "CONSUMER'S SURPLUS\nConsumer's surplus. (Polit. econ.)\n\nDefn: The excess that a purchaser would be willing to pay for a\ncommodity over that he does pay, rather than go without the\ncommodity; -- called also consumer's rent.\n\nThe price which a person pays for a thing can never exceed, and\nseldom comes up to, that which he would be willing to pay rather than\ngo without it. . . . The excess of the price which he would be\nwilling to pay rather than go without it, over that which he actually\ndoes pay, is the economic measure of this surplus satisfaction.  It\nhas some analogies to a rent; but is perhaps best called simply\nconsumer's surplus.\nAlfred Marshall."
     ],
-    "references": [
-      "CONSUMER'S SURPLUS"
-    ]
+    "references": []
   },
   {
     "spellings": "CONSUMINGLY",
@@ -127768,7 +127453,6 @@
     "references": [
       "CHICKEN",
       "CONTAGIOUS",
-      "CONTAGIOUS DISEASE",
       "DANGER",
       "DIPHTHERIA",
       "FARCY",
@@ -129864,27 +129548,21 @@
     "variants": [
       "CONTINENTAL DRIVE\nCon`ti*nen\"tal drive. (Automobiles)\n\nDefn: A transmission arrangement in which the longitudinal crank\nshaft drives the rear wheels through a clutch, change-speed gear,\ncountershaft, and two parallel side chains, in order."
     ],
-    "references": [
-      "CONTINENTAL DRIVE"
-    ]
+    "references": []
   },
   {
     "spellings": "CONTINENTAL GLACIER",
     "variants": [
       "CONTINENTAL GLACIER\nContinental glacier.\n\nDefn: A broad ice sheet resting on a plain or plateau and spreading\noutward from a central névé, or region of accumulation."
     ],
-    "references": [
-      "CONTINENTAL GLACIER"
-    ]
+    "references": []
   },
   {
     "spellings": "CONTINENTAL PRONUNCIATION",
     "variants": [
       "CONTINENTAL PRONUNCIATION\nContinental pronunciation (of Latin and Greek.)\n\nDefn: A method of pronouncing Latin and Greek in which the vowels\nhave their more familiar Continental values, as in German and\nItalian, the consonants being pronounced mostly as in English. The\nstricter form of this method of pronouncing Latin approaches the\nRoman, the modified form the English, pronunciation. The Continental\nmethod of Greek pronunciation is often called Erasmian."
     ],
-    "references": [
-      "CONTINENTAL PRONUNCIATION"
-    ]
+    "references": []
   },
   {
     "spellings": "CONTINENTAL SYSTEM",
@@ -129892,8 +129570,7 @@
       "CONTINENTAL SYSTEM\nContinental system. (Hist.)\n\nDefn: The system of commercial blockade aiming to exclude England\nfrom commerce with the Continent instituted by the Berlin decree,\nwhich Napoleon I. issued from Berlin Nov. 21, 1806, declaring the\nBritish Isles to be in a state of blockade, and British subjects,\nproperty, and merchandise subject to capture, and excluding British\nships from all parts of Europe under French dominion. The retaliatory\nmeasures of England were followed by the Milan decree, issued by\nNapoleon from Milan Dec. 17, 1807, imposing further restrictions, and\ndeclaring every ship going to or from a port of England or her\ncolonies to be lawful prize."
     ],
     "references": [
-      "CONTINENTAL",
-      "CONTINENTAL SYSTEM"
+      "CONTINENTAL"
     ]
   },
   {
@@ -131611,18 +131288,14 @@
     "variants": [
       "CONTRACT SYSTEM\nCon\"tract sys\"tem.\n\n1. The sweating system.\n\n2.  The system of employing convicts by selling their labor (to be\nperformed inside the prison) at a fixed price per day to contractors\nwho are allowed to have agents in the prison to superintend the work."
     ],
-    "references": [
-      "CONTRACT SYSTEM"
-    ]
+    "references": []
   },
   {
     "spellings": "CONTRACT TABLET",
     "variants": [
       "CONTRACT TABLET\nCon\"tract tablet. (Babylonian & Assyrian Antiq.)\n\nDefn: A clay tablet on which was inscribed a contract, for safe\nkeeping.  Such tablets were inclosed in an outer case (often called\nthe envelope), on which was inscribed a duplicate of the inscription\non the inclosed tablet."
     ],
-    "references": [
-      "CONTRACT TABLET"
-    ]
+    "references": []
   },
   {
     "spellings": "CONTRACTURE",
@@ -132603,9 +132276,7 @@
     "variants": [
       "CONTRIBUTION PLAN\nCon`tri*bu\"tion plan. (Life Insurance)\n\nDefn: A plan of distributing surplus by giving to each policy the\nexcess of premiums and interest earned thereon over the expenses of\nmanagement, cost of insurance, and the policy value at the date of\ncomputation. This excess is called the contribution of the policy."
     ],
-    "references": [
-      "CONTRIBUTION PLAN"
-    ]
+    "references": []
   },
   {
     "spellings": "CONTRIBUTIVE",
@@ -135793,9 +135464,7 @@
     "variants": [
       "CONVOY PENNANT\nCon\"voy pen\"nant. A white pennant with red border, carried :\n (a) Forward on all vessels on convoy duty.\n (b) Alone by a senior officer present during evolutions or drills,\nwhen it commands \"Silence.\"\n (c) Over a signal number, when it refers to the signal number of an\nofficer in the Annual Navy Register."
     ],
-    "references": [
-      "CONVOY PENNANT"
-    ]
+    "references": []
   },
   {
     "spellings": "CONVULSE",
@@ -137596,9 +137265,7 @@
     "variants": [
       "COPPER WORKS\nCop\"per works.\n\nDefn: A place where copper is wrought or manufactured. Woodward."
     ],
-    "references": [
-      "COPPER WORKS"
-    ]
+    "references": []
   },
   {
     "spellings": "COPPERWORM",
@@ -137671,9 +137338,7 @@
     "variants": [
       "COPPLE DUST\nCop\"ple dust`.\n\nDefn: Cupel dust. [Obs.]\nPowder of steel, or copple dust. Bacon."
     ],
-    "references": [
-      "COPPLE DUST"
-    ]
+    "references": []
   },
   {
     "spellings": "COPPLESTONE",
@@ -137804,7 +137469,6 @@
       "COPTIC CHURCH\nCoptic Church.\n\nDefn: The native church of Egypt or church of Alexandria, which in\ngeneral organization and doctrines resembles the Roman Catholic\nChurch, except that it holds to the Monophysitic doctrine which was\ncondemned (a. d. 451) by the council of Chalcedon, and allows its\npriests to marry. The \"pope and patriarch\" has jurisdiction over the\nAbyssinian Church. Since the 7th century the Coptic Church has been\nso isolated from modifying influences that in many respects it is the\nmost ancient monument of primitive Christian rites and ceremonies.\nBut centuries of subjection to Moslem rule have weakened and degraded\nit."
     ],
     "references": [
-      "COPTIC CHURCH",
       "HAIKAL"
     ]
   },
@@ -138214,9 +137878,7 @@
     "variants": [
       "COQUILLA NUT\nCo*quil\"la nut. Etym: [Pg. coquilho, Sp. coquillo, dim. of coco a\ncocoanut.] (Bot.)\n\nDefn: The fruit of a Brazilian tree (Attalea funifera of Martius.).\n\nNote: Its shell is hazel-brown in color, very hard and close in\ntexture, and much used by turners in forming ornamental articles,\nsuch as knobs for umbrella handles."
     ],
-    "references": [
-      "COQUILLA NUT"
-    ]
+    "references": []
   },
   {
     "spellings": "COQUILLE",
@@ -138877,7 +138539,6 @@
     ],
     "references": [
       "CORAL",
-      "CORAL FISH",
       "POMACENTROID"
     ]
   },
@@ -139735,9 +139396,7 @@
     "variants": [
       "CORE LOSS\nCore loss. (Elec.)\n\nDefn: Energy wasted by hysteresis or eddy currents in the core of an\narmature, transformer, etc."
     ],
-    "references": [
-      "CORE LOSS"
-    ]
+    "references": []
   },
   {
     "spellings": "COREOPSIS",
@@ -140006,9 +139665,7 @@
     "variants": [
       "CORK FOSSIL\nCork\" fos`sil (krk\" fs`sl). (Min.)\n\nDefn: A variety of amianthus which is very light, like cork."
     ],
-    "references": [
-      "CORK FOSSIL"
-    ]
+    "references": []
   },
   {
     "spellings": "CORKINESS",
@@ -140022,9 +139679,7 @@
     "variants": [
       "CORKING PIN\nCork\"ing pin` (krk\"ng pn`).\n\nDefn: A pin of a large size, formerly used attaching a woman's\nheaddress to a cork mold. [Obs.] Swift."
     ],
-    "references": [
-      "CORKING PIN"
-    ]
+    "references": []
   },
   {
     "spellings": "CORKSCREW",
@@ -140968,9 +140623,7 @@
     "variants": [
       "CORNO DI BASSETTO\nCor\"no di bas*set\"to (kr\"n d bs-st\"t or bs-st\"t); pl. Corni (-n di\nbasseto. Etym: [It.] (Mus.)\n\nDefn: A tenor clarinet; -- called also basset horn, and sometimes\nconfounded with the English horn, which is a tenor oboe."
     ],
-    "references": [
-      "CORNO DI BASSETTO"
-    ]
+    "references": []
   },
   {
     "spellings": "CORNO INGLESE",
@@ -140978,7 +140631,6 @@
       "CORNO INGLESE\nCor\"no In*gle\"se (n-gl\"z); pl. Corni Inglesi (-z. Etym: [It.] (Mus.)\n\nDefn: A reed instrument, related to the oboe, but deeper in pitch;\nthe English horn."
     ],
     "references": [
-      "CORNO INGLESE",
       "ENGLISH"
     ]
   },
@@ -141084,8 +140736,7 @@
       "CORNU AMMONIS\nCor\"nu Am*mo\"nis (m-m\"ns); pl. Cornua Ammonis. Etym: [L., horn of\nAmmon. See Ammonite.] (Paleon.)\n\nDefn: A fossil shell, curved like a ram's horn; an obsolete name for\nan ammonite."
     ],
     "references": [
-      "AMMONITE",
-      "CORNU AMMONIS"
+      "AMMONITE"
     ]
   },
   {
@@ -141384,18 +141035,14 @@
     "variants": [
       "CORONARY BONE\nCor\"o*na*ry bone.\n\nDefn: The small pastern bone of the horse and allied animals."
     ],
-    "references": [
-      "CORONARY BONE"
-    ]
+    "references": []
   },
   {
     "spellings": "CORONARY CUSHION",
     "variants": [
       "CORONARY CUSHION\nCoronary cushion.\n\nDefn: A cushionlike band of vascular tissue at the upper border of\nthe wall of the hoof of the horse and allied animals. It takes an\nimportant part in the secretion of the horny walls."
     ],
-    "references": [
-      "CORONARY CUSHION"
-    ]
+    "references": []
   },
   {
     "spellings": "CORONATE; CORONATED",
@@ -142777,9 +142424,7 @@
     "variants": [
       "CORRESPONDENCE SCHOOL\nCor`res*pond\"ence school.\n\nDefn: A school that teaches by correspondence, the instruction being\nbased on printed instruction sheets and the recitation papers written\nby the student in answer to the questions or requirements of these\nsheets. In the broadest sense of the term correspondence school may\nbe used to include any educational institution or department for\ninstruction by correspondence, as in a university or other\neducational bodies, but the term is commonly applied to various\neducational institutions organized on a commercial basis, some of\nwhich offer a large variety of courses in general and technical\nsubjects, conducted by specialists."
     ],
-    "references": [
-      "CORRESPONDENCE SCHOOL"
-    ]
+    "references": []
   },
   {
     "spellings": "CORRESPONDENCY",
@@ -143187,9 +142832,7 @@
     "variants": [
       "CORRIDOR TRAIN\nCor\"ri*dor train.\n\nDefn: A train whose coaches are connected so as to have through its\nentire length a continuous corridor, into which the compartments\nopen. [Eng.]"
     ],
-    "references": [
-      "CORRIDOR TRAIN"
-    ]
+    "references": []
   },
   {
     "spellings": "CORRIE",
@@ -144137,9 +143780,7 @@
     "variants": [
       "CORTES GERAES\nCor\"tes Ge*ra\"es. [Pg.]\n\nDefn: See Legislature, Portugal."
     ],
-    "references": [
-      "CORTES GERAES"
-    ]
+    "references": []
   },
   {
     "spellings": "CORTEX",
@@ -144876,9 +144517,7 @@
     "variants": [
       "COSSACK POST\nCos\"sack post. (Mil.)\n\nDefn: An outpost consisting of four men, forming one of a single line\nof posts substituted for the more formal line of sentinels and line\nof pickets."
     ],
-    "references": [
-      "COSSACK POST"
-    ]
+    "references": []
   },
   {
     "spellings": "COSSAS",
@@ -145248,9 +144887,7 @@
     "variants": [
       "COSTON LIGHTS\nCos\"ton lights.\n\nDefn: Signals made by burning lights of different colors and used by\nvessels at sea, and in the life-saving service; -- named after their\ninventor."
     ],
-    "references": [
-      "COSTON LIGHTS"
-    ]
+    "references": []
   },
   {
     "spellings": "COSTOTOME",
@@ -146084,8 +145721,7 @@
       "COTTON BATTING\nCot\"ton bat\"ting.\n\nDefn: Cotton prepared in sheets or rolls for quilting, upholstering,\nand similar purposes."
     ],
     "references": [
-      "BATTING",
-      "COTTON BATTING"
+      "BATTING"
     ]
   },
   {
@@ -146104,7 +145740,6 @@
       "BECCHI'S TEST",
       "CAKE",
       "COTTOLENE",
-      "COTTON SEED; COTTONSEED",
       "COTTONSEED MEAL",
       "COTTONSEED OIL"
     ]
@@ -146114,9 +145749,7 @@
     "variants": [
       "COTTONSEED MEAL\nCottonseed meal.\n\nDefn: A meal made from hulled cotton seeds after the oil has been\nexpressed."
     ],
-    "references": [
-      "COTTONSEED MEAL"
-    ]
+    "references": []
   },
   {
     "spellings": "COTTONSEED OIL",
@@ -146124,8 +145757,7 @@
       "COTTONSEED OIL\nCottonseed oil.\n\nDefn: A fixed, semidrying oil extracted from cottonseed. It is pale\nyellow when pure (sp. gr., .92-.93). and is extensively used in soap\nmaking, in cookery, and as an adulterant of other oils."
     ],
     "references": [
-      "BECCHI'S TEST",
-      "COTTONSEED OIL"
+      "BECCHI'S TEST"
     ]
   },
   {
@@ -146133,9 +145765,7 @@
     "variants": [
       "COTTON STATE\nCotton State.\n\nDefn: Alabama; -- a nickname."
     ],
-    "references": [
-      "COTTON STATE"
-    ]
+    "references": []
   },
   {
     "spellings": "COTTONTAIL",
@@ -146406,7 +146036,6 @@
       "COUCH GRASS\nCouch\" grass` (grs`). (Bot.)\n\nDefn: See Quitch grass."
     ],
     "references": [
-      "COUCH GRASS",
       "GRASS",
       "QUITCH GRASS"
     ]
@@ -146970,18 +146599,14 @@
     "variants": [
       "COULOMB METER\nCou`lomb\" me\"ter. (Elec.)\n\nDefn: Any instrument by which electricity can be measured in\ncoulombs."
     ],
-    "references": [
-      "COULOMB METER"
-    ]
+    "references": []
   },
   {
     "spellings": "COULOMB'S LAW",
     "variants": [
       "COULOMB'S LAW\nCou`lomb's\" law. (Physics)\n\nDefn: The law that the force exerted between two electric or magnetic\ncharges is directly proportional to the product of the charges and\ninversely to the square of the distance between them."
     ],
-    "references": [
-      "COULOMB'S LAW"
-    ]
+    "references": []
   },
   {
     "spellings": "COULTER",
@@ -147823,7 +147448,6 @@
     ],
     "references": [
       "COUNTER",
-      "COUNTER BRACE",
       "COUNTERBRACE",
       "MAIN"
     ]
@@ -148526,7 +148150,6 @@
       "CONTRALTO",
       "CONTRATENOR",
       "COUNTER",
-      "COUNTER TENOR",
       "FALSETTO"
     ]
   },
@@ -148622,9 +148245,7 @@
     "variants": [
       "COUNTER WEIGHT\nCoun\"ter *weight` (-wt`), n.\n\nDefn: A counterpoise."
     ],
-    "references": [
-      "COUNTER WEIGHT"
-    ]
+    "references": []
   },
   {
     "spellings": "COUNTERWHEEL",
@@ -149446,9 +149067,7 @@
     "variants": [
       "COUNTRY BANK\nCoun\"try bank. (Banking)\n\nDefn: A national bank not in a reserve city. [Colloq., U. S.]"
     ],
-    "references": [
-      "COUNTRY BANK"
-    ]
+    "references": []
   },
   {
     "spellings": "COUNTRY-BASE",
@@ -149463,7 +149082,6 @@
       "COUNTRY CLUB\nCoun\"try club.\n\nDefn: A club usually located in the suburbs or vicinity of a city or\ntown and devoted mainly to outdoor sports."
     ],
     "references": [
-      "COUNTRY CLUB",
       "TUXEDO COAT; TUXEDO"
     ]
   },
@@ -149472,9 +149090,7 @@
     "variants": [
       "COUNTRY COUSIN\nCoun\"try cousin.\n\nDefn: A relative from the country visiting the city and unfamiliar\nwith city manners and sights."
     ],
-    "references": [
-      "COUNTRY COUSIN"
-    ]
+    "references": []
   },
   {
     "spellings": "COUNTRY-DANCE",
@@ -149515,7 +149131,6 @@
     "references": [
       "AIRINESS",
       "CHATEAU",
-      "COUNTRY SEAT",
       "PRETORIUM",
       "TRAVEL",
       "VICINITY",
@@ -151969,7 +151584,6 @@
     ],
     "references": [
       "CHASE",
-      "COURT TENNIS",
       "DEDANS",
       "TENNIS"
     ]
@@ -152916,9 +152530,7 @@
     "variants": [
       "COVER CROP\nCov\"er crop.\n\nDefn: A catch crop planted, esp. in orchards. as a protection to the\nsoil in winter, as well as for the benefit of the soil when plowed\nunder in spring."
     ],
-    "references": [
-      "COVER CROP"
-    ]
+    "references": []
   },
   {
     "spellings": "COVERED",
@@ -154148,7 +153760,6 @@
       "COVERSED SINE\nCo*versed\" sine (k-vrst\" sn`). Etym: [Co- (=co- in co- sine) + versed\nsine.] (Geom.)\n\nDefn: The versed sine of the complement of an arc or angle. See\nIllust. of Functions."
     ],
     "references": [
-      "COVERSED SINE",
       "FUNCTION"
     ]
   },
@@ -154215,9 +153826,7 @@
     "variants": [
       "COVERT BARON\nCov\"ert bar`on (br`n). (Law)\n\nDefn: Under the protection of a husband; married. Burrill."
     ],
-    "references": [
-      "COVERT BARON"
-    ]
+    "references": []
   },
   {
     "spellings": "COVERTLY",
@@ -154974,7 +154583,6 @@
       "COW PARSLEY\nCow\" pars`ley (kou` prs`l). (Bot.)\n\nDefn: An umbelliferous plant of the genus Chærophyllum (C. temulum\nand C. sylvestre)."
     ],
     "references": [
-      "COW PARSLEY",
       "COWWEED"
     ]
   },
@@ -154985,7 +154593,6 @@
     ],
     "references": [
       "BEAR'S-BREECH",
-      "COW PARSNIP",
       "MASTERWORT",
       "PARSNIP"
     ]
@@ -155004,9 +154611,7 @@
     "variants": [
       "COWPER'S GLANDS\nCow\"per's glands` (kou\"prz glndz`). Etym: [After the discoverer,\nWilliam Cowper, an English surgeon.] (Anat.)\n\nDefn: Two small glands discharging into the male urethra."
     ],
-    "references": [
-      "COWPER'S GLANDS"
-    ]
+    "references": []
   },
   {
     "spellings": "COW-PILOT",
@@ -155103,7 +154708,6 @@
       "COW'S LUNGWORT\nCow's\" lung\"wort` (kouz\" lng\"wrt`).\n\nDefn: Mullein."
     ],
     "references": [
-      "COW'S LUNGWORT",
       "LUNGWORT"
     ]
   },
@@ -155113,7 +154717,6 @@
       "COW TREE\nCow\" tree` (kou\" tr`). Etym: [Cf. SP. palo de vaca.] (Bot.)\n\nDefn: A tree (Galactodendron utile or Brosimum Galactodendron) of\nSouth America, which yields, on incision, a nourishing fluid,\nresembling milk."
     ],
     "references": [
-      "COW TREE",
       "MILK"
     ]
   },
@@ -155319,9 +154922,7 @@
     "variants": [
       "COYOTE STATE\nCoyote State.\n\nDefn: South Dakota; -- a nickname."
     ],
-    "references": [
-      "COYOTE STATE"
-    ]
+    "references": []
   },
   {
     "spellings": "COYOTILLO",
@@ -155655,7 +155256,6 @@
     ],
     "references": [
       "CRAB",
-      "CRAB TREE",
       "THWACK"
     ]
   },
@@ -155821,9 +155421,7 @@
     "variants": [
       "CRACKER STATE\nCracker State.\n\nDefn: Georgia; -- a nickname. See Cracker, n. 5."
     ],
-    "references": [
-      "CRACKER STATE"
-    ]
+    "references": []
   },
   {
     "spellings": "CRACKLE",
@@ -156273,9 +155871,7 @@
     "variants": [
       "CRAIG FLOUNDER\nCraig\" floun`der (krg\" floun`dr). Etym: [Scot. craig a rock. See 1st\nCrag.] (Zoöl.)\n\nDefn: The pole flounder."
     ],
-    "references": [
-      "CRAIG FLOUNDER"
-    ]
+    "references": []
   },
   {
     "spellings": "CRAIL",
@@ -156436,7 +156032,6 @@
     "references": [
       "CRAMP",
       "CRAMPET",
-      "CRAMP IRON",
       "INCRUSTATION"
     ]
   },
@@ -157070,9 +156665,7 @@
     "variants": [
       "CRAP SHOOTING\nCrap shooting.\n\nDefn: Same as Craps."
     ],
-    "references": [
-      "CRAP SHOOTING"
-    ]
+    "references": []
   },
   {
     "spellings": "CRAPULA; CRAPULE",
@@ -157487,9 +157080,7 @@
     "variants": [
       "CRAWL STROKE\nCrawl stroke. (Swimming)\n\nDefn: A racing stroke, in which the swimmer, lying flat on the water\nwith face submerged, takes alternate overhand arm strokes while\nmoving his legs up and down alternately from the knee."
     ],
-    "references": [
-      "CRAWL STROKE"
-    ]
+    "references": []
   },
   {
     "spellings": "CRAWLY",
@@ -157821,7 +157412,6 @@
       "CREAM LAID\nCream\" laid` (krm\" ld`).\n\nDefn: See under Laid."
     ],
     "references": [
-      "CREAM LAID",
       "LAID"
     ]
   },
@@ -158639,18 +158229,14 @@
     "variants": [
       "CREDIT FONCIER\nCre`dit\" fon`cier\" (krd\" fn`s\"). Etym: [F. cr credit & foncier\nrelating to land, landed.]\n\nDefn: A company licensed for the purpose of carrying out\nimprovements, by means of loans and advances upon real securities. ]"
     ],
-    "references": [
-      "CREDIT FONCIER"
-    ]
+    "references": []
   },
   {
     "spellings": "CREDIT MOBILIER",
     "variants": [
       "CREDIT MOBILIER\nCre`dit\" mo`bi`lier\" (m`b`ly\"). Etym: [F. cr credit & mobilier\npersonal, pertaining to personal property.]\n\nDefn: A joint stock company, formed for general banking business, or\nfor the construction of public works, by means of loans on personal\nestate, after the manner of the crédit foncier on real estate. In\npractice, however, this distinction has not been strictly observed."
     ],
-    "references": [
-      "CREDIT MOBILIER"
-    ]
+    "references": []
   },
   {
     "spellings": "CREDITOR",
@@ -159073,9 +158659,7 @@
     "variants": [
       "CREEPING CHARLIE\nCreep\"ing Char\"lie.\n\nDefn: The stonecrop (Sedum acre)."
     ],
-    "references": [
-      "CREEPING CHARLIE"
-    ]
+    "references": []
   },
   {
     "spellings": "CREEPINGLY",
@@ -159366,9 +158950,7 @@
     "variants": [
       "CREOLE STATE\nCreole State.\n\nDefn: Louisiana; -- a nickname. See Creole, n. & a."
     ],
-    "references": [
-      "CREOLE STATE"
-    ]
+    "references": []
   },
   {
     "spellings": "CREOSOL",
@@ -159403,9 +158985,7 @@
     "variants": [
       "CREOSOTE BUSH\nCre\"o*sote bush.\n\nDefn: A shrub (Covillea mexicana) found in desert regions from\nColorado to California and southward through Mexico. It has yellow\nflowers and very resinous foliage with a strong odor of creosote."
     ],
-    "references": [
-      "CREOSOTE BUSH"
-    ]
+    "references": []
   },
   {
     "spellings": "CREPANCE; CREPANE",
@@ -162285,9 +161865,7 @@
     "variants": [
       "CROFTON SYSTEM\nCrof\"ton sys\"tem. [After Sir Walter Crofton, Irish penologist.]\n(Penology)\n\nDefn: A system of prison discipline employing for consecutive periods\ncellular confinement, associated imprisonment under the mark system,\nrestraint intermediate between imprisonment and freedom, and\nliberation on ticket of leave."
     ],
-    "references": [
-      "CROFTON SYSTEM"
-    ]
+    "references": []
   },
   {
     "spellings": "CROIS",
@@ -162624,9 +162202,7 @@
     "variants": [
       "CROOKES SPACE\nCrookes space (krooks). [After Sir William Crookes, English chemist,\nwho first described it.] (Physics)\n\nDefn: The dark space within the negative-pole glow at the cathode of\na vacuum tube, observed only when the pressure is low enough to give\na striated discharge; -- called also Crookes layer."
     ],
-    "references": [
-      "CROOKES SPACE"
-    ]
+    "references": []
   },
   {
     "spellings": "CROOKES TUBE",
@@ -162634,7 +162210,6 @@
       "CROOKES TUBE\nCrookes\" tube` (krks\" tb`). (Phys.)\n\nDefn: A vacuum tube in which the exhaustion is carried to a very high\ndegree, with the production of a distinct class of effects; -- so\ncalled from W. Crookes who introduced it."
     ],
     "references": [
-      "CROOKES TUBE",
       "HITTORF TUBE",
       "PLUCKER TUBE"
     ]
@@ -164048,9 +163623,7 @@
     "variants": [
       "CROTCH CHAIN\nCrotch chain. (Logging)\n\nDefn: A form of tackle for loading a log sideways on a sled, skidway,\netc."
     ],
-    "references": [
-      "CROTCH CHAIN"
-    ]
+    "references": []
   },
   {
     "spellings": "CROTCHED",
@@ -164130,7 +163703,6 @@
       "CROTON BUG\nCro\"ton bug` (bg`). Etym: [From the Croton water of New York.]\n(Zoöl.)\n\nDefn: A small, active, winged species of cockroach (Ectobia\nGermanica), the water bug. It is common aboard ships, and in houses\nin cities, esp. in those with hot-water pipes."
     ],
     "references": [
-      "CROTON BUG",
       "WATER BUG"
     ]
   },
@@ -164940,9 +164512,7 @@
     "variants": [
       "CROWN COLONY\nCrown colony.\n\nDefn: A colony of the British Empire not having an elective\nmagistracy or a parliament, but governed by a chief magistrate\n(called Governor) appointed by the Crown, with executive councilors\nnominated by him and not elected by the people."
     ],
-    "references": [
-      "CROWN COLONY"
-    ]
+    "references": []
   },
   {
     "spellings": "CROWNED",
@@ -165058,7 +164628,6 @@
     ],
     "references": [
       "CROWN",
-      "CROWN OFFICE",
       "CROWN SIDE"
     ]
   },
@@ -165095,8 +164664,7 @@
     ],
     "references": [
       "CROWN",
-      "CROWN OFFICE",
-      "CROWN SIDE"
+      "CROWN OFFICE"
     ]
   },
   {
@@ -165107,7 +164675,6 @@
     "references": [
       "CONTRATE",
       "CROWN",
-      "CROWN WHEEL",
       "ESCAPEMENT",
       "FACE"
     ]
@@ -165272,7 +164839,6 @@
       "CRUCIAN CARP\nCru\"cian carp` (-shan krp`). Etym: [Cf. Sw. karussa, G. karausche, F.\ncarousse, -assin, corassin, LL. coracinus, Gr. (Zoöl.)\n\nDefn: A kind of European carp (Carasius vulgaris), inferior to the\ncommon carp; -- called also German carp.\n\nNote: The gibel or Prussian carp is now generally considered a\nvariety of the crucian carp, or perhaps a hybrid between it and the\ncommon carp."
     ],
     "references": [
-      "CRUCIAN CARP",
       "GERMAN"
     ]
   },
@@ -165330,7 +164896,6 @@
       "CRUCIBLE STEEL\nCru\"ci*ble steel.\n\nDefn: Cast steel made by fusing in crucibles crude or scrap steel,\nwrought iron, and other ingredients and fluxes."
     ],
     "references": [
-      "CRUCIBLE STEEL",
       "TOOL STEEL"
     ]
   },
@@ -166835,8 +166400,7 @@
       "CRUX ANSATA\nCrux an*sa\"ta. [L., cross with a handle.]\n\nDefn: A cross in the shape of the ankh."
     ],
     "references": [
-      "ANKH",
-      "CRUX ANSATA"
+      "ANKH"
     ]
   },
   {
@@ -168817,7 +168381,6 @@
       "CUCKING STOOL\nCuck\"ing stool` (k. Etym: [Cf. AS. scealfingstol, a word of similar\nmeaning, allied to scealfor a diver, mergus avis; or possibly from F.\ncoquine a hussy, slut, jade, f. of coquin, OE. cokin, a rascal; or\ncf. Icel. k to dung, k dung, the name being given as to a disgracing\nor infamous punishment.]\n\nDefn: A kind of chair formerly used for punishing scolds, and also\ndishonest tradesmen, by fastening them in it, usually in front of\ntheir doors, to be pelted and hooted at by the mob, but sometimes to\nbe taken to the water and ducked; -- called also a castigatory, a\ntumbrel, and a trebuchet; and often, but not so correctly, a ducking\nstool. Sir. W. Scott."
     ],
     "references": [
-      "CUCKING STOOL",
       "DUCKING",
       "TREBUCHET; TREBUCKET",
       "TUMBREL; TUMBRIL"
@@ -168881,9 +168444,7 @@
     "variants": [
       "CUCKOLD'S KNOT\nCuck\"old's knot` (kk\"ldz nt`). (Naut.)\n\nDefn: A hitch or knot, by which a rope is secured to a spar, the two\nparts of the rope being crossed and seized together; -- called also\ncuckold's neck. Ham. Nav. Encyc."
     ],
-    "references": [
-      "CUCKOLD'S KNOT"
-    ]
+    "references": []
   },
   {
     "spellings": "CUCKOO",
@@ -169293,9 +168854,7 @@
     "variants": [
       "CUI BONO\nCui` bo\"no. [L.]\n\nDefn: Lit., for whose benefit; incorrectly understood, it came to be\nused in the sense, of what good or use; and hence, (what) purpose;\nobject; specif., the ultimate object of life."
     ],
-    "references": [
-      "CUI BONO"
-    ]
+    "references": []
   },
   {
     "spellings": "CUINAGE",
@@ -169350,7 +168909,6 @@
       "CUIR BOUILLI\nCuir\" bou`illi\". [F.]\n\nDefn: In decorative art, boiled leather, fitted by the process to\nreceive impressed patterns, like those produced by chasing metal, and\nto retain the impression permanently."
     ],
     "references": [
-      "CUIR BOUILLI",
       "QUIRBOILLY"
     ]
   },
@@ -170106,9 +169664,7 @@
     "variants": [
       "CULTURE FEATURES\nCulture features. (Surv.)\n\nDefn: The artificial features of a district as distinguished from the\nnatural."
     ],
-    "references": [
-      "CULTURE FEATURES"
-    ]
+    "references": []
   },
   {
     "spellings": "CULTURELESS",
@@ -170122,9 +169678,7 @@
     "variants": [
       "CULTURE MYTH\nCulture myth.\n\nDefn: A myth accounting for the discovery of arts and sciences or the\nadvent of a higher civilization, as in the Prometheus myth."
     ],
-    "references": [
-      "CULTURE MYTH"
-    ]
+    "references": []
   },
   {
     "spellings": "CULTURIST",
@@ -170156,7 +169710,6 @@
     ],
     "references": [
       "BUFFALO",
-      "CULTUS COD",
       "LING"
     ]
   },
@@ -170201,9 +169754,7 @@
     "variants": [
       "CULVER'S PHYSIC; CULVER'S ROOT\nCul\"ver's phys\"ic, or Cul\"ver's root`. [So called after a Dr. Culver,\nwho used it.] (Bot.)\n\nDefn: The root of a handsome erect herb (Leptandra, syn. Veronica,\nVirginica) common in most moist woods of North America , used as an\nactive cathartic and emetic; also, the plant itself."
     ],
-    "references": [
-      "CULVER'S PHYSIC; CULVER'S ROOT"
-    ]
+    "references": []
   },
   {
     "spellings": "CULVERT",
@@ -171213,8 +170764,7 @@
       "CUP SHAKE\nCup shake. (Forestry)\n\nDefn: A shake or fissure between the annual rings of a tree, found\noftenest near the roots."
     ],
     "references": [
-      "CUPPY",
-      "CUP SHAKE"
+      "CUPPY"
     ]
   },
   {
@@ -171582,7 +171132,6 @@
       "CURB ROOF\nCurb\" roof` (rf`).\n\nDefn: A roof having a double slope, or composed, on each side, of two\nparts which have unequal inclination; a gambrel roof."
     ],
     "references": [
-      "CURB ROOF",
       "DECK",
       "GAMBREL",
       "MANSARD ROOF"
@@ -173358,7 +172907,6 @@
       "CURTAIL DOG\nCur\"tail dog` (d.\n\nDefn: A dog with a docked tail; formerly, the dog of a person not\nqualified to course, which, by the forest laws, must have its tail\ncut short, partly as a mark, and partly from a notion that the tail\nis necessary to a dog in running; hence, a dog not fit for sporting.\nHope is a curtail dog in some affairs. Shak."
     ],
     "references": [
-      "CURTAIL DOG",
       "CURTAL"
     ]
   },
@@ -173445,7 +172993,6 @@
       "CURTAL AX; CURTLE AX; CURTELASSE\nCur\"tal ax`, Cur\"tle ax`, Curte\"lasse (krt\"las).\n\nDefn: A corruption of Cutlass."
     ],
     "references": [
-      "CURTAL AX; CURTLE AX; CURTELASSE",
       "CUTLASS"
     ]
   },
@@ -173454,9 +173001,7 @@
     "variants": [
       "CURTAL FRIAR\nCur\"tal fri`ar (fr`r).\n\nDefn: A friar who acted as porter at the gate of a monastery. Sir W.\nScott."
     ],
-    "references": [
-      "CURTAL FRIAR"
-    ]
+    "references": []
   },
   {
     "spellings": "CURTANA",
@@ -174038,9 +173583,7 @@
     "variants": [
       "CUSCUS OIL\nCuscus oil.\n\nDefn: Same as Vetiver oil."
     ],
-    "references": [
-      "CUSCUS OIL"
-    ]
+    "references": []
   },
   {
     "spellings": "CUSHAT",
@@ -174138,9 +173681,7 @@
     "variants": [
       "CUSHION TIRE\nCushion tire.\n\nDefn: A thick solid-rubber tire, as for a bicycle, with a hollow\ngroove running lengthwise on the inside."
     ],
-    "references": [
-      "CUSHION TIRE"
-    ]
+    "references": []
   },
   {
     "spellings": "CUSHIONY",
@@ -176398,18 +175939,14 @@
     "variants": [
       "CUTTLE BONE\nCut\"tle bone` (bn`).\n\nDefn: The shell or bone of cuttlefishes, used for various purposes,\nas for making polishing powder, etc."
     ],
-    "references": [
-      "CUTTLE BONE"
-    ]
+    "references": []
   },
   {
     "spellings": "CUTTOO PLATE",
     "variants": [
       "CUTTOO PLATE\nCut*too\" plate` (kt-t\" plt`).\n\nDefn: A hood over the end of a wagon wheel hub to keep dirt away from\nthe axle."
     ],
-    "references": [
-      "CUTTOO PLATE"
-    ]
+    "references": []
   },
   {
     "spellings": "CUTTY",
@@ -176729,7 +176266,6 @@
     "references": [
       "BIURET",
       "CYANURATE",
-      "CYANURIC ACID",
       "FULMINIC",
       "FULMINURIC",
       "ISOCYANIC",
@@ -177037,9 +176573,7 @@
     "variants": [
       "CYCLONE CELLAR; CYCLONE PIT\nCyclone cellar or pit .\n\nDefn: A cellar or excavation used for refuge from a cyclone, or\ntornado. [Middle U. S.]"
     ],
-    "references": [
-      "CYCLONE CELLAR; CYCLONE PIT"
-    ]
+    "references": []
   },
   {
     "spellings": "CYCLONIC",

--- a/output/wordDisplayData#D.json
+++ b/output/wordDisplayData#D.json
@@ -2873,7 +2873,6 @@
       "DADDY LONGLEGS\nDad\"dy long\"legs`.\n\n1. (Zoöl.)\n\nDefn: An arachnidan of the genus Phalangium, and allied genera,\nhaving a small body and four pairs of long legs; -- called also\nharvestman, carter, and grandfather longlegs.\n\n2. (Zoöl.)\n\nDefn: A name applied to many species of dipterous insects of the\ngenus Tipula, and allied genera, with slender bodies, and very long,\nslender legs; the crane fly; -- called also father longlegs."
     ],
     "references": [
-      "DADDY LONGLEGS",
       "FATHER LONGLEGS",
       "HARVEST",
       "HARVESTMAN",
@@ -3588,9 +3587,7 @@
     "variants": [
       "DAKER HEN\nDa\"ker hen`. Etym: [Perh. fr. W. crecial the daker hen; crec a sharp\nnoise (creg harsh, hoarse, crechian to scream) + iar hen; or cf. D.\nduiken to dive, plunge.] (Zoöl.)\n\nDefn: The corncrake or land rail."
     ],
-    "references": [
-      "DAKER HEN"
-    ]
+    "references": []
   },
   {
     "spellings": "DAKOIT; DAKOITY",
@@ -3604,9 +3601,7 @@
     "variants": [
       "DAKOTA GROUP\nDa*ko\"ta group`. (Geol.)\n\nDefn: A subdivision at the base of the cretaceous formation in\nWestern North America; -- so named from the region where the strata\nwere first studied."
     ],
-    "references": [
-      "DAKOTA GROUP"
-    ]
+    "references": []
   },
   {
     "spellings": "DAKOTAS",
@@ -3776,7 +3771,6 @@
       "DAL SEGNO\nDal` se\"gno. Etym: [It., from the sign.] (Mus.)\n\nDefn: A direction to go back to the sign Segno."
     ],
     "references": [
-      "DAL SEGNO",
       "SEGNO"
     ]
   },
@@ -4010,9 +4004,7 @@
     "variants": [
       "DAMAGE FEASANT\nDam\"age fea`sant. Etym: [OF. damage + F. faisant doing, p. pr. See\nFeasible.] (Law)\n\nDefn: Doing injury; trespassing, as cattle. Blackstone."
     ],
-    "references": [
-      "DAMAGE FEASANT"
-    ]
+    "references": []
   },
   {
     "spellings": "DAMAN",
@@ -4078,7 +4070,6 @@
     ],
     "references": [
       "DAMASCUS",
-      "DAMASCUS STEEL",
       "DAMASK"
     ]
   },
@@ -4561,9 +4552,7 @@
     "variants": [
       "DAMP OFF\nDamp\" off`.\n\nDefn: To decay and perish through excessive moisture."
     ],
-    "references": [
-      "DAMP OFF"
-    ]
+    "references": []
   },
   {
     "spellings": "DAMPY",
@@ -6352,9 +6341,7 @@
     "variants": [
       "DANDIE DINMONT; DANDIE\nDan\"die Din\"mont, or Dan\"die, n.\n\n1.\n\nDefn: In Scott's \"Guy Mannering\", a Border farmer of eccentric but\nfine character, who owns two terriers claimed to be the progenitors\nof the Dandie Dinmont terriers.\n\n2.  One of a breed of terriers with short legs, long body, and rough\ncoat, originating in the country about the English and Scotch border."
     ],
-    "references": [
-      "DANDIE DINMONT; DANDIE"
-    ]
+    "references": []
   },
   {
     "spellings": "DANDIFIED",
@@ -9035,9 +9022,7 @@
     "variants": [
       "DATE LINE\nDate line.\n\nDefn: The hypothetical line on the surface of the earth fixed by\ninternational or general agreement as a boundary on one side of which\nthe same day shall have a different name and date in the calendar\nfrom its name and date on the other side.\n\n Speaking generally, the date line coincides with the meridian 180º\nfrom Greenwich. It deflects between north latitudes 80º and 45º, so\nthat all Asia lies to the west, all North America, including the\nAleutian Islands, to the east of the line; and between south\nlatitudes 12º and 56º, so that Chatham Island and the Tonga group lie\nto the west of it. A vessel crossing this line to the westward sets\nthe date forward by one day, as from Sunday to Monday. A vessel\ncrossing the line to the eastward sets the date back by one day, as\nfrom Monday to Sunday. Hawaii has the same day name as San Francisco;\nManila, the same day name as Australia, and this is one day later\nthan the day of Hawaii. Thus when it is Monday May 1st at San\nFrancisco it is Tuesday may 2d at Manila."
     ],
-    "references": [
-      "DATE LINE"
-    ]
+    "references": []
   },
   {
     "spellings": "DATER",
@@ -9498,7 +9483,6 @@
       "DAVY JONES\nDa\"vy Jones\".\n\nDefn: The spirit of the sea; sea devil; -- a term used by sailors.\nThis same Davy Jones, according to the mythology of sailors, is the\nfiend that presides over all the evil spirits of the deep, and is\nseen in various shapes warning the devoted wretch of death and woe.\nSmollett.\nDavy Jones's Locker, the ocean, or bottom of the ocean.\n -- Gone to Davy Jones's Locker, dead, and buried in the sea; thrown\noverboard."
     ],
     "references": [
-      "DAVY JONES",
       "LOCKER"
     ]
   },
@@ -9508,7 +9492,6 @@
       "DAVY LAMP\nDa\"vy lamp`.\n\nDefn: See Safety lamp, under Lamp."
     ],
     "references": [
-      "DAVY LAMP",
       "LAMP"
     ]
   },
@@ -10665,7 +10648,6 @@
       "DAY LILY\nDay\" lil`y. (Bot.)\n(a) A genus of plants (Hemerocallis) closely resembling true lilies,\nbut having tuberous rootstocks instead of bulbs. The common species\nhave long narrow leaves and either yellow or tawny-orange flowers.\n(b) A genus of plants (Funkia) differing from the last in having\novate veiny leaves, and large white or blue flowers."
     ],
     "references": [
-      "DAY LILY",
       "HEMEROCALLIS"
     ]
   },
@@ -11435,8 +11417,7 @@
       "DEAD BEAT\nDead` beat\".\n\nDefn: See Beat, n., 7. [Low, U.S.]"
     ],
     "references": [
-      "BEAT",
-      "DEAD BEAT"
+      "BEAT"
     ]
   },
   {
@@ -13714,9 +13695,7 @@
     "variants": [
       "DE BENE ESSE\nDe be\"ne es\"se. Etym: [L.] (Law)\n\nDefn: Of well being; of formal sufficiency for the time;\nconditionally; provisionally. Abbott."
     ],
-    "references": [
-      "DE BENE ESSE"
-    ]
+    "references": []
   },
   {
     "spellings": "DEBENTURE",
@@ -13740,9 +13719,7 @@
     "variants": [
       "DEBENTURE STOCK\nDebenture stock. (Finance)\n\nDefn: The debt or series of debts, collectively, represented by a\nseries of debentures; a debt secured by a trust deed of property for\nthe benefit of the holders of shares in the debt or of a series of\ndebentures. By the terms of much debenture stock the holders are not\nentitled to demand payment until the winding up of the company or\ndefault in payment; in the winding up of the company or default in\npayment; in the case of railway debentures, they cannot demand\npayment of the principal, and the debtor company cannot redeem the\nstock, except by authority of an act of Parliament. [Eng.]"
     ],
-    "references": [
-      "DEBENTURE STOCK"
-    ]
+    "references": []
   },
   {
     "spellings": "DEBILE",
@@ -16790,7 +16767,6 @@
       "DECKLE EDGE\nDec\"kle edge`.\n\nDefn: The rough, untrimmed edge of paper left by the deckle; also, a\nrough edge in imitation of this."
     ],
     "references": [
-      "DECKLE EDGE",
       "DECKLE-EDGED"
     ]
   },
@@ -18123,7 +18099,6 @@
     ],
     "references": [
       "DECORATION",
-      "DECORATION DAY",
       "MEMORIAL",
       "MEMORIAL DAY"
     ]
@@ -19580,9 +19555,7 @@
     "variants": [
       "DEED POLL\nDeed\" poll`. (Law)\n\nDefn: A deed of one part, or executed by only one party, and\ndistinguished from an indenture by having the edge of the parchment\nor paper cut even, or polled as it was anciently termed, instead of\nbeing indented. Burrill."
     ],
-    "references": [
-      "DEED POLL"
-    ]
+    "references": []
   },
   {
     "spellings": "DEEDY",
@@ -20574,7 +20547,6 @@
       "DE FACTO\nDe` fac\"to. Etym: [L.]\n\nDefn: Actually; in fact; in reality; as, a king de facto, --\ndistinguished from a king de jure, or by right."
     ],
     "references": [
-      "DE FACTO",
       "FACTO"
     ]
   },
@@ -25203,8 +25175,7 @@
       "DE JURE\nDe` ju\"re. Etym: [L.]\n\nDefn: By right; of right; by law; -- often opposed to be facto."
     ],
     "references": [
-      "DE FACTO",
-      "DE JURE"
+      "DE FACTO"
     ]
   },
   {
@@ -25625,8 +25596,7 @@
       "DEL CREDERE\nDel` cred\"er*e. Etym: [It., of belief or trust.] (Mercantile Law)\n\nDefn: An agreement by which an agent or factor, in consideration of\nan additional premium or commission (called a del credere\ncommission), engages, when he sells goods on credit, to insure,\nwarrant, or guarantee to his principal the solvency of the purchaser,\nthe engagement of the factor being to pay the debt himself if it is\nnot punctually discharged by the buyer when it becomes due."
     ],
     "references": [
-      "COMMISSION",
-      "DEL CREDERE"
+      "COMMISSION"
     ]
   },
   {
@@ -27512,7 +27482,6 @@
       "DELLA CRUSCA\nDel\"la Crus\"ca.\n\nDefn: A shortened form of Academia della Crusca, an academy in\nFlorescence, Italy, founded in the 16th century, especially for\nconversing the purity of the Italian language.\n\nNote: The Accademia della Crusca (literally, academy of the bran or\nchaff) was so called in allusion to its chief object of bolting or\npurifying the national language."
     ],
     "references": [
-      "DELLA CRUSCA",
       "DELLACRUSCAN"
     ]
   },
@@ -27646,9 +27615,7 @@
     "variants": [
       "DELSARTE; DELSARTE SYSTEM\nDel*sarte\", n., or Delsarte system.\n\nDefn: A system of calisthenics patterned on the theories of François\nDelsarte (1811 -- 71), a French teacher of dramatic and musical\nexpression."
     ],
-    "references": [
-      "DELSARTE; DELSARTE SYSTEM"
-    ]
+    "references": []
   },
   {
     "spellings": "DELTA",
@@ -27669,7 +27636,6 @@
       "DELTA CONNECTION\nDelta connection. (Elec.)\n\nDefn: One of the usual forms or methods for connecting apparatus to a\nthree-phase circuit, the three corners of the delta or triangle, as\ndiagrammatically represented, being connected to the three wires of\nthe supply circuit."
     ],
     "references": [
-      "DELTA CONNECTION",
       "DELTA CURRENT"
     ]
   },
@@ -27678,9 +27644,7 @@
     "variants": [
       "DELTA CURRENT\nDelta current. (Elec.)\n\nDefn: The current flowing through a delta connection."
     ],
-    "references": [
-      "DELTA CURRENT"
-    ]
+    "references": []
   },
   {
     "spellings": "DELTAFICATION",
@@ -30246,7 +30210,6 @@
       "DENMARK SATIN\nDen\"mark sat\"in.\n\nDefn: See under Satin."
     ],
     "references": [
-      "DENMARK SATIN",
       "SATIN"
     ]
   },
@@ -31960,9 +31923,7 @@
     "variants": [
       "DEPARTMENT STORE\nDe*part\"ment store.\n\nDefn: A store keeping a great variety of goods which are arranged in\nseveral departments, esp. one with dry goods as the principal stock."
     ],
-    "references": [
-      "DEPARTMENT STORE"
-    ]
+    "references": []
   },
   {
     "spellings": "DEPARTURE",
@@ -34833,9 +34794,7 @@
     "variants": [
       "DERBYSHIRE SPAR\nDer\"by*shire spar\". (Min.)\n\nDefn: A massive variety of fluor spar, found in Derbyshire, England,\nand wrought into vases and other ornamental work."
     ],
-    "references": [
-      "DERBYSHIRE SPAR"
-    ]
+    "references": []
   },
   {
     "spellings": "DERDOING",
@@ -34957,9 +34916,7 @@
     "variants": [
       "DE RIGUEUR\nDe ri`gueur\". [F. See 2d Rigor.]\n\nDefn: According to strictness (of etiquette, rule, or the like);\nobligatory; strictly required."
     ],
-    "references": [
-      "DE RIGUEUR"
-    ]
+    "references": []
   },
   {
     "spellings": "DERISION",
@@ -40977,9 +40934,7 @@
     "variants": [
       "DETECTOR BAR\nDe*tect\"or bar. (Railroads)\n\nDefn: A bar, connected with a switch, longer than the distance\nbetween any two consecutive wheels of a train (45 to 50 feet), laid\ninside a rail and operated by the wheels so that the switch cannot be\nthrown until all the train is past the switch."
     ],
-    "references": [
-      "DETECTOR BAR"
-    ]
+    "references": []
   },
   {
     "spellings": "DETENEBRATE",
@@ -43585,7 +43540,6 @@
     "references": [
       "DABCHICK",
       "DEVIL",
-      "DEVIL-DIVER; DEVIL BIRD",
       "SWIFT"
     ]
   },
@@ -43695,8 +43649,7 @@
     ],
     "references": [
       "DARN",
-      "DEVIL",
-      "DEVIL'S DARNING-NEEDLE"
+      "DEVIL"
     ]
   },
   {
@@ -44699,9 +44652,7 @@
     "variants": [
       "DEWAR VESSEL\nDew\"ar ves`sel (du\"er). [After Sir James Dewar, British physicist.]\n\nDefn: A double-walled glass vessel for holding liquid air, etc.,\nhaving the space between the walls exhausted so as to prevent\nconduction of heat, and sometimes having the glass silvered to\nprevent absorption of radiant heat; -- called also, according to the\nparticular shape, Dewar bulb, Dewar tube, etc."
     ],
-    "references": [
-      "DEWAR VESSEL"
-    ]
+    "references": []
   },
   {
     "spellings": "DEWBERRY",
@@ -46770,9 +46721,7 @@
     "variants": [
       "DIAMOND ANNIVERSARY; DIAMOND JUBILEE\nDiamond anniversary, jubilee, etc.\n\nDefn: One celebrated upon the completion of sixty, or, according to\nsome, seventy-five, years from the beginning of the thing\ncommemorated."
     ],
-    "references": [
-      "DIAMOND ANNIVERSARY; DIAMOND JUBILEE"
-    ]
+    "references": []
   },
   {
     "spellings": "DIAMOND-BACK",
@@ -46815,9 +46764,7 @@
     "variants": [
       "DIAMOND STATE\nDiamond State.\n\nDefn: Delaware; -- a nickname alluding to its small size."
     ],
-    "references": [
-      "DIAMOND STATE"
-    ]
+    "references": []
   },
   {
     "spellings": "DIAMYLENE",
@@ -49982,7 +49929,6 @@
       "DIESEL ENGINE; DIESEL MOTOR\nDie\"sel en`gine or mo`tor. [After Dr. Rudolf Diesel, of Munich, the\ninventor.]\n\nDefn: A type of internal-combustion engine in which the air drawn in\nby the suction stroke is so highly compressed that the heat generated\nignites the fuel (usually crude oil), the fuel being automatically\nsprayed into the cylinder under pressure. The Diesel engine has a\nvery high thermal efficiency."
     ],
     "references": [
-      "DIESEL ENGINE; DIESEL MOTOR",
       "INTERNAL-COMBUSTION; INTERNAL-COMBUSTION ENGINE",
       "SEMI-DIESEL"
     ]
@@ -50006,9 +49952,7 @@
     "variants": [
       "DIES IRAE\nDi\"es I\"ræ.\n\nDefn: Day of wrath; -- the name and beginning of a famous mediæval\nLatin hymn on the Last Judgment."
     ],
-    "references": [
-      "DIES IRAE"
-    ]
+    "references": []
   },
   {
     "spellings": "DIESIS",
@@ -50024,9 +49968,7 @@
     "variants": [
       "DIES JURIDICUS\nDi\"es ju*rid\"i*cus; pl. Dies juridici. Etym: [L.] (Law)\n\nDefn: A court day."
     ],
-    "references": [
-      "DIES JURIDICUS"
-    ]
+    "references": []
   },
   {
     "spellings": "DIES NON",
@@ -50034,7 +49976,6 @@
       "DIES NON\nDi\"es non\". Etym: [L. dies non juridicus.] (Law)\n\nDefn: A day on which courts are not held, as Sunday or any legal\nholiday."
     ],
     "references": [
-      "DIES NON",
       "GRAND"
     ]
   },
@@ -56193,9 +56134,7 @@
     "variants": [
       "DINGDONG THEORY\nDing\"dong` the\"o*ry. (Philol.)\n\nDefn: The theory which maintains that the primitive elements of\nlanguage are reflex expressions induced by sensory impressions; that\nis, as stated by Max Müller, the creative faculty gave to each\ngeneral conception as it thrilled for the first time through the\nbrain a phonetic expression; -- jocosely so called from the analogy\nof the sound of a bell induced by the stroke of the clapper."
     ],
-    "references": [
-      "DINGDONG THEORY"
-    ]
+    "references": []
   },
   {
     "spellings": "DINGEY; DINGY; DINGHY",
@@ -57495,8 +57434,7 @@
     ],
     "references": [
       "BONE",
-      "CORIDINE",
-      "DIPPEL'S OIL"
+      "CORIDINE"
     ]
   },
   {
@@ -58230,7 +58168,6 @@
     ],
     "references": [
       "DIRECT",
-      "DIRECT ACTION",
       "ELECTROLYZE",
       "HYDROTROPE",
       "INJECTOR",
@@ -58254,7 +58191,6 @@
       "DIRECT CURRENT\nDirect current. (Elec.)\n (a) A current flowing in one direction only; -- distinguished from\nalternating current. When steady and not pulsating a direct current\nis often called a continuous current.\n (b) A direct induced current, or momentary current of the same\ndirection as the inducing current, produced by stopping or removing\nthe latter; also, a similar current produced by removal of a magnet."
     ],
     "references": [
-      "DIRECT CURRENT",
       "IMPEDANCE",
       "VOLT AMPERE"
     ]
@@ -59146,7 +59082,6 @@
       "DIRECT NOMINATION\nDirect nomination. (Political Science)\n\nDefn: The nomination or designation of candidates for public office\nby direct popular vote rather than through the action of a convention\nor body of elected nominating representatives or delegates. The term\nis applied both to the nomination of candidates without any\nnominating convention, and, loosely, to the nomination effected, as\nin the case of candidates for president or senator of the United\nStates, by the election of nominating representatives pledged or\ninstructed to vote for certain candidates dssignated by popular vote."
     ],
     "references": [
-      "DIRECT NOMINATION",
       "DIRECT PRIMARY"
     ]
   },
@@ -59155,9 +59090,7 @@
     "variants": [
       "DIRECTOIRE STYLE\nDi`rec`toire\" style. (Dressmaking)\n\nDefn: A style of dress prevalent at the time of the French Directory,\ncharacterized by great extravagance of design and imitating the Greek\nand Roman costumes."
     ],
-    "references": [
-      "DIRECTOIRE STYLE"
-    ]
+    "references": []
   },
   {
     "spellings": "DIRECTOR",
@@ -59249,9 +59182,7 @@
     "variants": [
       "DIRECT PRIMARY\nDirect primary. (Political Science)\n\nDefn: A primary by which direct nominations of candidates for office\nare made."
     ],
-    "references": [
-      "DIRECT PRIMARY"
-    ]
+    "references": []
   },
   {
     "spellings": "DIRECTRESS",
@@ -65398,8 +65329,7 @@
       "DISCOVERY DAY\nDis*cov\"er*y Day.\n\nDefn: = Columbus Day, above."
     ],
     "references": [
-      "COLUMBUS DAY",
-      "DISCOVERY DAY"
+      "COLUMBUS DAY"
     ]
   },
   {
@@ -69759,9 +69689,7 @@
     "variants": [
       "DISK CLUTCH\nDisk clutch. (Engin.)\n\nDefn: A friction clutch in which the gripping surfaces are disks or\nmore or less resemble disks."
     ],
-    "references": [
-      "DISK CLUTCH"
-    ]
+    "references": []
   },
   {
     "spellings": "DISKINDNESS",
@@ -83441,9 +83369,7 @@
     "variants": [
       "DIVINITY CALF\nDi*vin\"i*ty calf`. (Bookbinding)\n\nDefn: Calf stained dark brown and worked without gilding, often used\nfor theological books."
     ],
-    "references": [
-      "DIVINITY CALF"
-    ]
+    "references": []
   },
   {
     "spellings": "DIVINIZATION",
@@ -85819,9 +85745,7 @@
     "variants": [
       "DOBELL'S SOLUTION\nDo*bell's\" so*lu\"tion. (Med.)\n\nDefn: An aqueous solution of carbolic acid, borax, sodium\nbicarbonate, and glycerin, used as a spray in diseases of the nose\nand throat."
     ],
-    "references": [
-      "DOBELL'S SOLUTION"
-    ]
+    "references": []
   },
   {
     "spellings": "DOBSON",
@@ -87047,9 +86971,7 @@
     "variants": [
       "DOE, JOHN\nDoe, John. (Law)\n\nDefn: The fictitious lessee acting as plaintiff in the common-law\naction of ejectment, the fictitious defendant being usually\ndenominated Richard Roe. Hence, a fictitious name for a party, real\nor fictitious, to any action or proceeding."
     ],
-    "references": [
-      "DOE, JOHN"
-    ]
+    "references": []
   },
   {
     "spellings": "DOER",
@@ -87912,9 +87834,7 @@
     "variants": [
       "DOG BEE\nDog\" bee`.\n\nDefn: A male or drone bee. Halliwell."
     ],
-    "references": [
-      "DOG BEE"
-    ]
+    "references": []
   },
   {
     "spellings": "DOGBERRY",
@@ -87955,7 +87875,6 @@
       "CANICULAR",
       "CICADA",
       "DAY",
-      "DOG DAY; DOGDAY",
       "DOG DAYS",
       "DOG STAR"
     ]
@@ -87968,7 +87887,6 @@
     "references": [
       "CANICULAR",
       "DOG DAY; DOGDAY",
-      "DOG DAYS",
       "DOG STAR"
     ]
   },
@@ -88031,7 +87949,6 @@
       "DOG FANCIER\nDog\" fan`cier.\n\nDefn: One who has an unusual fancy for, or interest in, dogs; also,\none who deals in dogs."
     ],
     "references": [
-      "DOG FANCIER",
       "FANCIER"
     ]
   },
@@ -88381,7 +88298,6 @@
     ],
     "references": [
       "CRAB",
-      "DOG'S-TAIL GRASS",
       "GOLDSEED"
     ]
   },
@@ -88396,7 +88312,6 @@
       "CYNIC; CYNICAL",
       "DOG",
       "DOG DAYS",
-      "DOG STAR",
       "SIRIUS",
       "SOTHIAC; SOTHIC",
       "SWART"
@@ -89030,7 +88945,6 @@
       "DOLLY VARDEN\nDol\"ly Var\"den.\n\n1. A character in Dickens's novel \"Barnaby Rudge,\" a beautiful,\nlively, and coquettish girl who wore a cherry-colored mantle and\ncherry-colored ribbons.\n\n2. A style of light, bright-figured dress goods for women; also, a\nstyle of dress. Dolly Varden trout (Zoöl.), a trout of northwest\nAmerica; -- called also bull trout, malma, and red-spotted trout. See\nMalma."
     ],
     "references": [
-      "DOLLY VARDEN",
       "MALMA",
       "TROUT"
     ]
@@ -90072,9 +89986,7 @@
     "variants": [
       "DOMINION DAY\nDo*min\"ion Day.\n\nDefn: In Canada, a legal holiday, July lst, being the anniversary of\nthe proclamation of the formation of the Dominion in 1867."
     ],
-    "references": [
-      "DOMINION DAY"
-    ]
+    "references": []
   },
   {
     "spellings": "DOMINO",
@@ -90093,9 +90005,7 @@
     "variants": [
       "DOMINO WHIST\nDom\"i*no whist.\n\nDefn: A game of cards in which the suits are played in sequence,\nbeginning with a 5 or 9, the player who gets rid of his cards first\nbeing the winner."
     ],
-    "references": [
-      "DOMINO WHIST"
-    ]
+    "references": []
   },
   {
     "spellings": "DOMINUS",
@@ -91097,7 +91007,6 @@
       "DOOB GRASS\nDoob\" grass`. Etym: [Hind. d.] (Bot.)\n\nDefn: A perennial, creeping grass (Cynodon dactylon), highly prized,\nin Hindostan, as food for cattle, and acclimated in the United\nStates. [Written also doub grass.]"
     ],
     "references": [
-      "DOOB GRASS",
       "DOUB GRASS"
     ]
   },
@@ -91216,7 +91125,6 @@
       "DOOM PALM\nDoom\" palm`. Etym: [Ar. daum, dum: cf. F. doume.] (Bot.)\n\nDefn: A species of palm tree (Hyphæne Thebaica), highly valued for\nthe fibrous pulp of its fruit, which has the flavor of gingerbread,\nand is largely eaten in Egypt and Abyssinia. [Written also doum\npalm.]"
     ],
     "references": [
-      "DOOM PALM",
       "DOUM PALM",
       "GINGERBREAD"
     ]
@@ -91924,9 +91832,7 @@
     "variants": [
       "DORKING FOWL\nDor\"king fowl`. Etym: [From the town of Dorking in England.] (Zoöl.)\n\nDefn: One of a breed of large-bodied domestic fowls, having five\ntoes, or the hind toe double. There are several strains, as the\nwhite, gray, and silver-gray. They are highly esteemed for the table."
     ],
-    "references": [
-      "DORKING FOWL"
-    ]
+    "references": []
   },
   {
     "spellings": "DORMANCY",
@@ -91975,7 +91881,6 @@
     ],
     "references": [
       "DORMANT",
-      "DORMER; DORMER WINDOW",
       "LUCARNE",
       "LUTHERN"
     ]
@@ -92520,9 +92425,7 @@
     "variants": [
       "DOSS HOUSE\nDoss house.\n\nDefn: A cheap lodging house.\n\nThey [street Arabs] consort together and sleep in low doss houses\nwhere they meet with all kinds of villainy.\nW. Besant."
     ],
-    "references": [
-      "DOSS HOUSE"
-    ]
+    "references": []
   },
   {
     "spellings": "DOSSIER",
@@ -93104,7 +93007,6 @@
       "DOTTING PEN\nDot\"ting pen`.\n\nDefn: See under Pun."
     ],
     "references": [
-      "DOTTING PEN",
       "PEN"
     ]
   },
@@ -93157,7 +93059,6 @@
     ],
     "references": [
       "BIBLE",
-      "DOUAY BIBLE",
       "PARALIPOMENON",
       "RHEMISH",
       "VULGATE"
@@ -93169,8 +93070,7 @@
       "DOUB GRASS\nDoub\" grass`.(Bot.)\n\nDefn: Doob grass."
     ],
     "references": [
-      "DOOB GRASS",
-      "DOUB GRASS"
+      "DOOB GRASS"
     ]
   },
   {
@@ -93573,7 +93473,6 @@
       "DOUBLE-BEAT VALVE\nDou\"ble-beat` valve\".\n\nDefn: See under Valve."
     ],
     "references": [
-      "DOUBLE-BEAT VALVE",
       "VALVE"
     ]
   },
@@ -93601,9 +93500,7 @@
     "variants": [
       "DOUBLE DEALER\nDou\"ble deal\"er.\n\nDefn: One who practices double dealing; a deceitful, trickish person.\nL'Estrange."
     ],
-    "references": [
-      "DOUBLE DEALER"
-    ]
+    "references": []
   },
   {
     "spellings": "DOUBLE DEALING",
@@ -93613,7 +93510,6 @@
     "references": [
       "DEALING",
       "DOUBLE DEALER",
-      "DOUBLE DEALING",
       "DUPLICITY",
       "FALSENESS"
     ]
@@ -93676,9 +93572,7 @@
     "variants": [
       "DOUBLE FIRST\nDou\"ble first`. (Eng. Universities)\n(a) A degree of the first class both in classics and mathematics.\n(b) One who gains at examinations the highest honor both in the\nclassics and the mathematics. Beaconsfield."
     ],
-    "references": [
-      "DOUBLE FIRST"
-    ]
+    "references": []
   },
   {
     "spellings": "DOUBLEGANGER",
@@ -93756,9 +93650,7 @@
     "variants": [
       "DOUBLE PEDRO\nDouble pedro.\n\nDefn: Cinch (the game)."
     ],
-    "references": [
-      "DOUBLE PEDRO"
-    ]
+    "references": []
   },
   {
     "spellings": "DOUBLE-QUICK",
@@ -94601,9 +94493,7 @@
     "variants": [
       "DOUM PALM\nDoum\" palm` (doom\" päm`).\n\nDefn: See Doom palm."
     ],
-    "references": [
-      "DOUM PALM"
-    ]
+    "references": []
   },
   {
     "spellings": "DOUPE",
@@ -94787,7 +94677,6 @@
       "DOVE PLANT\nDove\" plant`. (Bot.)\n\nDefn: A Central American orchid (Peristeria elata), having a flower\nstem five or six feet high, with numerous globose white fragrant\nflowers. The column in the center of the flower resembles a dove; --\ncalled also Holy Spirit plant."
     ],
     "references": [
-      "DOVE PLANT",
       "HOLY",
       "PERISTERIA"
     ]
@@ -94797,9 +94686,7 @@
     "variants": [
       "DOVER'S POWDER\nDo\"ver's Pow\"der. Etym: [From Dr. Dover, an English physician.]\n(Med.)\n\nDefn: A powder of ipecac and opium, compounded, in the United States,\nwith sugar of milk, but in England (as formerly in the United States)\nwith sulphate of potash, and in France (as in Dr. Dover's original\nprescription) with nitrate and sulphate of potash and licorice. It is\nan anodyne diaphoretic."
     ],
-    "references": [
-      "DOVER'S POWDER"
-    ]
+    "references": []
   },
   {
     "spellings": "DOVE'S-FOOT",
@@ -97278,9 +97165,7 @@
     "variants": [
       "DRAG LINE; DRAG ROPE\nDrag line or drag rope . (Aëronautics)\n\nDefn: A guide rope."
     ],
-    "references": [
-      "DRAG LINE; DRAG ROPE"
-    ]
+    "references": []
   },
   {
     "spellings": "DRAGLINK",
@@ -97432,7 +97317,6 @@
       "DRACONIN",
       "DRACONTIC",
       "DRAGON",
-      "DRAGON'S BLOOD; DRAGON'S HEAD; DRAGON'S TAIL",
       "NODE"
     ]
   },
@@ -97891,9 +97775,7 @@
     "variants": [
       "DRAMATIS PERSONAE\nDram\"a*tis per*so\"næ. Etym: [L.]\n\nDefn: The actors in a drama or play."
     ],
-    "references": [
-      "DRAMATIS PERSONAE"
-    ]
+    "references": []
   },
   {
     "spellings": "DRAMATIST",
@@ -98001,9 +97883,7 @@
     "variants": [
       "DRAP D'ETE\nDrap` d'é*té\". Etym: [F., clot of summer.]\n\nDefn: A thin woolen fabric, twilled like merino."
     ],
-    "references": [
-      "DRAP D'ETE"
-    ]
+    "references": []
   },
   {
     "spellings": "DRAPE",
@@ -99273,7 +99153,6 @@
     ],
     "references": [
       "DRAWING",
-      "DRAWING KNIFE; DRAWKNIFE",
       "DRAWSHAVE",
       "KNIFE",
       "SHAVE",
@@ -100526,9 +100405,7 @@
     "variants": [
       "DRESDEN WARE\nDres\"den ware`.\n\nDefn: A superior kind of decorated porcelain made near Dresden in\nSaxony."
     ],
-    "references": [
-      "DRESDEN WARE"
-    ]
+    "references": []
   },
   {
     "spellings": "DRESS",
@@ -100950,7 +100827,6 @@
     ],
     "references": [
       "CIRCLE",
-      "DRESS CIRCLE",
       "PARQUET"
     ]
   },
@@ -100961,8 +100837,7 @@
     ],
     "references": [
       "BODY",
-      "CLAW",
-      "DRESS COAT"
+      "CLAW"
     ]
   },
   {
@@ -100991,7 +100866,6 @@
       "CASHMERETTE",
       "DEBEIGE",
       "DOLLY VARDEN",
-      "DRESS GOODS",
       "GOOD",
       "GRISAILLE",
       "PIQUE",
@@ -101746,8 +101620,7 @@
       "DRILL PRESS\nDrill\" press` .\n\nDefn: A machine for drilling holes in metal, the drill being pressed\nto the metal by the action of a screw."
     ],
     "references": [
-      "DRILL",
-      "DRILL PRESS"
+      "DRILL"
     ]
   },
   {
@@ -103290,7 +103163,6 @@
     ],
     "references": [
       "DOG BEE",
-      "DRONE BEE",
       "DRONE FLY"
     ]
   },
@@ -103300,7 +103172,6 @@
       "DRONE FLY\nDrone\" fly`. (Zoöl.)\n\nDefn: A dipterous insect (Eristalis tenax), resembling the drone bee.\nSee Eristalis."
     ],
     "references": [
-      "DRONE FLY",
       "ERISTALIS"
     ]
   },
@@ -104217,8 +104088,7 @@
       "DRUDGING BOX\nDrudg\"ing box`.\n\nDefn: See Dredging box."
     ],
     "references": [
-      "DREDGER",
-      "DRUDGING BOX"
+      "DREDGER"
     ]
   },
   {
@@ -104565,8 +104435,7 @@
       "DRUM MAJOR\nDrum\" ma\"jor\n\nDefn: .\n\n1. The chief or first drummer of a regiment; an instructor of\ndrummers.\n\n2. The marching leader of a military band. [U.S.]\n\n3. A noisy gathering. [R.] See under Drum, n.,\n\n4."
     ],
     "references": [
-      "DRUM",
-      "DRUM MAJOR"
+      "DRUM"
     ]
   },
   {
@@ -104601,7 +104470,6 @@
     ],
     "references": [
       "CALCIUM",
-      "DRUMMOND LIGHT",
       "OXYCALCIUM"
     ]
   },
@@ -104619,9 +104487,7 @@
     "variants": [
       "DRUM WINDING\nDrum winding. (Elec.)\n\nDefn: A method of armature winding in which the wire is wound upon\nthe outer surface of a cylinder or drum from end to end of the\ncylinder; -- distinguished from ring winding, etc."
     ],
-    "references": [
-      "DRUM WINDING"
-    ]
+    "references": []
   },
   {
     "spellings": "DRUNK",
@@ -105310,7 +105176,6 @@
     "references": [
       "DOCK",
       "DRY",
-      "DRY DOCK",
       "FLOATING"
     ]
   },
@@ -105352,7 +105217,6 @@
     "references": [
       "DEALER",
       "DEPARTMENT STORE",
-      "DRY GOODS",
       "GOOD"
     ]
   },
@@ -105473,7 +105337,6 @@
       "DRY NURSE\nDry\" nurse`.\n\nDefn: A nurse who attends and feeds a child by hand; -- in\ndistinction from a wet nurse, who suckles it."
     ],
     "references": [
-      "DRY NURSE",
       "NURSE",
       "WET NURSE"
     ]
@@ -105820,7 +105683,6 @@
       "DUCES TECUM\nDu\"ces te\"cum. Etym: [L., bring with thee.]\n\nDefn: A judicial process commanding a person to appear in court and\nbring with him some piece of evidence or other thing to be produced\nto the court."
     ],
     "references": [
-      "DUCES TECUM",
       "SUBPOENA"
     ]
   },
@@ -105846,18 +105708,14 @@
     "variants": [
       "DUCHESSE D'ANGOULEME\nDu`chesse\" d'An`gou`lême\". Etym: [F.] (Bot.)\n\nDefn: A variety of pear of large size and excellent flavor."
     ],
-    "references": [
-      "DUCHESSE D'ANGOULEME"
-    ]
+    "references": []
   },
   {
     "spellings": "DUCHESSE LACE",
     "variants": [
       "DUCHESSE LACE\nDu`chesse\" lace.\n\nDefn: A beautiful variety of Brussels pillow lace made originally in\nBelgium and resembling Honiton guipure. It is worked with fine thread\nin large sprays, usually of the primrose pattern, with much raised\nwork."
     ],
-    "references": [
-      "DUCHESSE LACE"
-    ]
+    "references": []
   },
   {
     "spellings": "DUCHY",
@@ -107061,9 +106919,7 @@
     "variants": [
       "DUFFEL BAG\nDuffel bag.\n\nDefn: A sack to hold miscellaneous articles, as tools, supplies, or\nthe like."
     ],
-    "references": [
-      "DUFFEL BAG"
-    ]
+    "references": []
   },
   {
     "spellings": "DUFFER",
@@ -108109,9 +107965,7 @@
     "variants": [
       "DUMDUM BULLET\nDum\"dum bul\"let. (Mil.)\n\nDefn: A kind of manstopping bullet; -- so named from Dumdum, in\nIndia, where bullets are manufactured for the Indian army."
     ],
-    "references": [
-      "DUMDUM BULLET"
-    ]
+    "references": []
   },
   {
     "spellings": "DUMETOSE",
@@ -108254,9 +108108,7 @@
     "variants": [
       "DUMPY LEVEL\nDump\"y lev\"el. (Surv.)\n\nDefn: A level having a short telescope (hence its name) rigidly fixed\nto a table capable only of rotatory movement in a horizontal plane.\nThe telescope is usually an inverting one. It is sometimes called the\nTroughton level, from the name of the inventor, and a variety\nimproved by one Gavatt is known as the Gavatt level."
     ],
-    "references": [
-      "DUMPY LEVEL"
-    ]
+    "references": []
   },
   {
     "spellings": "DUN",
@@ -109186,7 +109038,6 @@
       "ARACHNOID",
       "DURA",
       "DURAL",
-      "DURA MATER",
       "FALX",
       "MATER",
       "MENINGES",
@@ -111051,7 +110902,6 @@
     ],
     "references": [
       "BALANCE",
-      "D VALVE",
       "EQUILIBRIUM",
       "PILOT VALVE",
       "POTLID",

--- a/output/wordDisplayData#E.json
+++ b/output/wordDisplayData#E.json
@@ -6357,7 +6357,6 @@
     ],
     "references": [
       "ARLES",
-      "EARLES PENNY",
       "EARNEST"
     ]
   },
@@ -6390,7 +6389,6 @@
     "references": [
       "ATTACH",
       "CHIVALRY",
-      "EARL MARSHAL",
       "HERALD",
       "MARSHAL"
     ]
@@ -8258,7 +8256,6 @@
     ],
     "references": [
       "AMIANTHUS",
-      "EARTH FLAX",
       "FLAX",
       "SPAAD"
     ]
@@ -8428,8 +8425,7 @@
       "EARTH SHINE\nEarth\" shine`.\n\nDefn: See Earth light, under Earth."
     ],
     "references": [
-      "EARTH",
-      "EARTH SHINE"
+      "EARTH"
     ]
   },
   {
@@ -9742,9 +9738,7 @@
     "variants": [
       "EASTER LILY\nEas\"ter lil`y. (Bot.) Any one of various lilies or lilylike flowers\nwhich bloom about Easter; specif.:\n (a) The common white lily (Lilium candidum), called also\nAnnunciation lily.\n (b) The larger white lily (Lilium longiflorum eximium, syn. L.\nHarrisii) called also Bermuda lily.\n (c) The daffodil (Narcissus Pseudo-Narcissus).\n (d) The Atamasco lily."
     ],
-    "references": [
-      "EASTER LILY"
-    ]
+    "references": []
   },
   {
     "spellings": "EASTERLING",
@@ -9961,7 +9955,6 @@
     "references": [
       "DETEST",
       "EASTERN",
-      "EASTERN CHURCH",
       "ECCLESIARCH",
       "EXARCH",
       "FILIOQUE",
@@ -10018,7 +10011,6 @@
       "COOLY; COOLIE",
       "CUCUMBER",
       "DELUNDUNG",
-      "EAST INDIAN",
       "EAST-INSULAR",
       "EGGPLANT",
       "ELEPHANT",
@@ -10782,9 +10774,7 @@
     "variants": [
       "EAU DE COLOGNE\nEau` de Co*logne\". Etym: [F. eau water (L. aqua) + de of + Cologne.]\n\nDefn: Same as Cologne."
     ],
-    "references": [
-      "EAU DE COLOGNE"
-    ]
+    "references": []
   },
   {
     "spellings": "EAU DE VIE",
@@ -10792,8 +10782,7 @@
       "EAU DE VIE\nEau` de vie\". Etym: [F., water of life; eau (L. aqua) water + de of +\nvie (L. vita) life.]\n\nDefn: French name for brandy. Cf. Aqua vitæ, under Aqua. Bescherelle."
     ],
     "references": [
-      "AQUA",
-      "EAU DE VIE"
+      "AQUA"
     ]
   },
   {
@@ -10801,9 +10790,7 @@
     "variants": [
       "EAU FORTE\nEau` forte\" (o` fort\"). [F., strong water, nitric acid (which is used\nin etching plates).] (Art)\n\nDefn: An etching or a print from an etched plate."
     ],
-    "references": [
-      "EAU FORTE"
-    ]
+    "references": []
   },
   {
     "spellings": "EAVEDROP",
@@ -10915,7 +10902,6 @@
     ],
     "references": [
       "ALTERNATE",
-      "EBB TIDE",
       "FALLING",
       "FLOOD",
       "LOW",
@@ -11243,9 +11229,7 @@
     "variants": [
       "ECCE HOMO\nEc\"ce ho\"mo. Etym: [L., behold the man. See John xix. 5.] (Paint.)\n\nDefn: A picture which represents the Savior as given up to the people\nby Pilate, and wearing a crown of thorns."
     ],
-    "references": [
-      "ECCE HOMO"
-    ]
+    "references": []
   },
   {
     "spellings": "ECCENTRIC",
@@ -12912,9 +12896,7 @@
     "variants": [
       "EDAM; EDAM CHEESE\nE\"dam, n., or Edam cheese.\n\nDefn: A Dutch pressed cheese of yellow color and fine flavor, made in\nballs weighing three or four pounds, and usually colored crimson\noutside; -- so called from the village of Edam, near Amsterdam. Also,\ncheese of the same type, wherever made."
     ],
-    "references": [
-      "EDAM; EDAM CHEESE"
-    ]
+    "references": []
   },
   {
     "spellings": "EDDA",
@@ -12992,7 +12974,6 @@
     ],
     "references": [
       "CORE LOSS",
-      "EDDY CURRENT",
       "FOUCAULT CURRENT"
     ]
   },
@@ -13002,7 +12983,6 @@
       "EDDY KITE\nEd\"dy kite. Called also Malay kite. [After William A. Eddy, American\nkite expert.]\n\nDefn: A quadrilateral, tailless kite, with convex surfaces exposed to\nthe wind. This kite was extensively used by Eddy in his famous\nmeteorological experiments. It is now generally superseded by the box\nkite."
     ],
     "references": [
-      "EDDY KITE",
       "FINBAT KITE"
     ]
   },
@@ -14052,9 +14032,7 @@
     "variants": [
       "EDITION DE LUXE\nÉ`di`tion\" de luxe\". Etym: [F.]\n\nDefn: See Luxe."
     ],
-    "references": [
-      "EDITION DE LUXE"
-    ]
+    "references": []
   },
   {
     "spellings": "EDITIONER",
@@ -17009,9 +16987,7 @@
     "variants": [
       "EGG SQUASH\nEgg\" squash`.\n\nDefn: A variety of squash with small egg-shaped fruit."
     ],
-    "references": [
-      "EGG SQUASH"
-    ]
+    "references": []
   },
   {
     "spellings": "EGHEN",
@@ -20477,9 +20453,7 @@
     "variants": [
       "EL DORADO\nEl` Do*ra\"do, pl. El Doradoes (. Etym: [Sp., lit., the gilt (sc.\nland); el the + dorado gilt, p. p. of dorare to gild. Cf. Dorado.]\n\n1. A name given by the Spaniards in the 16th century to an imaginary\ncountry in the interior of South America, reputed to abound in gold\nand precious stones.\n\n2. Any region of fabulous wealth; exceeding richness.\nThe whole comedy is a sort of El Dorado of wit. T. Moore."
     ],
-    "references": [
-      "EL DORADO"
-    ]
+    "references": []
   },
   {
     "spellings": "ELDRITCH",
@@ -21936,9 +21910,7 @@
     "variants": [
       "ELECTROPOION; ELECTROPOION FLUID\nE*lec`tro*poi\"on, n., or Electropoion fluid. [NL.; electro- + Gr.\npoiw^n, p. pr. of poiei^n to make.] (Elec.)\n\nDefn: An exciting and depolarizing acid solution used in certain\ncells or batteries, as the Grenet battery. Electropoion is best\nprepared by mixing one gallon of concentrated sulphuric acid diluted\nwith three gallons of water, with a solution of six pounds of\npotassium bichromate in two gallons of boiling water. It should be\nused cold."
     ],
-    "references": [
-      "ELECTROPOION; ELECTROPOION FLUID"
-    ]
+    "references": []
   },
   {
     "spellings": "ELECTRO-POLAR",
@@ -22483,9 +22455,7 @@
     "variants": [
       "ELEME FIGS; ELEMI FIGS\nEl\"e*me figs`, El\"e*mi figs`  (el\"e*mi). [Turk. eleme anything which\nhas been sifted and freed from dust or broken parts.]\n\nDefn: A kind of figs of superior quality."
     ],
-    "references": [
-      "ELEME FIGS; ELEMI FIGS"
-    ]
+    "references": []
   },
   {
     "spellings": "ELEMENT",
@@ -23691,7 +23661,6 @@
       "ELGIN MARBLES\nEl\"gin mar\"bles.\n\nDefn: Greek sculptures in the British Museum. They were obtained at\nAthens, about 1811, by Lord Elgin."
     ],
     "references": [
-      "ELGIN MARBLES",
       "MARBLE"
     ]
   },
@@ -24318,7 +24287,6 @@
     "references": [
       "CASTOR AND POLLUX",
       "CORPOSANT",
-      "ELMO'S FIRE",
       "FIRE",
       "HELENA",
       "SAINT"
@@ -25784,9 +25752,7 @@
     "variants": [
       "EMAIL OMBRANT; AEMAIL OMBRANT\nE`mail` om`brant\", Æ`mail` om`brant\". Etym: [F., shaded enamel.]\n(Fine Arts)\n\nDefn: An art or process of flooding transparent colored glaze over\ndesigns stamped or molded on earthenware or porcelain. Ure."
     ],
-    "references": [
-      "EMAIL OMBRANT; AEMAIL OMBRANT"
-    ]
+    "references": []
   },
   {
     "spellings": "EMANANT",
@@ -27784,7 +27750,6 @@
       "EMBRYO SAC\nEm\"bry*o sac`. (Bot.)\n\nDefn: See under Embryonic."
     ],
     "references": [
-      "EMBRYO SAC",
       "ENDOSPERM",
       "PERISPERM",
       "SPORE",
@@ -29686,7 +29651,6 @@
     ],
     "references": [
       "EMPIRE",
-      "EMPIRE STATE",
       "EMPIRE STATE OF THE SOUTH",
       "EMPIRE STATE OF THE WEST"
     ]
@@ -29696,18 +29660,14 @@
     "variants": [
       "EMPIRE STATE OF THE SOUTH\nEmpire State of the South.\n\nDefn: Georgia; -- a nickname."
     ],
-    "references": [
-      "EMPIRE STATE OF THE SOUTH"
-    ]
+    "references": []
   },
   {
     "spellings": "EMPIRE STATE OF THE WEST",
     "variants": [
       "EMPIRE STATE OF THE WEST\nEmpire State of the West.\n\nDefn: Missouri; -- a nickname."
     ],
-    "references": [
-      "EMPIRE STATE OF THE WEST"
-    ]
+    "references": []
   },
   {
     "spellings": "EMPIRIC",
@@ -30880,7 +30840,6 @@
     ],
     "references": [
       "EMU",
-      "EMU WREN",
       "WREN"
     ]
   },
@@ -32267,9 +32226,7 @@
     "variants": [
       "EN BLOC\nEn` bloc\". [F. Cf. Block, n. ]\n\nDefn: In a lump; as a whole; all together. \"Movement of the ossicles\nen bloc.\"  Nature.\n\nEn bloc they are known as \"the herd\".\nW. A. Fraser."
     ],
-    "references": [
-      "EN BLOC"
-    ]
+    "references": []
   },
   {
     "spellings": "ENBROUDE",
@@ -38652,9 +38609,7 @@
     "variants": [
       "ENGINEER CORPS; CORPS OF ENGINEERS\nEn`gi*neer\" Corps.\n (a) In the United States army, the Corps of Engineers, a corps of\nofficers and enlisted men consisting of one band and three battalions\nof engineers commanded by a brigadier general, whose title is Chief\nof Engineers. It has charge of the construction of fortifications for\nland and seacoast defense, the improvement of rivers and harbors, the\nconstruction of lighthouses, etc., and, in time of war, supervises\nthe engineering operations of the armies in the field.\n (b) In the United States navy, a corps made up of the engineers,\nwhich was amalgamated with the line by act of March 3, 1899. It\nconsisted of assistant and passed assistant engineers, ranking with\nensigns and lieutenants, chief engineers, ranking from lieutenant to\ncaptain, and engineer in chief, ranking with commodore and having\ncharge of the Bureau of Steam Engineering."
     ],
-    "references": [
-      "ENGINEER CORPS; CORPS OF ENGINEERS"
-    ]
+    "references": []
   },
   {
     "spellings": "ENGINEERING",
@@ -38719,9 +38674,7 @@
     "variants": [
       "ENGINE-TYPE GENERATOR\nEn\"gine-type` gen\"er*a`tor. (Elec.)\n\nDefn: A generator having its revolving part carried on the shaft of\nthe driving engine."
     ],
-    "references": [
-      "ENGINE-TYPE GENERATOR"
-    ]
+    "references": []
   },
   {
     "spellings": "ENGINOUS",
@@ -41729,9 +41682,7 @@
     "variants": [
       "EN PASSANT\nEn` pas`sant\". [F.]\n\nDefn: In passing; in the course of any procedure; -- said specif.\n(Chess),\n\nDefn: of the taking of an adverse pawn which makes a first move of\ntwo squares by a pawn already so advanced as to threaten the first of\nthese squares. The pawn which takes en passant is advanced to the\nthreatened square."
     ],
-    "references": [
-      "EN PASSANT"
-    ]
+    "references": []
   },
   {
     "spellings": "ENPATRON",
@@ -41843,9 +41794,7 @@
     "variants": [
       "EN RAPPORT\nEn` rap`port\". [F.]\n\nDefn: In accord, harmony, or sympathy; having a mutual, esp. a\nprivate, understanding; of a hypnotic subject, being in such a mental\nstate as to be especially subject to the influence of a particular\nperson or persons."
     ],
-    "references": [
-      "EN RAPPORT"
-    ]
+    "references": []
   },
   {
     "spellings": "ENRAPT",
@@ -42069,7 +42018,6 @@
       "EN ROUTE\nEn` route\". Etym: [F.]\n\nDefn: On the way or road."
     ],
     "references": [
-      "EN ROUTE",
       "OBSERVATION CAR"
     ]
   },
@@ -43067,9 +43015,7 @@
     "variants": [
       "ENTERING EDGE; ENTRANT EDGE\nEn\"ter*ing edge or En\"trant edge.\n\nDefn: = Advancing edge."
     ],
-    "references": [
-      "ENTERING EDGE; ENTRANT EDGE"
-    ]
+    "references": []
   },
   {
     "spellings": "ENTERITIS",
@@ -49241,7 +49187,6 @@
     "references": [
       "BITTER",
       "EPSOMITE",
-      "EPSOM SALTS; EPSOM SALT",
       "HAIR-SALT",
       "MAGNESIUM",
       "SAL",
@@ -49309,9 +49254,7 @@
     "variants": [
       "EPWORTH LEAGUE\nEp\"worth League.\n\nDefn: A religious organization of Methodist young people, founded in\n1889 at Cleveland, Ohio, and taking its name from John Wesley's\nbirthplace, Epworth, Lincolnshire, England."
     ],
-    "references": [
-      "EPWORTH LEAGUE"
-    ]
+    "references": []
   },
   {
     "spellings": "EQUABILITY",
@@ -58701,9 +58644,7 @@
     "variants": [
       "ESTABLISHED SUIT\nEs*tab\"lished suit. (Whist)\n\nDefn: A plain suit in which a player (or side) could, except for\ntrumping, take tricks with all his remaining cards."
     ],
-    "references": [
-      "ESTABLISHED SUIT"
-    ]
+    "references": []
   },
   {
     "spellings": "ESTABLISHER",
@@ -59907,9 +59848,7 @@
     "variants": [
       "ETAT MAJOR\nÉ`tat\" Ma`jor\". Etym: [F., fr. état state + L. major greater.] (Mil.)\n\nDefn: The staff of an army, including all officers above the rank of\ncolonel, also, all adjutants, inspectors, quartermasters,\ncommissaries, engineers, ordnance officers, paymasters, physicians,\nsignal officers, judge advocates; also, the noncommissioned\nassistants of the above officers."
     ],
-    "references": [
-      "ETAT MAJOR"
-    ]
+    "references": []
   },
   {
     "spellings": "ET CETERA; ET CAETERA",
@@ -59917,8 +59856,7 @@
       "ET CETERA; ET CAETERA\nEt` cet\"e*ra, Et` cæt\"e*ra. Etym: [L. et and + caetera other things.]\n\nDefn: Others of the like kind; and the rest; and so on; -- used to\npoint out that other things which could be mentioned are to be\nunderstood. Usually abbreviated into etc. or &c. (&c). Shak."
     ],
     "references": [
-      "AND",
-      "ET CETERA; ET CAETERA"
+      "AND"
     ]
   },
   {
@@ -61188,9 +61126,7 @@
     "variants": [
       "ETTER PIKE\nEt\"ter pike`, n. Etym: [Cf. Atter.] (Zoöl.)\n\nDefn: The stingfish, or lesser weever (Tranchinus vipera)."
     ],
-    "references": [
-      "ETTER PIKE"
-    ]
+    "references": []
   },
   {
     "spellings": "ETTIN",
@@ -70618,9 +70554,7 @@
     "variants": [
       "EVERGREEN STATE\nEvergreen State.\n\nDefn: Washington; -- a nickname alluding to the abundance of\nevergreen trees."
     ],
-    "references": [
-      "EVERGREEN STATE"
-    ]
+    "references": []
   },
   {
     "spellings": "EVERICH; EVERYCH",
@@ -72741,7 +72675,6 @@
     ],
     "references": [
       "EVIL",
-      "EVIL EYE",
       "EVIL-EYED",
       "OVERLOOK"
     ]
@@ -77118,9 +77051,7 @@
     "variants": [
       "EXCHANGE EDITOR\nEx*change\" ed\"i*tor.\n\nDefn: An editor who inspects, and culls from, periodicals, or\nexchanges, for his own publication."
     ],
-    "references": [
-      "EXCHANGE EDITOR"
-    ]
+    "references": []
   },
   {
     "spellings": "EXCHANGER",
@@ -81724,9 +81655,7 @@
     "variants": [
       "EX LIBRIS\nEx` li\"bris. [L. ex from + libris books.]\n\nDefn: An inscription, label, or the like, in a book indicating its\nownership; esp., a bookplate."
     ],
-    "references": [
-      "EX LIBRIS"
-    ]
+    "references": []
   },
   {
     "spellings": "EXMOOR",
@@ -81851,7 +81780,6 @@
       "EX OFFICIO\nEx` of*fi\"ci*o; pl. Ex officiis. Etym: [L.]\n\nDefn: From office; by virtue, or as a consequence, of an office;\nofficially."
     ],
     "references": [
-      "EX OFFICIO",
       "JUSTICIARY"
     ]
   },
@@ -82690,8 +82618,7 @@
     ],
     "references": [
       "AFFIDAVIT",
-      "DEPOSITION",
-      "EX PARTE"
+      "DEPOSITION"
     ]
   },
   {
@@ -83755,9 +83682,7 @@
     "variants": [
       "EXPERIENCE TABLE\nEx*pe\"ri*ence ta\"ble. (Life Insurance)\n\nDefn: A table of mortality computed from the experience of one or\nmore life-insurance companies."
     ],
-    "references": [
-      "EXPERIENCE TABLE"
-    ]
+    "references": []
   },
   {
     "spellings": "EXPERIENT",
@@ -85344,9 +85269,7 @@
     "variants": [
       "EXPOST FACTO; EXPOSTFACTO\nEx\"post` fac\"to, or Ex\"post`fac\"to. Etym: [L., from what is done\nafterwards.] (Law)\n\nDefn: From or by an after act, or thing done afterward; in\nconsequence of a subsequent act; retrospective. Ex post facto law, a\nlaw which operates by after enactment. The phrase is popularly\napplied to any law, civil or criminal, which is enacted with a\nretrospective effect, and with intention to produce that effect; but\nin its true application, as employed in American law, it relates only\nto crimes, and signifies a law which retroacts, by way of criminal\npunishment, upon that which was not a crime before its passage, or\nwhich raises the grade of an offense, or renders an act punishable in\na more severe manner that it was when committed. Ex post facto laws\nare held to be contrary to the fundamental principles of a free\ngovernment, and the States are prohibited from passing such laws by\nthe Constitution of the United States. Burrill. Kent."
     ],
-    "references": [
-      "EXPOST FACTO; EXPOSTFACTO"
-    ]
+    "references": []
   },
   {
     "spellings": "EX POST FACTO; EX POSTFACTO",
@@ -85354,8 +85277,7 @@
       "EX POST FACTO; EX POSTFACTO\nEx\" post` fac\"to, or Ex\" post`fac\"to (eks\" post\" fak\"to). [L., from\nwhat is done afterwards.] (Law)\n\nDefn: From or by an after act, or thing done afterward; in\nconsequence of a subsequent act; retrospective.\n\nEx post facto law, a law which operates by after enactment. The\nphrase is popularly applied to any law, civil or criminal, which is\nenacted with a retrospective effect, and with intention to produce\nthat effect; but in its true application, as employed in American\nlaw, it relates only to crimes, and signifies a law which retroacts,\nby way of criminal punishment, upon that which was not a crime before\nits passage, or which raises the grade of an offense, or renders an\nact punishable in a more severe manner that it was when committed. Ex\npost facto laws are held to be contrary to the fundamental principles\nof a free government, and the States are prohibited from passing such\nlaws by the Constitution of the United States.  Burrill.  Kent."
     ],
     "references": [
-      "EXPOST FACTO; EXPOSTFACTO",
-      "EX POST FACTO; EX POSTFACTO"
+      "EXPOST FACTO; EXPOSTFACTO"
     ]
   },
   {
@@ -86469,18 +86391,14 @@
     "variants": [
       "EXPRESS RIFLE\nEx*press\" ri\"fle.\n\nDefn: A sporting rifle for use at short ranges, employing a large\ncharge of powder and a light (short) bullet, giving a high initial\nvelocity and consequently a flat trajectory. It is usually of\nmoderately large caliber."
     ],
-    "references": [
-      "EXPRESS RIFLE"
-    ]
+    "references": []
   },
   {
     "spellings": "EXPRESS TRAIN",
     "variants": [
       "EXPRESS TRAIN\nExpress train.\n\nDefn: Formerly, a railroad train run expressly for the occasion; a\nspecial train; now, a train run at express or special speed and\nmaking few stops."
     ],
-    "references": [
-      "EXPRESS TRAIN"
-    ]
+    "references": []
   },
   {
     "spellings": "EXPRESSURE",
@@ -89798,9 +89716,7 @@
     "variants": [
       "EXTRAJUDICIAL CONVEYANCE\nExtrajudicial conveyance. (Law)\n\nDefn: A conveyance, as by deed, effected by the act of the parties\nand not involving, as in the fine and recovery, judicial proceedings."
     ],
-    "references": [
-      "EXTRAJUDICIAL CONVEYANCE"
-    ]
+    "references": []
   },
   {
     "spellings": "EXTRALIMITARY",
@@ -92428,9 +92344,7 @@
     "variants": [
       "EYE OPENER\nEye opener.\n\nDefn: That which makes the eyes open, as startling news or\noccurrence, or (U. S. Slang), a drink of liquor, esp. the first one\nin the morning."
     ],
-    "references": [
-      "EYE OPENER"
-    ]
+    "references": []
   },
   {
     "spellings": "EYEPIECE",

--- a/output/wordDisplayData#F-G.json
+++ b/output/wordDisplayData#F-G.json
@@ -8173,9 +8173,7 @@
     "variants": [
       "FAINEANT DEITY\nFainéant deity.\n\nDefn: A deity recognized as real but conceived as not acting in human\naffairs, hence not worshiped."
     ],
-    "references": [
-      "FAINEANT DEITY"
-    ]
+    "references": []
   },
   {
     "spellings": "FAINT",
@@ -8728,7 +8726,6 @@
       "FAIR CATCH\nFair catch. (Football)\n\nDefn: A catch made by a player on side who makes a prescribed signal\nthat he will not attempt to advance the ball when caught. He must not\nthen be interfered with."
     ],
     "references": [
-      "FAIR CATCH",
       "PUNT-OUT"
     ]
   },
@@ -10645,7 +10642,6 @@
       "DEER",
       "DOE",
       "FALLOW",
-      "FALLOW DEER",
       "HALFER",
       "HEAD",
       "PALM"
@@ -13843,7 +13839,6 @@
       "FAN PALM\nFan\" palm`. (Bot.)\n\nDefn: Any palm tree having fan-shaped or radiate leaves; as the\nChamærops humilis of Southern Europe; the species of Sabal and\nThrinax in the West Indies, Florida, etc.; and especially the great\ntalipot tree (Corypha umbraculifera) of Ceylon and Malaya. The leaves\nof the latter are often eighteen feet long and fourteen wide, and are\nused for umbrellas, tents, and roofs. When cut up, they are used for\nbooks and manuscripts."
     ],
     "references": [
-      "FAN PALM",
       "PALM",
       "TIGER"
     ]
@@ -17189,9 +17184,7 @@
     "variants": [
       "FATA MORGANA\nFa\"ta Mor*ga\"na. Etym: [It.; -- so called because this phenomenon was\nlooked upon as the work of a fairy (It. fata) of the name of Morgána.\nSee Fairy.]\n\nDefn: A kind of mirage by which distant objects appear inverted,\ndistorted, displaced, or multiplied. It is noticed particularly at\nthe Straits of Messina, between Calabria and Sicily."
     ],
-    "references": [
-      "FATA MORGANA"
-    ]
+    "references": []
   },
   {
     "spellings": "FATBACK",
@@ -17728,7 +17721,6 @@
     ],
     "references": [
       "DADDY LONGLEGS",
-      "FATHER LONGLEGS",
       "GRANDFATHER"
     ]
   },
@@ -18717,9 +18709,7 @@
     "variants": [
       "FAUX PAS\nfaux` pas\". Etym: [F. See False, and Pas.]\n\nDefn: A false step; a mistake or wrong measure."
     ],
-    "references": [
-      "FAUX PAS"
-    ]
+    "references": []
   },
   {
     "spellings": "FAVAGINOUS",
@@ -18770,9 +18760,7 @@
     "variants": [
       "FAVIER EXPLOSIVE\nFa`vier\" ex*plo\"sive. [After the inventor, P. A. Favier, a\nFrenchman.]\n\nDefn: Any of several explosive mixtures, chiefly of ammonium nitrate\nand a nitrate derivative of naphthalene. They are stable, but require\nprotection from moisture. As prepared it is a compressed cylinder of\nthe explosive, filled with loose powder of the same composition, all\ninclosed in waterproof wrappers. It is used for mining."
     ],
-    "references": [
-      "FAVIER EXPLOSIVE"
-    ]
+    "references": []
   },
   {
     "spellings": "FAVILLOUS",
@@ -24201,7 +24189,6 @@
       "EXCOMMUNICATION",
       "FAMILIARITY",
       "FELLOW",
-      "FELLOWSHIP; GOOD FELLOWSHIP",
       "FRATERNATE",
       "FRATERNIZE",
       "GATHER",
@@ -24347,7 +24334,6 @@
       "ESTOVERS",
       "FELON",
       "FELONIOUS",
-      "FELONY; TO COMPOUND A FELONY",
       "MISDEMEANOR",
       "MISPRISION",
       "PARTY",
@@ -24524,7 +24510,6 @@
       "FELT GRAIN\nFelt grain\n\nDefn: , the grain of timber which is transverse to the annular rings\nor plates; the direction of the medullary rays in oak and some other\ntimber. Knight."
     ],
     "references": [
-      "FELT GRAIN",
       "FELTING"
     ]
   },
@@ -25032,7 +25017,6 @@
       "FEMALE FERN\nFemale fern (Bot.),\n\nDefn: a common species of fern with large decompound fronds\n(Asplenium Filixfæmina), growing in many countries; lady fern.\n\nNote: The names male fern and female fern were anciently given to two\ncommon ferns; but it is now understood that neither has any sexual\ncharacter.\n\nSyn.\n -- Female, Feminine. We apply female to the sex or individual, as\nopposed to male; also, to the distinctive belongings of women; as,\nfemale dress, female form, female character, etc.; feminine, to\nthings appropriate to, or affected by, women; as, feminine studies,\nemployments, accomplishments, etc. \"Female applies to sex rather than\ngender, and is a physiological rather than a grammatical term.\nFeminine applies to gender rather than sex, and is grammatical rather\nthan physiological.\" Latham."
     ],
     "references": [
-      "FEMALE FERN",
       "LADY",
       "MALE"
     ]
@@ -25042,9 +25026,7 @@
     "variants": [
       "FEMALE RHYMES\nFemale rhymes (Pros.),\n\nDefn: double rhymes, or rhymes (called in French feminine rhymes\nbecause they end in e weak, or feminine) in which two syllables, an\naccented and an unaccented one, correspond at the end of each line.\n\nNote: A rhyme, in which the final syllables only agree (strain,\ncomplain) is called a male rhyme; one in which the two final\nsyllables of each verse agree, the last being short (motion, ocean),\nis called female. Brande & C.\n -- Female screw, the spiral-threaded cavity into which another, or\nmale, screw turns. Nicholson."
     ],
-    "references": [
-      "FEMALE RHYMES"
-    ]
+    "references": []
   },
   {
     "spellings": "FEMALIST",
@@ -25178,8 +25160,7 @@
       "FEMININE RHYME\nFeminine rhyme. (Pros.)\n\nDefn: See Female rhyme, under Female, a.\n\nSyn.\n -- See Female, a."
     ],
     "references": [
-      "FEMALE RHYMES",
-      "FEMININE RHYME"
+      "FEMALE RHYMES"
     ]
   },
   {
@@ -25419,9 +25400,7 @@
     "variants": [
       "FENCE MONTH\nFence month (Forest Law),\n\nDefn: the month in which female deer are fawning, when hunting is\nprohibited. Bullokar.\n -- Fence roof, a covering for defense. \"They fitted their shields\nclose to one another in manner of a fence roof.\" Holland. Fence time,\nthe breeding time of fish or game, when they should not be killed.\n -- Rail fence, a fence made of rails, sometimes supported by posts.\n -- Ring fence, a fence which encircles a large area, or a whole\nestate, within one inclosure.\n -- Worm fence, a zigzag fence composed of rails crossing one another\nat their ends; -- called also snake fence, or Virginia rail fence.\n -- To be on the fence, to be undecided or uncommitted in respect to\ntwo opposing parties or policies. [Colloq.]"
     ],
-    "references": [
-      "FENCE MONTH"
-    ]
+    "references": []
   },
   {
     "spellings": "FENCER",
@@ -25501,9 +25480,7 @@
     "variants": [
       "FEN CRICKET\nFen\" crick`et. (Zoöl.)\n\nDefn: The mole cricket. [Prov. Eng.]"
     ],
-    "references": [
-      "FEN CRICKET"
-    ]
+    "references": []
   },
   {
     "spellings": "FEND",
@@ -25962,9 +25939,7 @@
     "variants": [
       "FERAE NATURAE\nFe\"ræ na*tu\"ræ. Etym: [L.]\n\nDefn: Of a wild nature; -- applied to animals, as foxes, wild ducks,\netc., in which no one can claim property."
     ],
-    "references": [
-      "FERAE NATURAE"
-    ]
+    "references": []
   },
   {
     "spellings": "FERAL",
@@ -26335,7 +26310,6 @@
     ],
     "references": [
       "FERMENTATION",
-      "FERMENTATION THEORY",
       "GERM"
     ]
   },
@@ -26543,7 +26517,6 @@
       "FERRANTI CABLES; FERRANTI MAINS\nFer*ran\"ti ca\"bles, Fer*ran\"ti mains\". (Elec.)\n\nDefn: A form of conductor, designed by Ferranti, for currents of high\npotential, and consisting of concentric tubes of copper separated by\nan insulating material composed of paper saturated with black mineral\nwax."
     ],
     "references": [
-      "FERRANTI CABLES; FERRANTI MAINS",
       "FERRANTI PHENOMENON"
     ]
   },
@@ -26552,9 +26525,7 @@
     "variants": [
       "FERRANTI PHENOMENON\nFer*ran\"ti phe*nom\"e*non. (Elec.)\n\nDefn: An increase in the ratio of transformation of an alternating\ncurrent converter, accompanied by other changes in electrical\nconditions, occurring when the secondary of the converter is\nconnected with a condenser of moderate capacity; -- so called because\nfirst observed in connection with the Ferranti cables in London."
     ],
-    "references": [
-      "FERRANTI PHENOMENON"
-    ]
+    "references": []
   },
   {
     "spellings": "FERRARA",
@@ -26864,9 +26835,7 @@
     "variants": [
       "FERRIS WHEEL\nFer\"ris wheel.\n\nDefn: An amusement device consisting of a giant power-driven steel\nwheel, revolvable on its stationary axle, and carrying a number of\nbalanced passenger cars around its rim; -- so called after G. W. G.\nFerris, American engineer, who erected the first of its kind for the\nWorld's Columbian Exposition in Chicago in 1893."
     ],
-    "references": [
-      "FERRIS WHEEL"
-    ]
+    "references": []
   },
   {
     "spellings": "FERRO-",
@@ -28502,9 +28471,7 @@
     "variants": [
       "FEU DE JOIE\nFeu` de joie\". Etym: [F., lit., fire of joy.]\n\nDefn: A fire kindled in a public place in token of joy; a bonfire; a\nfiring of guns in token of joy."
     ],
-    "references": [
-      "FEU DE JOIE"
-    ]
+    "references": []
   },
   {
     "spellings": "FEUDIST",
@@ -31200,9 +31167,7 @@
     "variants": [
       "FIERI FACIAS\nFi\"e*ri fa\"ci*as. Etym: [L., cause it to be done.] (Law)\n\nDefn: A judicial writ that lies for one who has recovered in debt or\ndamages, commanding the sheriff that he cause to be made of the\ngoods, chattels, or real estate of the defendant, the sum claimed.\nBlackstone. Cowell."
     ],
-    "references": [
-      "FIERI FACIAS"
-    ]
+    "references": []
   },
   {
     "spellings": "FIERINESS",
@@ -33532,9 +33497,7 @@
     "variants": [
       "FILE CLOSER\nFile\" clos`er. (Mil.)\n\nDefn: A commissioned or noncommissioned officer posted in the rear of\na line, or on the flank of a column, of soldiers, to rectify mistakes\nand insure steadiness and promptness in the ranks."
     ],
-    "references": [
-      "FILE CLOSER"
-    ]
+    "references": []
   },
   {
     "spellings": "FILEFISH",
@@ -34042,9 +34005,7 @@
     "variants": [
       "FILLED CHEESE\nFilled cheese.\n\nDefn: An inferior kind of cheese made from skim milk with a fatty\n\"filling,\" such as oleomargarine or lard, to replace the fat removed\nin the cream."
     ],
-    "references": [
-      "FILLED CHEESE"
-    ]
+    "references": []
   },
   {
     "spellings": "FILLER",
@@ -34579,9 +34540,7 @@
     "variants": [
       "FIMBLE; FIMBLE HEMP\nFim\"ble, n., or Fim\"ble hemp`.Etym: [Corrupted from female hemp.]\n\nDefn: Light summer hemp, that bears no seed."
     ],
-    "references": [
-      "FIMBLE; FIMBLE HEMP"
-    ]
+    "references": []
   },
   {
     "spellings": "FIMBRIA",
@@ -35122,9 +35081,7 @@
     "variants": [
       "FINBAT KITE\nFin\"bat kite.\n\nDefn: = Eddy kite. [Eng.]"
     ],
-    "references": [
-      "FINBAT KITE"
-    ]
+    "references": []
   },
   {
     "spellings": "FINCH",
@@ -35536,9 +35493,7 @@
     "variants": [
       "FIN DE SIECLE\nFin` de siè\"cle. [F.]\n\nDefn: Lit., end of the century; -- mostly used adjectively in English\nto signify: belonging to, or characteristic of, the close of the 19th\ncentury; modern; \"up-to-date;\" as, fin-de-siècle ideas."
     ],
-    "references": [
-      "FIN DE SIECLE"
-    ]
+    "references": []
   },
   {
     "spellings": "FINDFAULT",
@@ -37234,9 +37189,7 @@
     "variants": [
       "FIN KEEL\nFin keel. (Naut.)\n\nDefn: A projection downward from the keel of a yacht, resembling in\nshape the fin of a fish, though often with a cigar-shaped bulb of\nlead at the bottom, and generally made of metal. Its use is to\nballast the boat and also to enable her to sail close to the wind and\nto make the least possible leeway by offering great resistance to\nlateral motion through the water."
     ],
-    "references": [
-      "FIN KEEL"
-    ]
+    "references": []
   },
   {
     "spellings": "FINLANDER",
@@ -37290,9 +37243,7 @@
     "variants": [
       "FINNAN HADDIE\nFin\"nan had\"die. Etym: [See Haddock.]\n\nDefn: Haddock cured in peat smoke, originally at Findon (pron.\nfìn\"an), Scotland. the name is also applied to other kinds of smoked\nhaddock. [Written also finnan haddock.]"
     ],
-    "references": [
-      "FINNAN HADDIE"
-    ]
+    "references": []
   },
   {
     "spellings": "FINNED",
@@ -37391,9 +37342,7 @@
     "variants": [
       "FINSEN LIGHT\nFin\"sen light. [After Prof. Niels R. Finsen (b. 1860), Danish\nphysician.] (Med.)\n\nDefn: Highly actinic light, derived from sunlight or from some form\nof electric lamp, used in the treatment of lupus and other cutaneous\naffections."
     ],
-    "references": [
-      "FINSEN LIGHT"
-    ]
+    "references": []
   },
   {
     "spellings": "FINT",
@@ -37452,7 +37401,6 @@
       "FIPPENNY BIT\nFip\"pen*ny bit` ( or ). Etym: [Corruption of five penny bit.]\n\nDefn: The Spanish half real, or one sixteenth of a dollar, -- so\ncalled in Pennsylvania and the adjacent States. [Obs.]\n\nNote: Before the act of Congress, Feb. 21, 1857, caused the adoption\nof decimal coins and the withdrawal of foreign coinage from\ncirculation, this coin passed currently for 6fourpence ha'penny or\nfourpence; in New York a sixpence; in Pennsylvania, Virginia, etc., a\nfip; and in Louisiana, a picayune."
     ],
     "references": [
-      "FIPPENNY BIT",
       "PICAYUNE"
     ]
   },
@@ -38282,7 +38230,6 @@
     "references": [
       "CUCUJO",
       "FIRE",
-      "FIRE BEETLE",
       "FIREFLY",
       "GLOWWORM"
     ]
@@ -38680,7 +38627,6 @@
       "FIRING PIN\nFir\"ing pin`.\n\nDefn: In the breech mechanism of a firearm, the pin which strikes the\nhead of the cartridge and explodes it."
     ],
     "references": [
-      "FIRING PIN",
       "HAMMER",
       "PIN-FIRE",
       "PLUNGER"
@@ -40953,7 +40899,6 @@
       "ABIETENE",
       "ABIETIC",
       "CEIL",
-      "FIR TREE",
       "SEA FIR",
       "THOLE"
     ]
@@ -46016,9 +45961,7 @@
     "variants": [
       "FLANNEL FLOWER\nFlan\"nel flow`er. (Bot.)\n (a) The common mullein.\n (b) A Brazilian apocynaceous vine (Macrosiphonia longiflora) having\nwoolly leaves.\n (c) An umbelliferous Australian flower (Actinotus helianthi), often\nerroneously thought to be composite. The involucre looks as if cut\nout of white flannel."
     ],
-    "references": [
-      "FLANNEL FLOWER"
-    ]
+    "references": []
   },
   {
     "spellings": "FLANNEN",
@@ -46261,18 +46204,14 @@
     "variants": [
       "FLASH BOILER\nFlash boiler.\n\nDefn: A variety of water-tube boiler, used chiefly in steam\nautomobiles, consisting of a nest of strong tubes with very little\nwater space, kept nearly red hot so that the water as it trickles\ndrop by drop into the tubes is immediately flashed into steam and\nsuperheated."
     ],
-    "references": [
-      "FLASH BOILER"
-    ]
+    "references": []
   },
   {
     "spellings": "FLASH BURNER",
     "variants": [
       "FLASH BURNER\nFlash burner.\n\nDefn: A gas burner with a device for lighting by an electric spark."
     ],
-    "references": [
-      "FLASH BURNER"
-    ]
+    "references": []
   },
   {
     "spellings": "FLASHER",
@@ -46878,7 +46817,6 @@
       "FLAT FOOT\nFlat\" foot`. (Med.)\n\nDefn: A foot in which the arch of the instep is flattened so that the\nentire sole of the foot rests upon the ground; also, the deformity,\nusually congential, exhibited by such a foot; splayfoot."
     ],
     "references": [
-      "FLAT FOOT",
       "FLAT-FOOTED",
       "SPLAYFOOT"
     ]
@@ -50153,7 +50091,6 @@
       "ACHROMATIC",
       "CRYSTAL",
       "FLINT",
-      "FLINT GLASS",
       "GLASS",
       "LEAD",
       "LITHARGE",
@@ -50799,9 +50736,7 @@
     "variants": [
       "FLOATING CHARGE; FLOATING LIEN\nFloating charge, lien, etc. (Law)\n\nDefn: A charge, lien, etc., that successively attaches to such assets\nas a person may have from time to time, leaving him more or less free\nto dispose of or encumber them as if no such charge or lien existed."
     ],
-    "references": [
-      "FLOATING CHARGE; FLOATING LIEN"
-    ]
+    "references": []
   },
   {
     "spellings": "FLOATINGLY",
@@ -51807,7 +51742,6 @@
     ],
     "references": [
       "BEAN",
-      "FLORIDA BEAN",
       "SEA BEAN"
     ]
   },
@@ -52042,9 +51976,7 @@
     "variants": [
       "FLOTATION PROCESS\nFlotation process.\n\nDefn: A process of separating the substances contained in pulverized\nore or the like by depositing the mixture on the  surface of a\nflowing liquid, the substances that are quickly wet readily\novercoming the surface tension of the liquid and sinking, the others\nflowing off in a film or slime on the surface, though, perhaps,\nhaving a greater specific gravity than those that sink."
     ],
-    "references": [
-      "FLOTATION PROCESS"
-    ]
+    "references": []
   },
   {
     "spellings": "FLOTE",
@@ -53305,7 +53237,6 @@
       "FLOWER STATE\nFlow\"er State.\n\nDefn:   Florida; -- a nickname, alluding to sense of L. floridus,\nfrom florida flowery. See Florid."
     ],
     "references": [
-      "FLOWER STATE",
       "SUNFLOWER STATE"
     ]
   },
@@ -53579,8 +53510,7 @@
       "FLOXED SILK\nFloxed\" silk`.\n\nDefn: See Floss silk, under Floss."
     ],
     "references": [
-      "FLOSS",
-      "FLOXED SILK"
+      "FLOSS"
     ]
   },
   {
@@ -53799,7 +53729,6 @@
       "FLUE PIPE\nFlue pipe. (Music)\n\nDefn: A pipe, esp. an organ pipe, whose tone is produced by the\nimpinging of a current of air upon an edge, or lip, causing a wave\nmotion in the air within; a mouth pipe; -- distinguished from reed\npipe. Flue pipes are either open or closed (stopped at the distant\nend). The flute and flageolet are open pipes; a bottle acts as a\nclosed pipe when one blows across the neck. The organ has both open\nand closed flue pipes, those of metal being usually round in section,\nand those of wood triangular or square."
     ],
     "references": [
-      "FLUE PIPE",
       "LABIAL"
     ]
   },
@@ -54532,9 +54461,7 @@
     "variants": [
       "FLUOR ALBUS\nFlu\"or albus. Etym: [L., white flow.] (Med.)\n\nDefn: The whites; leucorrhæa."
     ],
-    "references": [
-      "FLUOR ALBUS"
-    ]
+    "references": []
   },
   {
     "spellings": "FLUORANTHENE",
@@ -54739,7 +54666,6 @@
       "DERBYSHIRE SPAR",
       "FLUORESCENCE",
       "FLUORITE",
-      "FLUOR SPAR",
       "KAND",
       "PSEUDOMORPH",
       "SPAR",
@@ -54994,9 +54920,7 @@
     "variants": [
       "FLUTE A BEC\nFlûte` à bec\". Etym: [F.] (Mus.)\n\nDefn: A beak flute, an older form of the flute, played with a\nmouthpiece resembling a beak, and held like a flageolet."
     ],
-    "references": [
-      "FLUTE A BEC"
-    ]
+    "references": []
   },
   {
     "spellings": "FLUTED",
@@ -55708,8 +55632,7 @@
       "FLY AMANITA; FLY FUNGUS\nFly amanita, Fly fungus. (Bot.)\n\nDefn: A poisonous mushroom (Amanita muscaria, syn. Agaricus\nmuscarius), having usually a bright red or yellowish cap covered with\nirregular white spots. It has a distinct volva at the base, generally\nan upper ring on the stalk, and white spores. Called also fly agaric,\ndeadly amanita."
     ],
     "references": [
-      "AMANITA",
-      "FLY AMANITA; FLY FUNGUS"
+      "AMANITA"
     ]
   },
   {
@@ -55727,9 +55650,7 @@
     "variants": [
       "FLYAWAY GRASS\nFlyaway grass. (Bot.)\n\nDefn: The hair grass (Agrostis scabra). So called from its light\npanicle, which is blown to great distances by the wind."
     ],
-    "references": [
-      "FLYAWAY GRASS"
-    ]
+    "references": []
   },
   {
     "spellings": "FLYBANE",
@@ -56012,8 +55933,7 @@
     ],
     "references": [
       "AEROBOAT",
-      "AEROYACHT",
-      "FLYING BOAT"
+      "AEROYACHT"
     ]
   },
   {
@@ -56024,7 +55944,6 @@
     "references": [
       "EXOCETUS; EXOCOETUS",
       "FLYING",
-      "FLYING FISH",
       "NATANT",
       "VOLADOR",
       "WING"
@@ -56039,7 +55958,6 @@
       "ASSAPAN; ASSAPANIC",
       "COLUGO",
       "FLYING",
-      "FLYING SQUIRREL",
       "PARACHUTE",
       "POLATOUCHE",
       "SQUIRREL",
@@ -56709,9 +56627,7 @@
     "variants": [
       "FOG BELT\nFog belt.\n\nDefn: A region of the ocean where fogs are of marked frequency, as\nnear the coast of Newfoundland."
     ],
-    "references": [
-      "FOG BELT"
-    ]
+    "references": []
   },
   {
     "spellings": "FOGBOW",
@@ -57672,7 +57588,6 @@
     "references": [
       "BANSSHEE; BANSHIE",
       "FAIRY",
-      "FOLKLORE; FOLK LORE",
       "KNOW",
       "LORE",
       "LOUP-GAROU"
@@ -58357,7 +58272,6 @@
     "references": [
       "ADVANCING EDGE",
       "ANGLE OF ENTRY",
-      "FOLLOWING EDGE",
       "TRAILING EDGE"
     ]
   },
@@ -58367,8 +58281,7 @@
       "FOLLOWING SURFACE\nFollowing surface. (Aëronautics)\n\nDefn: See Advancing-surface, above."
     ],
     "references": [
-      "ADVANCING SURFACE",
-      "FOLLOWING SURFACE"
+      "ADVANCING SURFACE"
     ]
   },
   {
@@ -60935,9 +60848,7 @@
     "variants": [
       "FOOT CANDLE\nFoot candle. (Photom.)\n\nDefn: The amount of illumination produced by a standard candle at a\ndistance of one foot."
     ],
-    "references": [
-      "FOOT CANDLE"
-    ]
+    "references": []
   },
   {
     "spellings": "FOOTCLOTH",
@@ -60984,9 +60895,7 @@
     "variants": [
       "FOOT GUARDS\nFoot\" Guards`, pl.\n\nDefn: Infantry soldiers belonging to select regiments called the\nGuards. [Eng.]"
     ],
-    "references": [
-      "FOOT GUARDS"
-    ]
+    "references": []
   },
   {
     "spellings": "FOOTHALT",
@@ -61180,7 +61089,6 @@
       "EQUIVALENT",
       "ERG",
       "FOOT",
-      "FOOT POUND",
       "FOOT POUNDAL",
       "JOULE",
       "WORK"
@@ -61192,8 +61100,7 @@
       "FOOT POUNDAL\nFoot\" pound`al. (Mech.)\n\nDefn: A unit of energy or work, equal to the work done in moving a\nbody through one foot against the force of one poundal."
     ],
     "references": [
-      "FOOT",
-      "FOOT POUNDAL"
+      "FOOT"
     ]
   },
   {
@@ -61308,9 +61215,7 @@
     "variants": [
       "FOOT TON\nFoot ton. (Mech.)\n\nDefn: A unit of energy or work, being equal to the work done in\nraising one ton against the force of gravity through the height of\none foot."
     ],
-    "references": [
-      "FOOT TON"
-    ]
+    "references": []
   },
   {
     "spellings": "FOOT VALVE",
@@ -61318,8 +61223,7 @@
       "FOOT VALVE\nFoot valve. (Mech.)\n\nDefn: A suction valve or check valve at the lower end of a pipe;\nesp., such a valve in a steam-engine condenser opening to the air\npump."
     ],
     "references": [
-      "FOOT",
-      "FOOT VALVE"
+      "FOOT"
     ]
   },
   {
@@ -68125,7 +68029,6 @@
     ],
     "references": [
       "FEED",
-      "FORCE PUMP",
       "FORCER",
       "FORCING"
     ]
@@ -70245,7 +70148,6 @@
       "FOREHEAD",
       "FOREHOOK",
       "FORELOCK",
-      "FORE PART; FOREPART",
       "FORESHIP",
       "FORE TOOTH",
       "FORETOP",
@@ -71118,7 +71020,6 @@
     ],
     "references": [
       "CUTTER",
-      "FORE TOOTH",
       "NIPPER"
     ]
   },
@@ -83272,8 +83173,7 @@
       "FOUCAULT CURRENT\nFou`cault\" cur`rent. [After J. B. L. Foucault (1819-68), French\nphysicist.] (Elec.)\n\nDefn: An eddy current."
     ],
     "references": [
-      "EDDY CURRENT",
-      "FOUCAULT CURRENT"
+      "EDDY CURRENT"
     ]
   },
   {
@@ -86958,9 +86858,7 @@
     "variants": [
       "FOWLER'S SOLUTION\nFow\"ler's so*lu\"tion\n\nDefn: . An Fowler, an English physician who first brought it into\nuse."
     ],
-    "references": [
-      "FOWLER'S SOLUTION"
-    ]
+    "references": []
   },
   {
     "spellings": "FOX",
@@ -88793,9 +88691,7 @@
     "variants": [
       "FRANKFORT BLACK\nFrank\"fort black`\n\nDefn: . A black pigment used in copperplate printing, prepared by\nburning vine twigs, the lees of wine, etc. McElrath."
     ],
-    "references": [
-      "FRANKFORT BLACK"
-    ]
+    "references": []
   },
   {
     "spellings": "FRANKINCENSE",
@@ -88915,7 +88811,6 @@
       "FRANKLIN STOVE\nFrank\"lin stove`\n\nDefn: . A kind of open stove introduced by Benjamin Franklin, the\npeculiar feature of which was that a current of heated air was\ndirectly supplied to the room from an air box; -- now applied to\nother varieties of open stoves."
     ],
     "references": [
-      "FRANKLIN STOVE",
       "STOVE"
     ]
   },
@@ -89431,7 +89326,6 @@
       "FRAUNHOFER LINES\nFraun\"ho*fer lines`. (Physics.)\n\nDefn: The lines of the spectrun; especially and properly, the dark\nlines of the solar spectrum, so called because first accurately\nobserved and interpreted by Fraunhofer, a German physicist."
     ],
     "references": [
-      "FRAUNHOFER LINES",
       "SPECTRUM"
     ]
   },
@@ -90465,7 +90359,6 @@
       "FREE COINAGE\nFree coinage.\n\nDefn: In the fullest sense, the conversion of bullion (of any\nspecified metal) into legal-tender coins for any person who chooses\nto bring it to the mint; in a modified sense, such coinage when done\nat a fixed charge proportionate to the cost of the operation."
     ],
     "references": [
-      "FREE COINAGE",
       "FREE SILVER"
     ]
   },
@@ -91047,9 +90940,7 @@
     "variants": [
       "FREE SILVER\nFree silver.\n\nDefn: The free coinage of silver; often, specif., the free coinage of\nsilver at a fixed ratio with gold, as at the ratio of 16 to 1, which\nratio for some time represented nearly or exactly the ratio of the\nmarket values of gold and silver respectively."
     ],
-    "references": [
-      "FREE SILVER"
-    ]
+    "references": []
   },
   {
     "spellings": "FREE-SOIL",
@@ -91154,7 +91045,6 @@
       "ELECTION",
       "ENTIRE",
       "FORE",
-      "FREE WILL",
       "FREEWILL",
       "JANSENISM",
       "JANSENIST",
@@ -93053,7 +92943,6 @@
       "FRESNEL LAMP; FRESNEL LANTERN\nFres`nel\" lamp\", Fres`nel\" lan\"tern. Etym: [From Fresnel the\ninventor, a French physicist.]\n\nDefn: A lantern having a lamp surrounded by a hollow cylindrical\nFresnel lens."
     ],
     "references": [
-      "FRESNEL LAMP; FRESNEL LANTERN",
       "FRESNEL LENS"
     ]
   },
@@ -93064,7 +92953,6 @@
     ],
     "references": [
       "FRESNEL LAMP; FRESNEL LANTERN",
-      "FRESNEL LENS",
       "LENS"
     ]
   },
@@ -94712,7 +94600,6 @@
     ],
     "references": [
       "FRINGE",
-      "FRINGE TREE",
       "SNOW"
     ]
   },
@@ -101539,9 +101426,7 @@
     "variants": [
       "FROST SIGNAL\nFrost\" sig`nal. (Meteor.)\n\nDefn: A signal consisting of a white flag with a black center, used\nby the United States Weather Bureau to indicate that a local frost is\nexpected. It is used only in Florida and along the coasts of the\nPacific and the Gulf Mexico."
     ],
-    "references": [
-      "FROST SIGNAL"
-    ]
+    "references": []
   },
   {
     "spellings": "FROSTWEED",
@@ -102045,7 +101930,6 @@
       "FRUE VANNER\nFrue\" van\"ner. Etym: [Etymol. uncertain.] (Mining)\n\nDefn: A moving, inclined, endless apron on which ore is concentrated\nby a current of water; a kind of buddle."
     ],
     "references": [
-      "FRUE VANNER",
       "VANNER"
     ]
   },
@@ -103664,9 +103548,7 @@
     "variants": [
       "FUDGE WHEEL\nFudge\" wheel\". (Shoemaking)\n\nDefn: A tool for ornamenting the edge of a sole."
     ],
-    "references": [
-      "FUDGE WHEEL"
-    ]
+    "references": []
   },
   {
     "spellings": "FUEGIAN",
@@ -106092,7 +105974,6 @@
       "FULL HOUSE\nFull house. (Poker)\n\nDefn: A hand containing three of a kind and a pair, as three kings\nand two tens. It ranks above a flush and below four of a kind."
     ],
     "references": [
-      "FULL HOUSE",
       "HOUSE",
       "POKER",
       "POKER DICE"
@@ -106672,9 +106553,7 @@
     "variants": [
       "FUMED OAK\nFumed oak. (Cabinetwork)\n\nDefn: Oak given a weathered appearance by exposure in an air-tight\ncompartment to fumes of ammonia from uncorked cans, being first given\na coat of filler."
     ],
-    "references": [
-      "FUMED OAK"
-    ]
+    "references": []
   },
   {
     "spellings": "FUMELESS",
@@ -107779,7 +107658,6 @@
       "FUNGI IMPERFECTI\nFun\"gi Im`per*fec\"ti, pl. [L. imperfecti imperfect.] (Bot.)\n\nDefn: A heterogenous group of fungi of which the complete life\nhistory is not known. Some undoubtedly represent the conidium stages\nof various Ascomycetes. The group is divided into the orders\nSphæropsidales, Melanconiales, and Moniliales."
     ],
     "references": [
-      "FUNGI IMPERFECTI",
       "MELANCONIALES",
       "MONILIALES"
     ]
@@ -109889,7 +109767,6 @@
       "AMYL ALCOHOL",
       "FAINTS",
       "FORESHOT",
-      "FUSEL; FUSEL OIL",
       "FUZZLE",
       "POTATO"
     ]
@@ -109906,9 +109783,7 @@
     "variants": [
       "FUSE PLUG; FUZE PLUG\nFuse, or Fuze, plug .\n\n1. (Ordnance)\n\nDefn: A plug fitted to the fuse hole of a shell to hold the fuse.\n\n2.  A fusible plug that screws into a receptacle, used as a fuse in\nelectric wiring."
     ],
-    "references": [
-      "FUSE PLUG; FUZE PLUG"
-    ]
+    "references": []
   },
   {
     "spellings": "FUSIBILITY",
@@ -114428,9 +114303,7 @@
     "variants": [
       "GAG LAW\nGag law. (Parliamentary Law)\n\nDefn: A law or ruling prohibiting proper or free debate, as in\nclosure. [Colloq. or Cant]"
     ],
-    "references": [
-      "GAG LAW"
-    ]
+    "references": []
   },
   {
     "spellings": "GAGTOOTH",
@@ -114859,9 +114732,7 @@
     "variants": [
       "GAINSBOROUGH HAT\nGains\"borough hat.\n\nDefn: A woman's broad-brimmed hat of a form thought to resemble those\nshown in portraits by Thomas Gainsborough, the English artist (1727-\n88)."
     ],
-    "references": [
-      "GAINSBOROUGH HAT"
-    ]
+    "references": []
   },
   {
     "spellings": "GAINSOME",
@@ -115133,9 +115004,7 @@
     "variants": [
       "GALAPEE TREE\nGal\"a*pee` tree\", (Bot.)\n\nDefn: The West Indian Sciadophyllum Brownei, a tree with very large\ndigitate leaves."
     ],
-    "references": [
-      "GALAPEE TREE"
-    ]
+    "references": []
   },
   {
     "spellings": "GALATEA",
@@ -116095,9 +115964,7 @@
     "variants": [
       "GALLIPOLI OIL\nGal*lip\"o*li oil`.\n\nDefn: An inferior kind of olive oil, brought from Gallipoli, in\nItaly."
     ],
-    "references": [
-      "GALLIPOLI OIL"
-    ]
+    "references": []
   },
   {
     "spellings": "GALLIPOT",
@@ -116733,7 +116600,6 @@
       "GAMA GRASS\nGa\"ma grass`. Etym: [From Gama, a cluster of the Maldive Islands.]\n(Bot.)\n\nDefn: A species of grass (Tripsacum dactyloides) tall, stout, and\nexceedingly productive; cultivated in the West Indies, Mexico, and\nthe Southern States of North America as a forage grass; -- called\nalso sesame grass."
     ],
     "references": [
-      "GAMA GRASS",
       "GRASS",
       "SESAME"
     ]
@@ -117461,8 +117327,7 @@
       "GAME FOWL\nGame\" fowl`. (Zoöl.)\n\nDefn: A handsome breed of the common fowl, remarkable for the great\ncourage and pugnacity of the males."
     ],
     "references": [
-      "GAMECOCK",
-      "GAME FOWL"
+      "GAMECOCK"
     ]
   },
   {
@@ -117624,7 +117489,6 @@
     ],
     "references": [
       "BECQUEREL RAYS",
-      "GAMMA RAYS",
       "RADIUM"
     ]
   },
@@ -118305,9 +118169,7 @@
     "variants": [
       "GANZ SYSTEM\nGanz system\n\nDefn: A haulage system for canal boats, in which an electric\nlocomotive running on a monorail has its adhesion materially\nincreased by the pull of the tow rope on a series of inclined\ngripping wheels."
     ],
-    "references": [
-      "GANZ SYSTEM"
-    ]
+    "references": []
   },
   {
     "spellings": "GAOL",
@@ -118410,7 +118272,6 @@
     ],
     "references": [
       "GAPE",
-      "GAPES; THE GAPES",
       "GAPER",
       "GAPESING",
       "GAPEWORM",
@@ -118719,9 +118580,7 @@
     "variants": [
       "GARDE CIVIQUE\nGarde` ci`vique\". [F.]\n\nDefn: See Army organization, above."
     ],
-    "references": [
-      "GARDE CIVIQUE"
-    ]
+    "references": []
   },
   {
     "spellings": "GARDEN",
@@ -119678,7 +119537,6 @@
       "EUGANOIDEI",
       "GANOIDEI",
       "GAR",
-      "GAR PIKE; GARPIKE",
       "GINGLYMODI",
       "HOLOSTEI",
       "HYOGANOIDEI",
@@ -119874,9 +119732,7 @@
     "variants": [
       "GARTER STITCH\nGarter stitch.\n\nDefn: The simplest stitch in knitting."
     ],
-    "references": [
-      "GARTER STITCH"
-    ]
+    "references": []
   },
   {
     "spellings": "GARTH",
@@ -120347,7 +120203,6 @@
       "ENGINEERING",
       "FLAME",
       "GAS",
-      "GAS ENGINE",
       "INTERNAL-COMBUSTION; INTERNAL-COMBUSTION ENGINE",
       "OIL",
       "OTTO CYCLE",
@@ -120546,7 +120401,6 @@
     "references": [
       "AUTOMIXTE SYSTEM",
       "CARBURETOR; CARBURETTOR",
-      "GASOLINE ENGINE; GASOLENE ENGINE",
       "INTERNAL-COMBUSTION; INTERNAL-COMBUSTION ENGINE"
     ]
   },
@@ -121697,7 +121551,6 @@
       "GATLING GUN\nGat\"ling gun` (. Etym: [From the inventor, R.J. Gatling.]\n\nDefn: An American machine gun, consisting of a cluster of barrels\nwhich, being revolved by a crank, are automatically loaded and fired.\n\nNote: The improved Gatling gun can be fired at the rate of 1,200\nshots per minute. Farrow."
     ],
     "references": [
-      "GATLING GUN",
       "GUN"
     ]
   },
@@ -121707,8 +121560,7 @@
       "GATTEN TREE\nGat\"ten tree`. Etym: [Cf. Prov. E. gatter bush.] (Bot.)\n\nDefn: A name given to the small trees called guelder-rose (Viburnum\nOpulus), cornel (Cornus sanguinea), and spindle tree (Euonymus\nEuropæus)."
     ],
     "references": [
-      "GAITRE; GAYTRE",
-      "GATTEN TREE"
+      "GAITRE; GAYTRE"
     ]
   },
   {
@@ -121992,9 +121844,7 @@
     "variants": [
       "GAUGING ROD\nGau\"ging rod`.\n\nDefn: See Gauge rod, under Gauge, n."
     ],
-    "references": [
-      "GAUGING ROD"
-    ]
+    "references": []
   },
   {
     "spellings": "GAUL",
@@ -122838,9 +122688,7 @@
     "variants": [
       "GAYLEY PROCESS\nGay\"ley proc\"ess. (Med.)\n\nDefn: The process of removing moisture from the blast of an iron\nblast furnace by reducing its temperature so far that it will not\nremain suspended as vapor in the blast current, but will be deposited\nas snow in the cooling apparatus. The resultant uniformly dehydrated\nblast effects great economy in fuel consumption, and promotes\nregularity of furnace operation, and certainty of furnace control."
     ],
-    "references": [
-      "GAYLEY PROCESS"
-    ]
+    "references": []
   },
   {
     "spellings": "GAYLUSSITE",
@@ -123462,7 +123310,6 @@
       "GEISSLER TUBE\nGeis\"sler tube`. (Elec.)\n\nDefn: A glass tube provided with platinum electrodes, and containing\nsome gas under very low tension, which becomes luminous when an\nelectrical discharge is passed through it; -- so called from the name\nof a noted maker in germany. It is called also Plücker tube, from the\nGerman physicist who devised it."
     ],
     "references": [
-      "GEISSLER TUBE",
       "VACUUM"
     ]
   },
@@ -127299,7 +127146,6 @@
       "GENESEE EPOCH\nGen`e*see\" ep\"och. (Geol.)\n\nDefn: The closing subdivision of the Hamilton period in the American\nDevonian system; -- so called because the formations of this period\ncrop out in Genesee, New York."
     ],
     "references": [
-      "GENESEE EPOCH",
       "HAMILTON PERIOD"
     ]
   },
@@ -127639,7 +127485,6 @@
       "GENIP; GENIP TREE\nGen\"ip, n., or Genip tree.\n\n1. Any tree or shrub of the genus Genipa.\n\n2.  The West Indian sapindaceous tree Melicocca bijuga, which yields\nthe honeyberry; also, the related trees Exothea paniculata and E.\ntrifoliata."
     ],
     "references": [
-      "GENIP; GENIP TREE",
       "HONEYBERRY"
     ]
   },
@@ -127889,9 +127734,7 @@
     "variants": [
       "GENOA CAKE\nGen\"o*a cake. (Cookery)\n\nDefn: A rich glazed cake, with almonds, pistachios, filberts, or\nother nuts; also, a rich currant cake with almonds on the top."
     ],
-    "references": [
-      "GENOA CAKE"
-    ]
+    "references": []
   },
   {
     "spellings": "GENOESE",
@@ -128530,9 +128373,7 @@
     "variants": [
       "GENTLEMEN'S AGREEMENT\nGen\"tle*men's a*gree\"ment.\n\nDefn: An agreement binding only as a matter of honor; often, specif.,\nsuch an agreement among the heads of industrial or merchantile\nenterprises, the terms of which could not be included and enforced in\na legal contract."
     ],
-    "references": [
-      "GENTLEMEN'S AGREEMENT"
-    ]
+    "references": []
   },
   {
     "spellings": "GENTLENESS",
@@ -132078,9 +131919,7 @@
     "variants": [
       "GEORGE NOBLE\nGeorge\" no`ble. Etym: [So called from the image of St. George on it.]\n\nDefn: A gold noble of the time of Henry VIII. See Noble, n."
     ],
-    "references": [
-      "GEORGE NOBLE"
-    ]
+    "references": []
   },
   {
     "spellings": "GEORGIAN",
@@ -132099,9 +131938,7 @@
     "variants": [
       "GEORGIAN ARCHITECTURE\nGeorgian architecture.\n\nDefn: British or British colonial architecture of the period of the\nfour Georges, especially that of the period before 1800."
     ],
-    "references": [
-      "GEORGIAN ARCHITECTURE"
-    ]
+    "references": []
   },
   {
     "spellings": "GEORGIC",
@@ -132128,7 +131965,6 @@
       "GEORGIUM SIDUS\nGeor\"gi*um Si`dus. Etym: [NL., the star of George (III. of England).]\n(Astron.)\n\nDefn: The planet Uranus, so named by its discoverer, Sir W. Herschel."
     ],
     "references": [
-      "GEORGIUM SIDUS",
       "URANUS"
     ]
   },
@@ -132973,7 +132809,6 @@
       "EGG",
       "GAMETE",
       "GERM",
-      "GERM CELL",
       "IMPREGNATION",
       "MENDEL'S LAW",
       "OVUM",
@@ -133140,7 +132975,6 @@
       "GERM PLASM\nGerm\" plasm`, (Biol.)\n\nDefn: See Plasmogen, and Idioplasm."
     ],
     "references": [
-      "GERM PLASM",
       "PLASMOGEN",
       "WEISMANNISM"
     ]
@@ -133153,8 +132987,7 @@
     "references": [
       "FERMENTATION",
       "FERMENTATION THEORY",
-      "GERM",
-      "GERM THEORY"
+      "GERM"
     ]
   },
   {
@@ -133320,9 +133153,7 @@
     "variants": [
       "GESSO DURO\nGes\"so du\"ro. [It., hard plaster.]\n\nDefn: A variety of gesso which when dried becomes hard and durable,\noften used in making bas-relief casts, which are colored and mounted\nin elaborate frames."
     ],
-    "references": [
-      "GESSO DURO"
-    ]
+    "references": []
   },
   {
     "spellings": "GEST",
@@ -134203,9 +134034,7 @@
     "variants": [
       "GHOST DANCE\nGhost dance.\n\nDefn: A religious dance of the North American Indians, participated\nin by both sexes, and looked upon as a rite of invocation the purpose\nof which is, through trance and vision, to bring the dancer into\ncommunion with the unseen world and the spirits of departed friends.\nThe dance is the chief rite of the Ghost-dance, or Messiah, religion,\nwhich originated about 1890 in the doctrines of the Piute Wovoka, the\nIndian Messiah, who taught that the time was drawing near when the\nwhole Indian race, the dead with the living, should be reunited to\nlive a life of millennial happiness upon a regenerated earth. The\nreligion inculcates peace, righteousness, and work, and holds that in\ngood time, without warlike intervention, the oppressive white rule\nwill be removed by the higher powers. The religion spread through a\nmajority of the western tribes of the United States, only in the case\nof the Sioux, owing to local causes, leading to an outbreak."
     ],
-    "references": [
-      "GHOST DANCE"
-    ]
+    "references": []
   },
   {
     "spellings": "GHOSTFISH",
@@ -134584,7 +134413,6 @@
       "GIB BOOM\nGib\" boom`.\n\nDefn: See Jib boom."
     ],
     "references": [
-      "GIB BOOM",
       "JIB"
     ]
   },
@@ -134903,9 +134731,7 @@
     "variants": [
       "GIFFARD INJECTOR\nGif\"fard in*ject\"or. (Mach.)\n\nDefn: See under Injector."
     ],
-    "references": [
-      "GIFFARD INJECTOR"
-    ]
+    "references": []
   },
   {
     "spellings": "GIFFGAFF",
@@ -135327,7 +135153,6 @@
       "GILA MONSTER\nGi\"la mon\"ster. (Zoöl.)\n\nDefn: A large tuberculated lizard (Heloderma suspectum) native of the\ndry plains of Arizona, New Mexico, etc. It is the only lizard known\nto have venomous teeth."
     ],
     "references": [
-      "GILA MONSTER",
       "LIZARD"
     ]
   },
@@ -141849,7 +141674,6 @@
     ],
     "references": [
       "GLASS",
-      "GLASS MAKER; GLASSMAKER",
       "PONTEE"
     ]
   },
@@ -141984,9 +141808,7 @@
     "variants": [
       "GLASTONBURY THORN\nGlas\"ton*bur*y thorn`. (Bot.)\n\nDefn: A variety of the common hawthorn. Loudon."
     ],
-    "references": [
-      "GLASTONBURY THORN"
-    ]
+    "references": []
   },
   {
     "spellings": "GLASYNGE",
@@ -142012,7 +141834,6 @@
     "references": [
       "ALKALI SOIL",
       "EFFLORESCE",
-      "GLAUBER'S SALT; GLAUBER'S SALTS",
       "MIRABILITE",
       "SALT",
       "SODA"
@@ -142446,9 +142267,7 @@
     "variants": [
       "GLEE CLUB\nGlee club.\n\nDefn: A club or company organized for singing glees, and (by\nextension) part songs, ballads, etc."
     ],
-    "references": [
-      "GLEE CLUB"
-    ]
+    "references": []
   },
   {
     "spellings": "GLEED",
@@ -142577,7 +142396,6 @@
     ],
     "references": [
       "ABATE",
-      "GLENGARRY; GLENGARRY BONNET",
       "PRETENSION"
     ]
   },
@@ -142790,9 +142608,7 @@
     "variants": [
       "GLIDING ANGLE\nGliding angle. (Aëronautics)\n\nDefn: The angle, esp. the least angle, at which a gliding machine or\naëroplane will glide to earth by virtue of gravity without applied\npower."
     ],
-    "references": [
-      "GLIDING ANGLE"
-    ]
+    "references": []
   },
   {
     "spellings": "GLIDINGLY",
@@ -142807,8 +142623,7 @@
       "GLIDING MACHINE\nGliding machine. (Aëronautics)\n\nDefn: A construction consisting essentially of one or more aëroplanes\nfor gliding in an inclined path from a height to the ground."
     ],
     "references": [
-      "GLIDING ANGLE",
-      "GLIDING MACHINE"
+      "GLIDING ANGLE"
     ]
   },
   {
@@ -144520,8 +144335,7 @@
       "GLOST OVEN\nGlost\" ov`en.\n\nDefn: An oven in which glazed pottery is fired; -- also called glaze\nkiln, or glaze."
     ],
     "references": [
-      "GLAZE",
-      "GLOST OVEN"
+      "GLAZE"
     ]
   },
   {
@@ -147428,8 +147242,7 @@
     ],
     "references": [
       "ARAROBA",
-      "CHRYSAROBIN",
-      "GOA POWDER"
+      "CHRYSAROBIN"
     ]
   },
   {
@@ -150599,9 +150412,7 @@
     "variants": [
       "GOLDEN STATE\nGold\"en State.\n\nDefn: California; -- a nickname alluding to its rich gold deposits."
     ],
-    "references": [
-      "GOLDEN STATE"
-    ]
+    "references": []
   },
   {
     "spellings": "GOLDFINCH",
@@ -151081,9 +150892,7 @@
     "variants": [
       "GOLIATH BEETLE\nGo*li\"ath bee\"tle. Etym: [From Goliath, the Philistine giant.]\n(Zoöl.)\n\nDefn: Any species of Goliathus, a genus of very large and handsome\nAfrican beetles."
     ],
-    "references": [
-      "GOLIATH BEETLE"
-    ]
+    "references": []
   },
   {
     "spellings": "GOLL",
@@ -153284,9 +153093,7 @@
     "variants": [
       "GOOD NOW\nGood\" now\".\n\nDefn: An exclamation of wonder, surprise, or entreaty. [Obs.] Shak."
     ],
-    "references": [
-      "GOOD NOW"
-    ]
+    "references": []
   },
   {
     "spellings": "GOODS",
@@ -154014,8 +153821,7 @@
       "GOOSE EGG\nGoose egg.\n\nDefn: In games, a zero; a score or record of naught; -- so named in\nallusion to the egglike outline of the zero sign 0. Called also duck\negg. [Slang]"
     ],
     "references": [
-      "BIRD'S NEST; BIRD'S-NEST",
-      "GOOSE EGG"
+      "BIRD'S NEST; BIRD'S-NEST"
     ]
   },
   {
@@ -154144,18 +153950,14 @@
     "variants": [
       "GOPHER STATE\nGo\"pher State.\n\nDefn: Minnesota; -- a nickname alluding to the abundance of gophers."
     ],
-    "references": [
-      "GOPHER STATE"
-    ]
+    "references": []
   },
   {
     "spellings": "GOPHER WOOD",
     "variants": [
       "GOPHER WOOD\nGo\"pher wood`. Etym: [Heb. gopher.]\n\nDefn: A species of wood used in the construction of Noah's ark. Gen.\nvi. 14."
     ],
-    "references": [
-      "GOPHER WOOD"
-    ]
+    "references": []
   },
   {
     "spellings": "GORACCO",
@@ -154564,8 +154366,7 @@
     ],
     "references": [
       "COZEN",
-      "GORE",
-      "GORING; GORING CLOTH"
+      "GORE"
     ]
   },
   {
@@ -154641,9 +154442,7 @@
     "variants": [
       "GOROON SHELL\nGo*roon\" shell`. (Zoöl.)\n\nDefn: A large, handsome, marine, univalve shell (Triton femorale)."
     ],
-    "references": [
-      "GOROON SHELL"
-    ]
+    "references": []
   },
   {
     "spellings": "GORSE",
@@ -156047,9 +155846,7 @@
     "variants": [
       "GOULARDS EXTRACT\nGou*lard\"s\" ex\"tract\". Etym: [Named after the introducer, Thomas\nGoulard, a French surgeon.] (Med.)\n\nDefn: An aqueous solution of the subacetate of lead, used as a lotion\nin cases of inflammation. Goulard's cerate is a cerate containing\nthis extract."
     ],
-    "references": [
-      "GOULARDS EXTRACT"
-    ]
+    "references": []
   },
   {
     "spellings": "GOUR",
@@ -156140,9 +155937,7 @@
     "variants": [
       "GOURD TREE\nGourd\" tree\". (Bot.)\n\nDefn: A tree (the Crescentia Cujete, or calabash tree) of the West\nIndies and Central America."
     ],
-    "references": [
-      "GOURD TREE"
-    ]
+    "references": []
   },
   {
     "spellings": "GOURDWORM",
@@ -157163,7 +156958,6 @@
     "references": [
       "CHIH TAI",
       "DURBAR",
-      "GOVERNOR GENERAL",
       "LIEUTENANT"
     ]
   },
@@ -158631,7 +158425,6 @@
     "references": [
       "BREAD",
       "BROWN",
-      "GRAHAM BREAD",
       "GRAHAMITE"
     ]
   },
@@ -159385,7 +159178,6 @@
       "GRAMA GRASS\nGra\"ma grass`. Etym: [Sp. grama a sort of grass.] (Bot.)\n\nDefn: The name of several kinds of pasture grasses found in the\nWestern United States, esp. the Bouteloua oligostachya."
     ],
     "references": [
-      "GRAMA GRASS",
       "GRASS"
     ]
   },
@@ -159650,9 +159442,7 @@
     "variants": [
       "GRAMME MACHINE\nGramme\" ma*chine\". (Elec.)\n\nDefn: A kind of dynamo-electric machine; -- so named from its French\ninventor, M. Gramme. Knight."
     ],
-    "references": [
-      "GRAMME MACHINE"
-    ]
+    "references": []
   },
   {
     "spellings": "GRAMOPHONE",
@@ -160139,9 +159929,7 @@
     "variants": [
       "GRAND MERCY\nGrand\" mer\"cy.\n\nDefn: See Gramercy. [Obs.]"
     ],
-    "references": [
-      "GRAND MERCY"
-    ]
+    "references": []
   },
   {
     "spellings": "GRANDMOTHER",
@@ -160307,7 +160095,6 @@
       "GRANGER RAILROADS; GRANGER ROADS\nGran\"ger railroads, or Granger roads. (Finance)\n\nDefn: Certain railroads whose traffic largely consists in carrying\nthe produce of farmers or grangers; -- specifically applied to the\nChicago & Alton; Chicago, Burlington & Quincey; Chicago, Rock Island\n& Pacific; Chicago, Milwaukee & St. Paul; and Chicago & Northwestern,\nrailroads. [U. S.]."
     ],
     "references": [
-      "GRANGER RAILROADS; GRANGER ROADS",
       "GRANGER STOCKS; GRANGER SHARES"
     ]
   },
@@ -160316,9 +160103,7 @@
     "variants": [
       "GRANGER STOCKS; GRANGER SHARES\nGranger stocks or shares.\n\nDefn: Stocks or shares of the granger railroads."
     ],
-    "references": [
-      "GRANGER STOCKS; GRANGER SHARES"
-    ]
+    "references": []
   },
   {
     "spellings": "GRANIFEROUS",
@@ -160401,9 +160186,7 @@
       "GRANITE STATE\nGran\"ite State.\n\nDefn: New Hampshire; -- a nickname alluding to its mountains, which\nare chiefly of granite.",
       "GRANITE STATE\nGran\"ite State.\n\nDefn: New Hampshire; -- a nickname alluding to its mountains, which\nare chiefly of granite.\n[Webster 1913 Suppl.]"
     ],
-    "references": [
-      "GRANITE STATE"
-    ]
+    "references": []
   },
   {
     "spellings": "GRANITIC",
@@ -160980,7 +160763,6 @@
       "GRAPE FRUIT\nGrape\" fruit`.\n\nDefn: The shaddock."
     ],
     "references": [
-      "GRAPE FRUIT",
       "POMELO"
     ]
   },
@@ -161921,7 +161703,6 @@
       "GRASS TREE\nGrass\" tree\". (Bot.)\n(a) An Australian plant of the genus Xanthorrhoea, having a thick\ntrunk crowned with a dense tuft of pendulous, grasslike leaves, from\nthe center of which arises a long stem, bearing at its summit a dense\nflower spike looking somewhat like a large cat-tail. These plants are\noften called \"blackboys\" from the large trunks denuded and blackened\nby fire. They yield two kinds of fragrant resin, called Botany-bay\ngum, and Gum Acaroides.\n(b) A similar Australian plant (Kingia australis)."
     ],
     "references": [
-      "GRASS TREE",
       "GUM",
       "XANTHORHOEA"
     ]
@@ -162906,9 +162687,7 @@
     "variants": [
       "GRAVES' DISEASE\nGraves\"' dis*ease\". Etym: [So called after Dr. Graves, of Dublin.]\n\nDefn: Same as Basedow's disease."
     ],
-    "references": [
-      "GRAVES' DISEASE"
-    ]
+    "references": []
   },
   {
     "spellings": "GRAVESTONE",
@@ -164227,9 +164006,7 @@
     "variants": [
       "GREASE COCK; GREASE CUP\nGrease cock or cup . (Mach.)\n\nDefn: A cock or cup containing grease, to serve as a lubricator."
     ],
-    "references": [
-      "GREASE COCK; GREASE CUP"
-    ]
+    "references": []
   },
   {
     "spellings": "GREASER",
@@ -166508,9 +166285,7 @@
     "variants": [
       "GREAT WHITE WAY\nGreat White Way.\n\nDefn: Broadway, in New York City, in the neighborhood chiefly\noccupied by theaters, as from about 30th Street about 50th Street; --\nso called from its brilliant illumination at night."
     ],
-    "references": [
-      "GREAT WHITE WAY"
-    ]
+    "references": []
   },
   {
     "spellings": "GREAVE",
@@ -167234,9 +167009,7 @@
     "variants": [
       "GREEK CALENDAR\nGreek calendar.\n\n1. Any of various calendars used by the ancient Greek states. The\nAttic calendar divided the year into twelve months of 29 and 30 days,\nas follows:\n\n1. Hecatombæon (July-Aug.). 2. Metageitnion (Aug.-Sept.). 3.\nBoëdromion (Sept.-Oct.). 4. Pyanepsion (Oct.-Nov.). 5. Mæmacterion\n(Nov.-Dec.). 6. Poseideon (Dec.-Jan.). 7. Gamelion (Jan.-Feb.). 8.\nAnthesterion (Feb.-Mar.). 9. Elaphebolion (Mar.-Apr.). 10. Munychion\n(Apr.-May). 11. Thargelion (May-June). 12. Scirophorion (June-July).\n\nA fixed relation to the seasons was maintained by introducing an\nintercalary month, \"the second Poseideon,\" at first in an inexact\nway, afterward in years 3, 5, 8, 11, 13, 16, 19 of the Metonic cycle.\nDates were reckoned in Olympiads.\n\n2.  The Julian calendar, used in the Greek Church."
     ],
-    "references": [
-      "GREEK CALENDAR"
-    ]
+    "references": []
   },
   {
     "spellings": "GREEK CALENDS; GREEK KALENDS",
@@ -167244,8 +167017,7 @@
       "GREEK CALENDS; GREEK KALENDS\nGreek calends or kalends.\n\nDefn: A time that will never come, as the Greeks had no calends."
     ],
     "references": [
-      "CALENDS",
-      "GREEK CALENDS; GREEK KALENDS"
+      "CALENDS"
     ]
   },
   {
@@ -169778,9 +169550,7 @@
     "variants": [
       "GRINDLE STONE\nGrin\"dle stone\".\n\nDefn: A grindstone. [Obs.]"
     ],
-    "references": [
-      "GRINDLE STONE"
-    ]
+    "references": []
   },
   {
     "spellings": "GRINDLET",
@@ -169883,9 +169653,7 @@
     "variants": [
       "GRIP CAR\nGrip car.\n\nDefn: A car with a grip to clutch a traction cable."
     ],
-    "references": [
-      "GRIP CAR"
-    ]
+    "references": []
   },
   {
     "spellings": "GRIPE",
@@ -173979,9 +173747,7 @@
     "variants": [
       "GROZING IRON\nGro\"zing i\"ron.\n\n1. A tool with a hardened steel point, formerly used instead of a\ndiamond for cutting glass.\n\n2. (Plumbing)\n\nDefn: A tool for smoothing the solder joints of lead pipe. Knight."
     ],
-    "references": [
-      "GROZING IRON"
-    ]
+    "references": []
   },
   {
     "spellings": "GRUB",
@@ -174187,7 +173953,6 @@
       "GRUGRU PALM\nGru\"gru palm\". (Bot.)\n\nDefn: A West Indian name for several kinds of palm. See Macaw tree,\nunder Macaw. [Written also grigri palm.]"
     ],
     "references": [
-      "GRUGRU PALM",
       "MACAW"
     ]
   },
@@ -174197,7 +173962,6 @@
       "GRUGRU WORM\nGru\"gru worm\". (Zoöl.)\n\nDefn: The larva or grub of a large South American beetle (Calandra\npalmarum), which lives in the pith of palm trees and sugar cane. It\nis eaten by the natives, and esteemed a delicacy."
     ],
     "references": [
-      "GRUGRU WORM",
       "PALM"
     ]
   },
@@ -174400,9 +174164,7 @@
     "variants": [
       "GRUYERE CHEESE\nGru\"yère` cheese\n\nDefn: '' (Gruyère, Switzerland. It is a firm cheese containing\nnumerous cells, and is known in the United States as Schweitzerkäse."
     ],
-    "references": [
-      "GRUYERE CHEESE"
-    ]
+    "references": []
   },
   {
     "spellings": "GRY",
@@ -175185,7 +174947,6 @@
       "GUATEMALA GRASS\nGua`te*ma\"la grass\". (Bot.)\n\nDefn: See Teosinte."
     ],
     "references": [
-      "GUATEMALA GRASS",
       "TEOSINTE"
     ]
   },
@@ -175367,9 +175128,7 @@
     "variants": [
       "GUERNSEY LILY\nGuern\"sey lil\"y. (Bot.)\n\nDefn: A South African plant (Nerine Sarniensis) with handsome\nlilylike flowers, naturalized on the island of Guernsey."
     ],
-    "references": [
-      "GUERNSEY LILY"
-    ]
+    "references": []
   },
   {
     "spellings": "GUERRILLA",
@@ -175467,9 +175226,7 @@
     "variants": [
       "GUESS ROPE\nGuess\" rope\". (Naut.)\n\nDefn: A guess warp."
     ],
-    "references": [
-      "GUESS ROPE"
-    ]
+    "references": []
   },
   {
     "spellings": "GUESS WARP",
@@ -175477,8 +175234,7 @@
       "GUESS WARP\nGuess\" warp\". (Naut.)\n\nDefn: A rope or hawser by which a vessel is towed or warped along; --\nso called because it is necessary to guess at the length to be\ncarried in the boat making the attachment to a distant object."
     ],
     "references": [
-      "GUESS ROPE",
-      "GUESS WARP"
+      "GUESS ROPE"
     ]
   },
   {
@@ -175555,8 +175311,7 @@
       "GUEST ROPE\nGuest\" rope\". (Naut.)\n\nDefn: The line by which a boat makes fast to the swinging boom. Ham.\nNav. Encyc."
     ],
     "references": [
-      "GIFT",
-      "GUEST ROPE"
+      "GIFT"
     ]
   },
   {
@@ -175983,7 +175738,6 @@
     ],
     "references": [
       "DRAG LINE; DRAG ROPE",
-      "GUIDE ROPE",
       "TRAIL ROPE"
     ]
   },
@@ -176582,9 +176336,7 @@
     "variants": [
       "GUINEA-PIG DIRECTOR\nGuin\"ea-pig` di*rec\"tor.\n\nDefn: A director (usually one holding a number of directorships) who\nserves merely or mainly for the fee (in England, often a guinea) paid\nfor attendance. [Colloq.]"
     ],
-    "references": [
-      "GUINEA-PIG DIRECTOR"
-    ]
+    "references": []
   },
   {
     "spellings": "GUIPURE",
@@ -177770,7 +177522,6 @@
       "GUNNY; GUNNY CLOTH\nGun\"ny, n., Gun\"ny cloth` (. Etym: [Hind. gon, gon,, a sack,\nsacking.]\n\nDefn: A strong, coarse kind of sacking, made from the fibers (called\njute) of two plants of the genus Corchorus (C. olitorius and C.\ncapsularis), of India. The fiber is also used in the manufacture of\ncordage. Gunny bag, a sack made of gunny, used for coarse\ncommodities."
     ],
     "references": [
-      "GUNNY; GUNNY CLOTH",
       "JUTE",
       "TAT"
     ]
@@ -177916,9 +177667,7 @@
     "variants": [
       "GUNTER RIG\nGun\"ter rig`. (Naut.)\n\nDefn: A topmast arranged with metal bands so that it will readily\nslide up and down the lower mast."
     ],
-    "references": [
-      "GUNTER RIG"
-    ]
+    "references": []
   },
   {
     "spellings": "GUNTER'S CHAIN",
@@ -177927,7 +177676,6 @@
     ],
     "references": [
       "CHAIN",
-      "GUNTER'S CHAIN",
       "GUNTER'S SCALE",
       "LAND",
       "LINK"
@@ -177939,7 +177687,6 @@
       "GUNTER'S LINE\nGun\"ter's line`.\n\nDefn: A logarithmic line on Gunter's scale, used for performing the\nmultiplication and division of numbers mechanically by the dividers;\n-- called also line of lines, and line of numbers."
     ],
     "references": [
-      "GUNTER'S LINE",
       "LINE"
     ]
   },
@@ -177949,7 +177696,6 @@
       "GUNTER'S QUADRANT\nGun\"ter's quad`rant.\n\nDefn: A thin quadrant, made of brass, wood, etc., showing a\nstereographic projection on the plane of the equator. By it are found\nthe hour of the day, the sun's azimuth, the altitude of objects in\ndegrees, etc. See Gunter's scale."
     ],
     "references": [
-      "GUNTER'S QUADRANT",
       "GUNTER'S SCALE",
       "QUADRANT"
     ]
@@ -177963,7 +177709,6 @@
       "GUNTER'S CHAIN",
       "GUNTER'S LINE",
       "GUNTER'S QUADRANT",
-      "GUNTER'S SCALE",
       "SCALE"
     ]
   },
@@ -179402,9 +179147,7 @@
     "variants": [
       "GYPSY MOTH; GIPSY MOTH\nGyp\"sy, or Gip\"sy, moth  .\n\nDefn: A tussock moth (Ocneria dispar) native of the Old World, but\naccidentally introduced into eastern Massachusetts about 1869, where\nits caterpillars have done great damage to fruit, shade, and forest\ntrees of many kinds. The male gypsy moth is yellowish brown, the\nfemale white, and larger than the male. In both sexes the wings are\nmarked by dark lines and a dark lunule. The caterpillars, when full-\ngrown, have a grayish mottled appearance, with blue tubercles on the\nanterior and red tubercles on the posterior part of the body, all\ngiving rise to long yellow and black hairs. They usually pupate in\nJuly and the moth appears in August. The eggs are laid on tree\ntrunks, rocks, etc., and hatch in the spring."
     ],
-    "references": [
-      "GYPSY MOTH; GIPSY MOTH"
-    ]
+    "references": []
   },
   {
     "spellings": "GYPSYWORT",

--- a/output/wordDisplayData#H-I.json
+++ b/output/wordDisplayData#H-I.json
@@ -1590,7 +1590,6 @@
     ],
     "references": [
       "ELECTRIFY",
-      "HABEAS CORPUS",
       "SUSPEND",
       "SUSPENSION"
     ]
@@ -4890,9 +4889,7 @@
     "variants": [
       "HAGUE TRIBUNAL\nHague Tribunal.\n\nDefn: The permanent court of arbitration created by the\n\"International Convention for the Pacific Settle of International\nDisputes.\", adopted by the International Peace Conference of 1899. It\nis composed of persons of known competency in questions of\ninternational law, nominated by the signatory powers. From these\npersons an arbitration tribunal is chosen by the parties to a\ndifference submitted to the court. On the failure of the parties to\nagree directly on the arbitrators, each chooses two arbitrators, an\numpire is selected by them, by a third power, or by two powers\nselected by the parties."
     ],
-    "references": [
-      "HAGUE TRIBUNAL"
-    ]
+    "references": []
   },
   {
     "spellings": "HAH",
@@ -4956,9 +4953,7 @@
     "variants": [
       "HAIKWAN TAEL\nHaikwan tael.\n\nDefn: A Chinese weight ( 1/10 catty) equivalent to 1 1/3 oz. or\n37.801 g."
     ],
-    "references": [
-      "HAIKWAN TAEL"
-    ]
+    "references": []
   },
   {
     "spellings": "HAIL",
@@ -5716,8 +5711,7 @@
       "HAIR GRASS\nHair\" grass`. (Bot.)\n\nDefn: A grass with very slender leaves or branches; as the Agrostis\nscabra, and several species of Aira or Deschampsia."
     ],
     "references": [
-      "FLYAWAY GRASS",
-      "HAIR GRASS"
+      "FLYAWAY GRASS"
     ]
   },
   {
@@ -6890,8 +6884,7 @@
     ],
     "references": [
       "BLOOD",
-      "BROTHER",
-      "HALF BLOOD"
+      "BROTHER"
     ]
   },
   {
@@ -7109,9 +7102,7 @@
     "variants": [
       "HALF NELSON\nHalf nelson. (Wrestling)\n\nDefn: A hold in which one arm is thrust under the corresponding arm\nof the opponent, generally behind, and the hand placed upon the back\nof his neck. In the full nelson both hands are so placed."
     ],
-    "references": [
-      "HALF NELSON"
-    ]
+    "references": []
   },
   {
     "spellings": "HALFNESS",
@@ -7182,7 +7173,6 @@
       "HALF SEAS OVER\nHalf\" seas` o`ver.\n\nDefn: Half drunk. [Slang: used only predicatively.] Spectator."
     ],
     "references": [
-      "HALF SEAS OVER",
       "SEA"
     ]
   },
@@ -7227,7 +7217,6 @@
       "HALF TONE; HALF-TONE\nHalf tone, or Half\"-tone`, n.\n\n1. (Fine Arts)\n (a) An intermediate or middle tone in a painting, engraving,\nphotograph, etc.; a middle tint, neither very dark nor very light.\n (b) A half-tone photo-engraving.\n\n2.  (Music) A half step."
     ],
     "references": [
-      "HALF TONE; HALF-TONE",
       "HALF-TONE"
     ]
   },
@@ -8929,8 +8918,7 @@
       "HAMILTON PERIOD\nHam\"il*ton pe\"ri*od. (Geol.)\n\nDefn: A subdivision of the Devonian system of America; -- so named\nfrom Hamilton, Madison Co., New York. It includes the Marcellus,\nHamilton, and Genesee epochs or groups. See the Chart of Geology."
     ],
     "references": [
-      "GENESEE EPOCH",
-      "HAMILTON PERIOD"
+      "GENESEE EPOCH"
     ]
   },
   {
@@ -9143,9 +9131,7 @@
     "variants": [
       "HAMMER BREAK\nHam\"mer break. (Elec.)\n\nDefn: An interrupter in which contact is broken by the movement of an\nautomatically vibrating hammer between a contact piece and an\nelectromagnet, or of a rapidly moving piece mechanically driven."
     ],
-    "references": [
-      "HAMMER BREAK"
-    ]
+    "references": []
   },
   {
     "spellings": "HAMMERCLOTH",
@@ -9213,9 +9199,7 @@
     "variants": [
       "HAMMER LOCK\nHammer lock. (Wrestling)\n\nDefn: A hold in which an arm of one contestant is held twisted and\nbent behind his back by his opponent."
     ],
-    "references": [
-      "HAMMER LOCK"
-    ]
+    "references": []
   },
   {
     "spellings": "HAMMERMAN",
@@ -11727,8 +11711,7 @@
       "HANSOM; HANSOM CAB\nHan\"som, n., Han\"som cab` (. Etym: [From the name of the inventor.]\n\nDefn: A light, low, two-wheeled covered carriage with the driver's\nseat elevated behind, the reins being passed over the top.\nHe hailed a cruising hansom . . . \" 'Tis the gondola of London,\" said\nLothair. Beaconsfield."
     ],
     "references": [
-      "CAB",
-      "HANSOM; HANSOM CAB"
+      "CAB"
     ]
   },
   {
@@ -12591,7 +12574,6 @@
       "HARBOR MASTER\nHar\"bor mas`ter.\n\nDefn: An officer charged with the duty of executing the regulations\nrespecting the use of a harbor."
     ],
     "references": [
-      "HARBOR MASTER",
       "HAVENER",
       "PORT",
       "SHEBANDER"
@@ -13546,7 +13528,6 @@
     ],
     "references": [
       "GRASS",
-      "HARD GRASS",
       "ORCHARD"
     ]
   },
@@ -13907,7 +13888,6 @@
       "HARD STEEL\nHard steel.\n\nDefn: Steel hardened by the addition of other elements, as manganese,\nphosphorus, or (usually) carbon."
     ],
     "references": [
-      "HARD STEEL",
       "JIG",
       "TOOL STEEL"
     ]
@@ -14171,7 +14151,6 @@
     ],
     "references": [
       "HAIRBRAINED",
-      "HAREBRAINED; HARE BRAINED",
       "PROSELYTE"
     ]
   },
@@ -14241,9 +14220,7 @@
     "variants": [
       "HARE'S-FOOT FERN\nHare's\"-foot` fern`. (Bot.)\n\nDefn: A species of fern (Davallia Canariensis) with a soft, gray,\nhairy rootstock; -- whence the name."
     ],
-    "references": [
-      "HARE'S-FOOT FERN"
-    ]
+    "references": []
   },
   {
     "spellings": "HARE'S-TAIL",
@@ -14264,9 +14241,7 @@
     "variants": [
       "HARIALI GRASS\nHa`ri*a\"li grass`. (Bot.)\n\nDefn: The East Indian name of the Cynodon Dactylon; dog's-grass."
     ],
-    "references": [
-      "HARIALI GRASS"
-    ]
+    "references": []
   },
   {
     "spellings": "HARICOT",
@@ -14360,9 +14335,7 @@
     "variants": [
       "HARLECH GROUP\nHar\"lech group`. Etym: [ So called from Harlech in Wales.] (Geol.)\n\nDefn: A minor subdivision at the base of the Cambrian system in\nWales."
     ],
-    "references": [
-      "HARLECH GROUP"
-    ]
+    "references": []
   },
   {
     "spellings": "HARLEQUIN",
@@ -15134,9 +15107,7 @@
     "variants": [
       "HARNESS CASK\nHar\"ness cask`. (Naut.)\n\nDefn: A tub lashed to a vessel's deck and containing salted\nprovisions for daily use; -- called also harness tub. W. C. Russell."
     ],
-    "references": [
-      "HARNESS CASK"
-    ]
+    "references": []
   },
   {
     "spellings": "HARNESSER",
@@ -15259,7 +15230,6 @@
       "HARPING IRON\nHarp\"ing i`ron. Etym: [F.harper to grasp strongly. See Harpoon.]\n\nDefn: A harpoon. Evelyn."
     ],
     "references": [
-      "HARPING IRON",
       "HARPOON"
     ]
   },
@@ -15764,7 +15734,6 @@
       "HART'S CLOVER\nHart's` clo`ver. (Bot.)\n\nDefn: Melilot or sweet clover. See Melilot."
     ],
     "references": [
-      "HART'S CLOVER",
       "MELILOT"
     ]
   },
@@ -15959,7 +15928,6 @@
       "HARVEY PROCESS\nHar\"vey proc\"ess. (Metal.)\n\nDefn: A process of hardening the face of steel, as armor plates,\ninvented by Hayward A. Harvey of New Jersey, consisting in the\nadditional carburizing of the face of a piece of low carbon steel by\nsubjecting it to the action of carbon under long-continued pressure\nat a very high heat, and then to a violent chilling, as by a spray of\ncold water. This process gives an armor plate a thick surface of\nextreme hardness supported by material gradually decreasing in\nhardness to the unaltered soft steel at the back."
     ],
     "references": [
-      "HARVEY PROCESS",
       "KRUPP PROCESS"
     ]
   },
@@ -19428,9 +19396,7 @@
     "variants": [
       "HASTINGS SANDS\nHas\"tings sands\". (Geol.)\n\nDefn: The lower group of the Wealden formation; -- so called from its\ndevelopment around Hastings, in Sussex, England."
     ],
-    "references": [
-      "HASTINGS SANDS"
-    ]
+    "references": []
   },
   {
     "spellings": "HASTIVE",
@@ -19542,7 +19508,6 @@
       "HASTY PUDDING\nHas\"ty pud\"ding.\n\n1. A thick batter pudding made of Indian meal stirred into boiling\nwater; mush. [U. S.]\n\n2. A batter or pudding made of flour or oatmeal, stirred into boiling\nwater or milk. [Eng.]"
     ],
     "references": [
-      "HASTY PUDDING",
       "MUSH",
       "STIRABOUT",
       "SUPAWN"
@@ -19823,9 +19788,7 @@
     "variants": [
       "HATCHET MAN\nHatchet man\n\nDefn: 1. A person hired to murder or physically attack another; a hit\nman.\n\nDefn: 2. A person who deliberately tries to ruin the reputation of\nanother, often unscrupulously, by slander or other malicious\ncommunication, often with political motive, and sometimes for pay."
     ],
-    "references": [
-      "HATCHET MAN"
-    ]
+    "references": []
   },
   {
     "spellings": "HATCHETTINE; HATCHETTITE",
@@ -29968,9 +29931,7 @@
     "variants": [
       "HAWKEYE STATE\nHawk\"eye` State.\n\nDefn: Iowa; -- a nickname of obscure origin."
     ],
-    "references": [
-      "HAWKEYE STATE"
-    ]
+    "references": []
   },
   {
     "spellings": "HAWK MOTH",
@@ -29979,7 +29940,6 @@
     ],
     "references": [
       "HAWK",
-      "HAWK MOTH",
       "HETEROCERA",
       "HOG",
       "HUMMING",
@@ -35701,8 +35661,7 @@
     ],
     "references": [
       "BRIDLE",
-      "HEAD",
-      "HEAD GEAR; HEADGEAR"
+      "HEAD"
     ]
   },
   {
@@ -35845,9 +35804,7 @@
     "variants": [
       "HEADMOLD SHOT; HEADMOULD SHOT\nHead\"mold\" shot\", Head\"mould` shot\". (Med.)\n\nDefn: An old name for the condition of the skull, in which the bones\nride, or are shot, over each other at the sutures. Dunglison."
     ],
-    "references": [
-      "HEADMOLD SHOT; HEADMOULD SHOT"
-    ]
+    "references": []
   },
   {
     "spellings": "HEADMOST",
@@ -40004,9 +39961,7 @@
     "variants": [
       "HEAVE OFFERING\nHeave\" of`fer*ing. (Jewish Antiq.)\n\nDefn: An offering or oblation heaved up or elevated before the altar,\nas the shoulder of the peace offering. See Wave offering. Ex. xxix.\n27."
     ],
-    "references": [
-      "HEAVE OFFERING"
-    ]
+    "references": []
   },
   {
     "spellings": "HEAVER",
@@ -40094,9 +40049,7 @@
     "variants": [
       "HEAVILY-TRAVELED; HEAVILY TRAVELED\nheavily-traveled, heavily traveled adj.\n\nDefn: subject to much traffic or travel; as, the region's most\nheavily traveled highways.\nSyn. -- heavily traveled.\n[WordNet 1.5]"
     ],
-    "references": [
-      "HEAVILY-TRAVELED; HEAVILY TRAVELED"
-    ]
+    "references": []
   },
   {
     "spellings": "HEAVINESS",
@@ -40707,7 +40660,6 @@
       "BARIUM",
       "BARYTES",
       "CAWK",
-      "HEAVY SPAR",
       "PERMANENT",
       "PONDEROUS",
       "TERRA"
@@ -40982,9 +40934,7 @@
     "variants": [
       "HEBREW CALENDAR\nHebrew calendar.\n\nDefn: = Jewish calendar."
     ],
-    "references": [
-      "HEBREW CALENDAR"
-    ]
+    "references": []
   },
   {
     "spellings": "HEBREWESS",
@@ -41436,9 +41386,7 @@
     "variants": [
       "HEDGING BILL\nHedg\"ing bill`.\n\nDefn: A hedge bill. See under Hedge."
     ],
-    "references": [
-      "HEDGING BILL"
-    ]
+    "references": []
   },
   {
     "spellings": "HEDONIC",
@@ -49257,9 +49205,7 @@
     "variants": [
       "HENRIETTA CLOTH\nHen`ri*et\"ta cloth`.\n\nDefn: A fine wide wooled fabric much used for women's dresses."
     ],
-    "references": [
-      "HENRIETTA CLOTH"
-    ]
+    "references": []
   },
   {
     "spellings": "HENROOST",
@@ -49835,9 +49781,7 @@
     "variants": [
       "HEP TREE\nHep\" tree`. Etym: [See Hep.]\n\nDefn: The wild dog-rose."
     ],
-    "references": [
-      "HEP TREE"
-    ]
+    "references": []
   },
   {
     "spellings": "HEPTYL",
@@ -56172,9 +56116,7 @@
     "variants": [
       "HICCIUS DOCTIUS\nHic\"ci*us doc\"ti*us. Etym: [Corrupted fr. L. hic est doctus this is a\nlearned man.]\n\nDefn: A juggler. [Cant] hocus pocus Hudibras."
     ],
-    "references": [
-      "HICCIUS DOCTIUS"
-    ]
+    "references": []
   },
   {
     "spellings": "HICCOUGH",
@@ -58028,9 +57970,7 @@
     "variants": [
       "HIGHER CRITICISM\nHigh\"er crit\"i*cism.\n\nDefn: Criticism which includes the study of the contents, literary\ncharacter, date, authorship, etc., of any writing; as, the higher\ncriticism of the Pentateuch. Called also historical criticism.\n\nThe comparison of the Hebrew and Greek texts . . . introduces us to a\nseries of questions affecting the composition, the editing, and the\ncollection of the sacred books. This class of questions forms the\nspecial subject of the branch of critical science which is usually\ndistinguished from the verbal criticism of the text by the name of\nhigher, or historical, criticism.\nW. Robertson Smith."
     ],
-    "references": [
-      "HIGHER CRITICISM"
-    ]
+    "references": []
   },
   {
     "spellings": "HIGHERING",
@@ -58044,9 +57984,7 @@
     "variants": [
       "HIGHER THOUGHT\nHigher thought.\n\nDefn: See New thought, below."
     ],
-    "references": [
-      "HIGHER THOUGHT"
-    ]
+    "references": []
   },
   {
     "spellings": "HIGHER-UP",
@@ -58083,9 +58021,7 @@
     "variants": [
       "HIGH FIVE\nHigh five.\n\nDefn: See Cinch (the game)."
     ],
-    "references": [
-      "HIGH FIVE"
-    ]
+    "references": []
   },
   {
     "spellings": "HIGHFLIER",
@@ -58541,7 +58477,6 @@
       "CONFARREATION",
       "EPHOD",
       "HIGH",
-      "HIGH PRIEST",
       "HIGH-PRIESTHOOD",
       "HOLY",
       "IDIOT",
@@ -58683,9 +58618,7 @@
     "variants": [
       "HIGH STEEL\nHigh steel.\n\nDefn: Steel containing a high percentage of carbon; high-carbon\nsteel."
     ],
-    "references": [
-      "HIGH STEEL"
-    ]
+    "references": []
   },
   {
     "spellings": "HIGH-STEPPER",
@@ -58920,7 +58853,6 @@
       "HILARY TERM\nHil\"a*ry term`.\n\nDefn: Formerly, one of the four terms of the courts of common law in\nEngland, beginning on the eleventh of January and ending on the\nthirty-first of the same month, in each year; -- so called from the\nfestival of St. Hilary, January 13th.\n\nNote: The Hilary term is superseded by the Hilary sittings, which\ncommence on the eleventh of January and end on the Wednesday before\nEaster. Mozley & W."
     ],
     "references": [
-      "HILARY TERM",
       "TERM"
     ]
   },
@@ -61965,9 +61897,7 @@
     "variants": [
       "HINDLEYS SCREW\nHind\"ley\"s screw`. (Mech.)\n\nDefn: A screw cut on a solid whose sides are arcs of the periphery of\na wheel into the teeth of which the screw is intended to work. It is\nnamed from the person who first used the form."
     ],
-    "references": [
-      "HINDLEYS SCREW"
-    ]
+    "references": []
   },
   {
     "spellings": "HINDOO; HINDU",
@@ -62022,9 +61952,7 @@
     "variants": [
       "HINDOO CALENDAR; HINDU CALENDAR\nHin\"doo, or Hindu, calendar  .\n\nDefn: A lunisolar calendar of India, according to which the year is\ndivided into twelve months, with an extra month inserted after every\nmonth in which two new moons occur (once in three years). The\nintercalary month has the name of the one which precedes it. The year\nusually commences about April 11. The months are follows:\n\nBaisakh . . . . . . . . . .    April-May\nJeth . . . . . . . . . . . . . May-June\nAsarh . . . . . . . . . . . .  June-July\nSawan (Sarawan) . . . . . . .  July-Aug.\nBhadon . . . . . . . . . . .   Aug.-Sept.\nAsin (Kuar). . . . . . . . . . Sept.-Oct.\nKatik (Kartik) . . . . . . . . Oct.-Nov.\nAghan . . . . . . . . . . . .  Nov.-Dec.\nPus . . . . . . . . . . . . .  Dec.-Jan.\nMagh . . . . . . . . . . . . . Jan.-Feb.\nPhagun (Phalgun) . . . . . . . Feb.-March\nChait . . . . . . . . . . . .  March-April"
     ],
-    "references": [
-      "HINDOO CALENDAR; HINDU CALENDAR"
-    ]
+    "references": []
   },
   {
     "spellings": "HINDOOISM; HINDUISM",
@@ -62427,9 +62355,7 @@
     "variants": [
       "HIP LOCK\nHip lock. (Wrestling)\n\nDefn: A lock in which a close grip is obtained and a fall attempted\nby a heave over the hip."
     ],
-    "references": [
-      "HIP LOCK"
-    ]
+    "references": []
   },
   {
     "spellings": "HIPPA; HIPPE",
@@ -62719,8 +62645,7 @@
     ],
     "references": [
       "EGLANTINE",
-      "HIP",
-      "HIP TREE"
+      "HIP"
     ]
   },
   {
@@ -62870,9 +62795,7 @@
     "variants": [
       "HIRE PURCHASE; HIRE PURCHASE AGREEMENT; HIRE AND PURCHASE AGREEMENT\nHire purchase, or, more fully, Hire purchase agreement, or Hire and\npurchase agreement. (Law)\n\nDefn: A contract (more fully called contract of hire with an option\nof purchase) in which a person hires goods for a specified period and\nat a fixed rent, with the added condition that if he shall retain the\ngoods for the full period and pay all the installments of rent as\nthey become due the contract shall determine and the title vest\nabsolutely in him, and that if he chooses he may at any time during\nthe term surrender the goods and be quit of any liability for future\ninstallments upon the contract. In the United States such a contract\nis generally treated as a conditional sale, and the term hire\npurchase is also sometimes applied to a contract in which the hirer\nis not free to avoid future liability by surrender of the goods. In\nEngland, however, if the hirer does not have this right the contract\nis a sale."
     ],
-    "references": [
-      "HIRE PURCHASE; HIRE PURCHASE AGREEMENT; HIRE AND PURCHASE AGREEMENT"
-    ]
+    "references": []
   },
   {
     "spellings": "HIRER",
@@ -69201,9 +69124,7 @@
     "variants": [
       "HITTORF RAYS\nHit\"torf rays. (Elec.)\n\nDefn: Rays (chiefly cathode rays) developed by the electric discharge\nin Hittorf tubes."
     ],
-    "references": [
-      "HITTORF RAYS"
-    ]
+    "references": []
   },
   {
     "spellings": "HITTORF TUBE",
@@ -69211,8 +69132,7 @@
       "HITTORF TUBE\nHit\"torf tube. (Elec.)\n (a) A highly exhausted glass tube with metallic electrodes nearly in\ncontact so as to exhibit the insulating effects of a vacuum. It was\nused by the German physicist W. Hittorf (b. 1824).\n (b) A Crookes tube."
     ],
     "references": [
-      "HITTORF RAYS",
-      "HITTORF TUBE"
+      "HITTORF RAYS"
     ]
   },
   {
@@ -69812,9 +69732,7 @@
     "variants": [
       "HOBBLE SKIRT\nHob\"ble skirt.\n\nDefn: A woman's skirt so scant at the bottom as to restrain freedom\nof movement after the fashion of a hobble. -- Hob\"ble-skirt`ed, a."
     ],
-    "references": [
-      "HOBBLE SKIRT"
-    ]
+    "references": []
   },
   {
     "spellings": "HOBBLINGLY",
@@ -69945,9 +69863,7 @@
     "variants": [
       "HOBSON'S CHOICE\nHob\"son's choice\".\n\nDefn: A choice without an alternative; the thing offered or nothing.\n\nNote: It is said to have had its origin in the name of one Hobson, at\nCambridge, England, who let horses, and required every customer to\ntake in his turn the horse which stood next the stable door."
     ],
-    "references": [
-      "HOBSON'S CHOICE"
-    ]
+    "references": []
   },
   {
     "spellings": "HOCCO",
@@ -70133,9 +70049,7 @@
     "variants": [
       "HODGKIN'S DISEASE\nHodg`kin's dis*ease\". (Med.)\n\nDefn: A morbid condition characterized by progressive anæmia and\nenlargement of the lymphatic glands; -- first described by Dr.\nHodgkin, an English physician."
     ],
-    "references": [
-      "HODGKIN'S DISEASE"
-    ]
+    "references": []
   },
   {
     "spellings": "HODIERN; HODIERNAL",
@@ -72156,9 +72070,7 @@
     "variants": [
       "HOLE IN THE AIR\nHole in the air. (Aëronautics)\n\nDefn: = Air hole, above."
     ],
-    "references": [
-      "HOLE IN THE AIR"
-    ]
+    "references": []
   },
   {
     "spellings": "HOLETHNIC",
@@ -72767,9 +72679,7 @@
     "variants": [
       "HOLLANDAISE SAUCE; HOLLANDAISE\nHol`lan*daise\" sauce, or Hol`lan*daise\", n. [F. hollandaise, fem. of\nhollandais Dutch.] (Cookery)\n\nDefn: A sauce consisting essentially of a seasoned emulsion of butter\nand yolk of eggs with a little lemon juice or vinegar."
     ],
-    "references": [
-      "HOLLANDAISE SAUCE; HOLLANDAISE"
-    ]
+    "references": []
   },
   {
     "spellings": "HOLLANDER",
@@ -73923,7 +73833,6 @@
       "HOLY CROSS\nHo\"ly cross\".\n\nDefn: The cross as the symbol of Christ's crucifixion. Congregation\nof the Holy Cross (R. C. Ch.), a community of lay brothers and\npriests, in France and the United States, engaged chiefly in teaching\nand manual Labor. Originally called Brethren of St. Joseph. The\nSisters of the Holy Cross engage in similar work. Addis & Arnold.\n -- Holy-cross day, the fourteenth of September, observed as a church\nfestival, in memory of the exaltation of our Savior's cross."
     ],
     "references": [
-      "HOLY CROSS",
       "PASSIONIST",
       "RUDMASDAY"
     ]
@@ -76210,9 +76119,7 @@
     "variants": [
       "HONITON LACE\nHon\"i*ton lace`\n\nDefn: . A kind of pillow lace, remarkable for the beauty of its\nfigures; -- so called because chiefly made in Honiton, England."
     ],
-    "references": [
-      "HONITON LACE"
-    ]
+    "references": []
   },
   {
     "spellings": "HONK",
@@ -77049,9 +76956,7 @@
     "variants": [
       "HOOD MOLDING; HOOD MOULDING\nHood\" mold`ing Hood\" mould`ing. (Arch.)\n\nDefn: A projecting molding over the head of an arch, forming the\noutermost member of the archivolt; -- called also hood mold."
     ],
-    "references": [
-      "HOOD MOLDING; HOOD MOULDING"
-    ]
+    "references": []
   },
   {
     "spellings": "HOODOO",
@@ -77909,18 +77814,14 @@
     "variants": [
       "HOOKE'S GEARING\nHooke's\" gear\"ing. Etym: [So called from the inventor.] (Mach.)\n\nDefn: Spur gearing having teeth slanting across the face of the\nwheel, sometimes slanting in opposite directions from the middle."
     ],
-    "references": [
-      "HOOKE'S GEARING"
-    ]
+    "references": []
   },
   {
     "spellings": "HOOKE'S JOINT",
     "variants": [
       "HOOKE'S JOINT\nHooke's joint. Etym: [So called from the inventor.] (Mach.)\n\nDefn: A universal joint. See under Universal."
     ],
-    "references": [
-      "HOOKE'S JOINT"
-    ]
+    "references": []
   },
   {
     "spellings": "HOOKEY",
@@ -78075,9 +77976,7 @@
     "variants": [
       "HOOSIER STATE\nHoo\"sier State.\n\nDefn: Indiana; -- a nickname of obscure origin."
     ],
-    "references": [
-      "HOOSIER STATE"
-    ]
+    "references": []
   },
   {
     "spellings": "HOOT",
@@ -80149,18 +80048,14 @@
     "variants": [
       "HORS DE COMBAT\nHors` de com`bat\". Etym: [F.]\n\nDefn: Out of the combat; disabled from fighting."
     ],
-    "references": [
-      "HORS DE COMBAT"
-    ]
+    "references": []
   },
   {
     "spellings": "HORS D'OEUVRE",
     "variants": [
       "HORS D'OEUVRE\nHors` d'ouvre\"; pl. Hors d'ouveres (#). [F., lit., outside of work.]\n\n1. Something unusual or extraordinary. [R.]\n\n2.  A dish served as a relish, usually at the beginning of a meal."
     ],
-    "references": [
-      "HORS D'OEUVRE"
-    ]
+    "references": []
   },
   {
     "spellings": "HORSE",
@@ -81122,9 +81017,7 @@
     "variants": [
       "HORSE GUARDS\nHorse\" Guards`. (Mil.)\n\nDefn: A body of cavalry so called; esp., a British regiment, called\nthe Royal Horse Guards, which furnishes guards of state for the\nsovereign. The Horse Guards, a name given to the former headquarters\nof the commander in chief of the British army, at Whitehall in\nLondon."
     ],
-    "references": [
-      "HORSE GUARDS"
-    ]
+    "references": []
   },
   {
     "spellings": "HORSEHAIR",
@@ -81312,7 +81205,6 @@
       "HAYFORK",
       "HORSE",
       "HORSELESS",
-      "HORSE POWER",
       "INDICATED",
       "JACK",
       "POWER",
@@ -81557,9 +81449,7 @@
     "variants": [
       "HORTUS SICCUS\nHor\"tus sic\"cus. Etym: [L., a dry garden.]\n\nDefn: A collection of specimens of plants, dried and preserved, and\narranged systematically; an herbarium."
     ],
-    "references": [
-      "HORTUS SICCUS"
-    ]
+    "references": []
   },
   {
     "spellings": "HORTYARD",
@@ -82212,9 +82102,7 @@
     "variants": [
       "HOST PLANT\nHost plant. (Agric.)\n\nDefn: A plant which aids, shelters, or protects another plant in its\ngrowth, as those which are used for nurse crops."
     ],
-    "references": [
-      "HOST PLANT"
-    ]
+    "references": []
   },
   {
     "spellings": "HOSTRY",
@@ -82514,7 +82402,6 @@
     "references": [
       "BLAST",
       "CUPELLATION",
-      "HOT BLAST",
       "WATER TU TUYERE"
     ]
   },
@@ -82538,7 +82425,6 @@
       "HOT BULB; HOT POT\nHot bulb, Hot pot. (Internal-combustion Engines)\n\nDefn: See Semi-diesel, below."
     ],
     "references": [
-      "HOT BULB; HOT POT",
       "SEMI-DIESEL"
     ]
   },
@@ -82548,8 +82434,7 @@
       "HOTCHKISS GUN\nHotch\"kiss gun [After Benjamin B. Hotchkiss (1826-85), American\ninventor.]\n\nDefn: A built-up, rifled, rapid-fire gun of oil-tempered steel,\nhaving a rectangular breechblock which moves horizontally or\nvertically in a mortise cut completely through the jacket. It is made\nin France."
     ],
     "references": [
-      "GUN",
-      "HOTCHKISS GUN"
+      "GUN"
     ]
   },
   {
@@ -86482,9 +86367,7 @@
     "variants": [
       "HUIA BIRD\nHu\"ia bird`. Etym: [Native name; -- so called from its cry.] (Zoöl.)\n\nDefn: A New Zealand starling (Heteralocha acutirostris), remarkable\nfor the great difference in the form and length of the bill in the\ntwo sexes, that of the male being sharp and straight, that of the\nfemale much longer and strongly curved."
     ],
-    "references": [
-      "HUIA BIRD"
-    ]
+    "references": []
   },
   {
     "spellings": "HUISHER",
@@ -88569,7 +88452,6 @@
       "HUMPBACKED SALMON\nHump\"backed` salm\"on.\n\nDefn: A small salmon (Oncorhynchus gorbuscha) which ascends the\nrivers of the Pacific coast from California to Alaska, and also on\nthe Asiatic side. In the breeding season the male has a large dorsal\nhump and distorted jaws."
     ],
     "references": [
-      "HUMPBACKED SALMON",
       "SALMON"
     ]
   },
@@ -93368,9 +93250,7 @@
     "variants": [
       "HYDROPNEUMATIC GUN CARRIAGE\nHy`dro*pneu*mat\"ic gun carriage. (Ordnance)\n\nDefn: A disappearing gun carriage in which the recoil is checked by\ncylinders containing liquid and air, the air when compressed\nfurnishing the power for restoring the gun to the firing position. It\nis used with some English and European heavy guns."
     ],
-    "references": [
-      "HYDROPNEUMATIC GUN CARRIAGE"
-    ]
+    "references": []
   },
   {
     "spellings": "HYDROPSY",
@@ -97074,8 +96954,7 @@
       "HYSTERON PROTERON\nHys\"te*ron prot\"e*ron. Etym: [NL., fr. Gr. (Rhet.)\n(a) A figure in which the natural order of sense is reversed;\nhysterology; as, valet atque vivit, \"he is well and lives.\"\n(b) An inversion of logical order, in which the conclusion is put\nbefore the premises, or the thing proved before the evidence."
     ],
     "references": [
-      "HYSTEROLOGY",
-      "HYSTERON PROTERON"
+      "HYSTEROLOGY"
     ]
   },
   {
@@ -102595,7 +102474,6 @@
       "CETRARIC",
       "CETRARIN",
       "FUMARIC",
-      "ICELAND MOSS",
       "LICHENIC",
       "LICHENIN",
       "MOSS"
@@ -102608,7 +102486,6 @@
     ],
     "references": [
       "CALCITE",
-      "ICELAND SPAR",
       "POSITIVE",
       "PRISM",
       "VARIETY"
@@ -102628,7 +102505,6 @@
     ],
     "references": [
       "GLYCYRRHIZA",
-      "ICE PLANT",
       "LATTICE",
       "ORYZA"
     ]
@@ -106863,9 +106739,7 @@
     "variants": [
       "I' FAITH\nI' faith\"\n\nDefn: . In faith; indeed; truly. Shak."
     ],
-    "references": [
-      "I' FAITH"
-    ]
+    "references": []
   },
   {
     "spellings": "IFERE",
@@ -106908,7 +106782,6 @@
     ],
     "references": [
       "BEAN",
-      "IGNATIUS BEAN",
       "STRYCHNINE"
     ]
   },
@@ -107032,7 +106905,6 @@
       "FIREDRAKE",
       "FRIAR",
       "GOBLIN",
-      "IGNIS FATUUS",
       "JACK",
       "NIGHT",
       "SWAMP",
@@ -108158,9 +108030,7 @@
     "variants": [
       "I' LL\nI' ll\n\nDefn: . Contraction for I will or I shall.\nI'll by a sign give notice to our friends. Shak."
     ],
-    "references": [
-      "I' LL"
-    ]
+    "references": []
   },
   {
     "spellings": "ILLABILE",
@@ -116438,9 +116308,7 @@
     "variants": [
       "IMPEYAN PHEASANT\nIm\"pey*an pheas\"ant. Etym: [From Lady Impey, who attempted to\nnaturalize the bird in England.] (Zoöl.)\n\nDefn: An Indian crested pheasant of the genus Lophophorus. Several\nspecies are known. Called also monaul, monal.\n\nNote: They are remarkable for the bright color and brilliant matallic\nhues of their plumage. The best known species (L. Impeyanus) has the\nneck of a brilliant metallic red, changing to golden yellow in\ncertain lights."
     ],
-    "references": [
-      "IMPEYAN PHEASANT"
-    ]
+    "references": []
   },
   {
     "spellings": "IMPHEE",
@@ -127217,7 +127085,6 @@
       "GRAFTING",
       "IMPETUS",
       "IN",
-      "IN AND IN",
       "INBREED",
       "SOMBRERO"
     ]
@@ -127372,8 +127239,7 @@
     ],
     "references": [
       "ANTA",
-      "DISTYLE",
-      "IN ANTIS"
+      "DISTYLE"
     ]
   },
   {
@@ -127799,9 +127665,7 @@
     "variants": [
       "INAUGURATION DAY\nIn*au`gu*ra\"tion Day.\n\nDefn: The day on which the President of the United States is\ninaugurated, the 4th of March in every year next after a year\ndivisible by four."
     ],
-    "references": [
-      "INAUGURATION DAY"
-    ]
+    "references": []
   },
   {
     "spellings": "INAUGURATOR",
@@ -131618,7 +131482,6 @@
       "COMMENDATARY",
       "COMMENDATOR",
       "COMMENDATORY",
-      "IN COMMENDAM",
       "PARTNERSHIP"
     ]
   },
@@ -136078,8 +135941,7 @@
       "INDEPENDENCE DAY\nIn`de*pend\"ence Day.\n\nDefn: In the United States, a holiday, the 4th of July, commemorating\nthe adoption of the Declaration of Independence on that day in 1776."
     ],
     "references": [
-      "HOLIDAY",
-      "INDEPENDENCE DAY"
+      "HOLIDAY"
     ]
   },
   {
@@ -137583,7 +137445,6 @@
       "IMPERMEABLE",
       "IMPREGNATE",
       "INDIA",
-      "INDIA RUBBER",
       "KAMPTULICON",
       "LEATHER",
       "LINOLEUM",
@@ -137604,9 +137465,7 @@
     "variants": [
       "INDIA STEEL\nIn\"di*a steel.\n\nDefn: Same as Wootz."
     ],
-    "references": [
-      "INDIA STEEL"
-    ]
+    "references": []
   },
   {
     "spellings": "INDICAL",
@@ -140509,9 +140368,7 @@
     "variants": [
       "INDO-DO-CHINESE LANGUAGES\nIn`do-do-Chinese languages.\n\nDefn: A family of languages, mostly of the isolating type, although\nsome are agglutinative, spoken in the great area extending from\nnorthern India in the west to Formosa in the east and from Central\nAsia in the north to the Malay Peninsula in the south."
     ],
-    "references": [
-      "INDO-DO-CHINESE LANGUAGES"
-    ]
+    "references": []
   },
   {
     "spellings": "INDO-ENGLISH",
@@ -141017,7 +140874,6 @@
       "DIRECT CURRENT",
       "FARADIC",
       "FARADISM; FARADIZATION",
-      "INDUCED CURRENT",
       "INDUCTION"
     ]
   },
@@ -141087,7 +140943,6 @@
       "INDUCTANCE COIL\nIn*duc\"tance coil. (Elec.)\n\nDefn: A choking coil."
     ],
     "references": [
-      "INDUCTANCE COIL",
       "SYNTONIZER"
     ]
   },
@@ -141189,9 +141044,7 @@
     "variants": [
       "INDUCTION GENERATOR\nIn*duc\"tion gen\"er*a`tor.\n\nDefn: A machine built as an induction motor and driven above\nsynchronous speed, thus acting as an alternating-current generator; -\n- called also asynchronous generator. Below synchronism the machine\ntakes in electrical energy and acts as an induction motor; at\nsynchronism the power component of current becomes zero and changes\nsign, so that above synchronism the machine (driven for this purpose\nby mechanical power) gives out electrical energy as a generator."
     ],
-    "references": [
-      "INDUCTION GENERATOR"
-    ]
+    "references": []
   },
   {
     "spellings": "INDUCTION MOTOR",
@@ -141200,7 +141053,6 @@
     ],
     "references": [
       "INDUCTION GENERATOR",
-      "INDUCTION MOTOR",
       "PHASE SPLITTER",
       "STATOR"
     ]
@@ -142671,7 +142523,6 @@
     "references": [
       "BLAZE",
       "ESSENTIAL",
-      "IN ESSE",
       "IN POSSE",
       "RADICALITY",
       "RESERVATION",
@@ -143848,9 +143699,7 @@
     "variants": [
       "INFANTILE PARALYSIS\nIn\"fan*tile pa*ral\"y*sis. (Med.)\n\nDefn: An acute disease, almost exclusively infantile, characterized\nby inflammation of the anterior horns of the gray substance of the\nspinal cord. It is attended with febrile symptoms, motor paralysis,\nand muscular atrophy, often producing permanent deformities. Called\nalso acute anterior poliomyelitis."
     ],
-    "references": [
-      "INFANTILE PARALYSIS"
-    ]
+    "references": []
   },
   {
     "spellings": "INFANTINE",
@@ -144195,7 +144044,6 @@
       "FERMENTATION THEORY",
       "FLAG",
       "INFECT",
-      "INFECTIOUS DISEASE",
       "MICROORGANISM; MICRO-ORGANISM",
       "MICROPHYTE",
       "PATHOGENE",
@@ -148540,9 +148388,7 @@
     "variants": [
       "INGOT STEEL\nIn\"got steel.\n\nDefn: Steel cast in ingots from the Bessemer converter or open-hearth\nfurnace."
     ],
-    "references": [
-      "INGOT STEEL"
-    ]
+    "references": []
   },
   {
     "spellings": "INGRACE",
@@ -151541,7 +151387,6 @@
     ],
     "references": [
       "CIRRUS",
-      "IN LOCO",
       "STROKE",
       "UROPOD",
       "WAPENTAKE"
@@ -152956,7 +152801,6 @@
       "IN ESSE",
       "INFEUDATION",
       "INHERIT",
-      "IN POSSE",
       "INTERPOLATE",
       "INVEST",
       "LEVITY",
@@ -153461,7 +153305,6 @@
       "EMBALM",
       "EXACERBATION",
       "FAMILIARITY",
-      "IN REM",
       "INTRUSION",
       "LEMON",
       "MEMORIAL",
@@ -155786,7 +155629,6 @@
       "BESTEAD",
       "DEEP",
       "HETEROTOPISM; HETEROTOPY",
-      "IN SITU",
       "MELODRAMATIC",
       "PITY",
       "TO",
@@ -166332,7 +166174,6 @@
       "DIESEL ENGINE; DIESEL MOTOR",
       "GAS ENGINE",
       "GASOLINE ENGINE; GASOLENE ENGINE",
-      "INTERNAL-COMBUSTION; INTERNAL-COMBUSTION ENGINE",
       "MASTER VIBRATOR",
       "OTTO CYCLE",
       "PREIGNITION",
@@ -173644,9 +173485,7 @@
     "variants": [
       "IN TRANSITU\nIn` tran\"si*tu. Etym: [L.] (Law)\n\nDefn: In transit; during passage; as, goods in transitu."
     ],
-    "references": [
-      "IN TRANSITU"
-    ]
+    "references": []
   },
   {
     "spellings": "INTRANSMISSIBLE",
@@ -175144,7 +174983,6 @@
     ],
     "references": [
       "INFLUENCE",
-      "IN VACUO",
       "PAYNE'S PROCESS"
     ]
   },
@@ -175900,9 +175738,7 @@
     "variants": [
       "INVERNESS; INVERNESS CAPE\nIn`ver*ness\", n., or In`ver*ness\" cape\".\n\nDefn: A kind of full sleeveless cape, fitting closely about the neck.\n\nRobert's wind-blown head and tall form wrapped in an Inverness cape.\nMrs. Humphry Ward."
     ],
-    "references": [
-      "INVERNESS; INVERNESS CAPE"
-    ]
+    "references": []
   },
   {
     "spellings": "INVERSE",
@@ -177956,7 +177792,6 @@
       "IO MOTH\nI\"o moth`. (Zoöl.)\n\nDefn: A large and handsome American moth (Hyperchiria Io), having a\nlarge, bright-colored spot on each hind wing, resembling the spots on\nthe tail of a peacock. The larva is covered with prickly hairs, which\nsting like nettles.\n\n-ION\n-ion. Etym: [L. -io, acc. -ionem: cf. F. -ion.]\n\nDefn: A noun suffix denoting act, process, result of an act or a\nprocess, thing acted upon, state, or condition; as, revolution, the\nact or process of revolving; construction, the act or process of\nconstructing; a thing constructed; dominion, territory ruled over;\nsubjection, state of being subject; dejection; abstraction."
     ],
     "references": [
-      "IO MOTH",
       "MOTH"
     ]
   },
@@ -178033,9 +177868,7 @@
     "variants": [
       "IOQUA SHELL\nI\"o*qua shell`. Etym: [From the native name.] (Zoöl.)\n\nDefn: The shell of a large Dentalium (D. pretiosum), formerly used as\nshell money, and for ornaments, by the Indians of the west coast of\nNorth America."
     ],
-    "references": [
-      "IOQUA SHELL"
-    ]
+    "references": []
   },
   {
     "spellings": "IOTA",
@@ -178066,9 +177899,7 @@
     "variants": [
       "I O U\nI O U. Etym: [i. e., I owe you.]\n\nDefn: A paper having on it these letters, with a sum named, and duly\nsigned; -- in use in England as an acknowledgment of a debt, and\ntaken as evidence thereof, but not amounting to a promissory note; a\ndue bill. Wharton. Story."
     ],
-    "references": [
-      "I O U"
-    ]
+    "references": []
   },
   {
     "spellings": "IOWAS",
@@ -178569,9 +178400,7 @@
     "variants": [
       "IRIS DIAPHRAGM\nI\"ris di\"a*phragm.\n\nDefn: An adjustable diaphragm, suggesting the iris of the eye in its\naction, for regulating the aperture of a lens, consisting of a number\nof thin pieces fastened to a ring. It is used in cameras and\nmicroscopes."
     ],
-    "references": [
-      "IRIS DIAPHRAGM"
-    ]
+    "references": []
   },
   {
     "spellings": "IRISED",
@@ -178676,9 +178505,7 @@
     "variants": [
       "IRISH AMERICAN\nI\"rish A*mer\"i*can.\n\nDefn: A native of Ireland who has become an American citizen; also, a\nchild or descendant of such a person."
     ],
-    "references": [
-      "IRISH AMERICAN"
-    ]
+    "references": []
   },
   {
     "spellings": "IRISHISM",
@@ -179680,9 +179507,7 @@
     "variants": [
       "IRONBARK TREE\nI\"ron*bark` tree`. (Bot.)\n\nDefn: The Australian Eucalyptus Sideroxylon, used largely by\ncarpenters and shipbuilders; -- called also ironwood."
     ],
-    "references": [
-      "IRONBARK TREE"
-    ]
+    "references": []
   },
   {
     "spellings": "IRONBOUND",
@@ -179935,7 +179760,6 @@
       "FINARY",
       "FINERY",
       "IRON",
-      "IRON WORKS",
       "LOOP",
       "LOUP",
       "MILL",
@@ -181506,9 +181330,7 @@
     "variants": [
       "IRREVERSIBLE STEERING GEAR\nIr`re*vers\"i*ble steering gear. (Mach.)\n\nDefn: A steering gear, esp. for an automobile, not affected by the\nroad wheels, as when they strike an obstacle side ways, but easily\ncontrolled by the hand wheel or steering lever."
     ],
-    "references": [
-      "IRREVERSIBLE STEERING GEAR"
-    ]
+    "references": []
   },
   {
     "spellings": "IRREVERSIBLY",
@@ -186933,7 +186755,6 @@
     ],
     "references": [
       "ANCHOR",
-      "ISABEL; ISABEL COLOR",
       "ISABELLINE",
       "SPAT"
     ]
@@ -186948,7 +186769,6 @@
       "GRAPEVINE",
       "HEDGEHOG",
       "ISABEL; ISABEL COLOR",
-      "ISABELLA; ISABELLA COLOR",
       "ISABELLA GRAPE",
       "ISABELLA MOTH",
       "ISABELLINE",
@@ -186960,9 +186780,7 @@
     "variants": [
       "ISABELLA GRAPE\nIs`a*bel\"la grape`. (Bot.)\n\nDefn: A favorite sweet American grape of a purple color. See Fox\ngrape, under Fox."
     ],
-    "references": [
-      "ISABELLA GRAPE"
-    ]
+    "references": []
   },
   {
     "spellings": "ISABELLA MOTH",
@@ -186971,7 +186789,6 @@
     ],
     "references": [
       "HEDGEHOG",
-      "ISABELLA MOTH",
       "WOOLLY"
     ]
   },
@@ -194285,9 +194102,7 @@
     "variants": [
       "ITA PALM\nI\"ta palm`. (Bot.)\n\nDefn: A magnificent species of palm (Mauritia flexuosa), growing near\nthe Orinoco. The natives eat its fruit and buds, drink its sap, and\nmake thread and cord from its fiber."
     ],
-    "references": [
-      "ITA PALM"
-    ]
+    "references": []
   },
   {
     "spellings": "ITCH",
@@ -199539,9 +199354,7 @@
     "variants": [
       "IVAN IVANOVITCH\nI*van\" I*van\"o*vitch\n\nDefn: . An ideal personification of the typical Russian or of the\nRussian people; -- used as \"John Bull\" is used for the typical\nEnglishman."
     ],
-    "references": [
-      "IVAN IVANOVITCH"
-    ]
+    "references": []
   },
   {
     "spellings": "I'VE",

--- a/output/wordDisplayData#J-L.json
+++ b/output/wordDisplayData#J-L.json
@@ -1257,9 +1257,7 @@
     "variants": [
       "JAAL GOAT\nJaal\" goat`. (Zoöl.)\n\nDefn: A species of wild goat (Capra Nubiana) found in the mountains\nof Abyssinia, Upper Egypt, and Arabia; -- called also beden, and\njaela."
     ],
-    "references": [
-      "JAAL GOAT"
-    ]
+    "references": []
   },
   {
     "spellings": "JAB",
@@ -1715,7 +1713,6 @@
       "JACK KETCH\nJack\" Ketch\". Etym: [Perh. fr. Jack, the proper name + Prov. E. ketch\na hangman, fr. ketch, for catch to seize; but see the citations\nbelow.]\n\nDefn: A public executioner, or hangman. [Eng.]\nThe manor of Tyburn was formerly held by Richard Jaquett, where\nfelons for a long time were executed; from whence we have Jack Ketch.\nLloyd's MS., British Museum.\n[Monmouth] then accosted John Ketch, the executioner, a wretch who\nhad butchered many brave and noble victims, and whose name has,\nduring a century and a half, been vulgarly given to all who have\nsucceeded him in his odious office. Macaulay."
     ],
     "references": [
-      "JACK KETCH",
       "KETCH"
     ]
   },
@@ -1906,9 +1903,7 @@
     "variants": [
       "JACOBAEAN LILY\nJac`o*bæ\"an lil\"y. Etym: [See Jacobean.] (Bot.)\n\nDefn: A bulbous plant (Amaryllis, or Sprekelia, formosissima) from\nMexico. It bears a single, large, deep, red, lilylike flower.\n[Written also Jacobean.]"
     ],
-    "references": [
-      "JACOBAEAN LILY"
-    ]
+    "references": []
   },
   {
     "spellings": "JACOBEAN; JACOBIAN",
@@ -2308,9 +2303,7 @@
     "variants": [
       "JAGGERY PALM\nJag\"ger*y palm.\n\nDefn: An East Indian palm (Caryota urens) having leaves pinnate with\nwedge-shaped divisions, the petiole very stout. It is the principal\nsource of jaggery, and is often cultivated for ornament."
     ],
-    "references": [
-      "JAGGERY PALM"
-    ]
+    "references": []
   },
   {
     "spellings": "JAGGY",
@@ -2342,9 +2335,7 @@
     "variants": [
       "JAGUA PALM\nJa\"gua palm`. Etym: [Sp. jagua the fruit of the jagua palm.] (Bot.)\n\nDefn: A great Brazilian palm (Maximiliana regia), having immense\nspathes which are used for baskets and tubs."
     ],
-    "references": [
-      "JAGUA PALM"
-    ]
+    "references": []
   },
   {
     "spellings": "JAGUAR",
@@ -2740,8 +2731,7 @@
       "JAMES'S POWDER\nJames\"'s pow`der. (Med.)\n\nDefn: Antimonial powder, first prepared by Dr. James, ar English\nphysician; -- called also fever powder."
     ],
     "references": [
-      "ANTIMONIAL",
-      "JAMES'S POWDER"
+      "ANTIMONIAL"
     ]
   },
   {
@@ -2750,7 +2740,6 @@
       "JAMESTOWN WEED\nJames\"town` weed`. (Bot.)\n\nDefn: The poisonous thorn apple or stramonium (Datura stramonium), a\nrank weed early noticed at Jamestown, Virginia. See Datura.\n\nNote: This name is often corrupted into jimson, jimpson, and gympsum."
     ],
     "references": [
-      "JAMESTOWN WEED",
       "JIMSON WEED",
       "STINKWEED",
       "STRAMONIUM",
@@ -3134,7 +3123,6 @@
       "JAPAN CURRENT\nJapan current.\n\nDefn: A branch of the equatorial current of the Pacific, washing the\neastern coast of Formosa and thence flowing northeastward past Japan\nand merging into the easterly drift of the North Pacific; -- called\nalso Kuro-Siwo, or Black Stream, in allusion to the deep blue of its\nwater. It is similar in may ways to the Gulf Stream."
     ],
     "references": [
-      "JAPAN CURRENT",
       "KURO-SIWO"
     ]
   },
@@ -4272,9 +4260,7 @@
     "variants": [
       "JEDDING AX\nJed\"ding ax`, n.\n\nDefn: A stone mason's tool, having a flat face and a pointed part.\nKnight."
     ],
-    "references": [
-      "JEDDING AX"
-    ]
+    "references": []
   },
   {
     "spellings": "JEE",
@@ -4383,9 +4369,7 @@
     "variants": [
       "JEFFERSONIAN SIMPLICITY\nJeffersonian simplicity.\n\nDefn: The absence of pomp or display which Jefferson aimed at in his\nadministration as President (1801-1809), eschewing display or\nceremony tending to distinguish the President from the people, as in\ngoing to the capital on horseback and with no escort, the abolition\nof court etiquette and the weekly levee, refusal to recognize titles\nof honor, etc."
     ],
-    "references": [
-      "JEFFERSONIAN SIMPLICITY"
-    ]
+    "references": []
   },
   {
     "spellings": "JEFFERSONITE",
@@ -4616,9 +4600,7 @@
     "variants": [
       "JEMLAH GOAT\nJem\"lah goat`. (Zoöl.)\n\nDefn: The jharal."
     ],
-    "references": [
-      "JEMLAH GOAT"
-    ]
+    "references": []
   },
   {
     "spellings": "JEMMINESS",
@@ -4772,9 +4754,7 @@
     "variants": [
       "JEQUIRITY; JEQUIRITY BEAN\nJe*quir\"i*ty, n., or Je*quir\"i*ty bean`. [Prob. fr. a native name.]\n(Bot.)\n\nDefn: The seed of the wild licorice (Abrus precatorius) used by the\npeople of India for beads in rosaries and necklaces, as a standard\nweight, etc.; -- called also jumble bead."
     ],
-    "references": [
-      "JEQUIRITY; JEQUIRITY BEAN"
-    ]
+    "references": []
   },
   {
     "spellings": "JERBOA",
@@ -5533,7 +5513,6 @@
       "JET D'EAU\nJet` d'eau\", pl. Jets d'eau (. Etym: [F., a throw of water. See Jet a\nshooting forth.]\n\nDefn: A stream of water spouting from a fountain or pipe (especially\nfrom one arranged to throw water upward), in a public place or in a\ngarden, for ornament."
     ],
     "references": [
-      "JET D'EAU",
       "JETTEAU"
     ]
   },
@@ -5622,18 +5601,14 @@
     "variants": [
       "JEU D'ESPRIT\nJeu\" d'es`prit\". Etym: [F., play of mind.]\n\nDefn: A witticism."
     ],
-    "references": [
-      "JEU D'ESPRIT"
-    ]
+    "references": []
   },
   {
     "spellings": "JEUNESSE DOREE",
     "variants": [
       "JEUNESSE DOREE\nJeu`nesse\" do`rée\". [F.]\n\nDefn: Lit., gilded youth; young people of wealth and fashion, esp. if\ngiven to prodigal living; -- in the French Revolution, applied to\nyoung men of the upper classes who aided in suppressing the Jacobins\nafter the Reign of Terror."
     ],
-    "references": [
-      "JEUNESSE DOREE"
-    ]
+    "references": []
   },
   {
     "spellings": "JEW",
@@ -5904,8 +5879,7 @@
       "JEWISH CALENDAR\nJew\"ish cal\"en*dar.\n\nDefn: A lunisolar calendar in use among Hebraic peoples, reckoning\nfrom the year 3761 b. c., the date traditionally given for the\nCreation. It received its present fixed form from Hillel II. about\n360 a. d. The present names of the months, which are Babylonian-\nAssyrian in origin, replaced older ones, Abib, Bul, etc., at the time\nof the Babylonian Exile. Nineteen years constitute a lunar cycle, of\nwhich the 3d, 6th, 8th, 11th, 14th, 17th, and 19th years are leap\nyears. The year 5663 [1902-3 a. d.] was the first year of the 299th\nlunar cycle. The common year is said to be defective, regular, or\nperfect (or abundant) according as it has 353, 354, or 355 days. The\nleap year has an intercalary month, and a total of 383 (defective),\n384 (regular), or 385 (perfect, or abundant) days. The calendar is\ncomplicated by various rules providing for the harmonious arrangement\nof festivals, etc., so that no simple perpetual calendar can be\nconstructed. The following table gives the months in order, with the\nnumber of days assigned to each. Only three months vary in length.\nThey are: Heshvan, which has 30 days in perfect years; Kislev, which\nhas 30 days in regular and perfect years; and Adar, which has 30 days\nin leap years. The ecclesiastical year commences with Nisan and the\ncivil year with Tishri. The date of the first of Tishri, or the\nJewish New Year, is also given for the Jewish years 5661-5696 (1900-\n1935 a. d.). From these tables it is possible to transform any Jewish\ndate into Christian, or vice versa, for the years 1900-1935 a. d.\n\nMonths of the Jewish Year.\n\n 1 Tishri . . . . . . 30\n 2 Heshvan . . . . .  29 (r. & d.)\n                                or 30 (p.)\n 3 Kislev . . . . . . 29 (d.) or\n                                   30 (r. & p.)\n 4 Tebet . . . . . .  29\n 5 Shebat . . . . . . 30\n 6 Adar . . . . . . . 29 or\n                                   30 (l.)\n -- Veadar . . . . .  29\n    (occuring only in leap years)\n 7 Nisan . . . . . . .30\n 8 Ivar . . . . . . ..29\n 9 Sivan . . . . . . .30\n10 Tammux . . . . . . 29\n11 Ab . . . . . . . . 30\n12 Elul . . . . . . ..29\n\nJewish Year                   a. d.\n\n5661 p.     begins     Sept.  24, 1900\n5662 d.l.    \"      \"   14, 1901\n5663 p.      \"      Oct.    2, 1902\n5664 r.      \"      Sept.  22, 1903\n5665 p.l.    \"      \"   10, 1904\n5666 p.      \"      \"   30, 1905\n5667 r.      \"      \"   20, 1906\n5668 d.l.    \"      \"    6, 1907\n5669 p.      \"      \"   26, 1908\n5670 d.l.    \"      \"   16, 1909\n5671 r.      \"      Oct.    4, 1910\n5672 p.      \"      Sept.  23, 1911\n5673 p.l.    \"      \"   12, 1912\n5674 r.      \"      Oct.    2, 1913\n5675 d.      \"      Sept.  21, 1914\n5676 p.l.    \"      \"    9, 1915\n5677 r.      \"      \"   28, 1916\n5678 p.      \"      \"   17, 1917\n5679 d.l.   begins     Sept.   7, 1918\n5680 r.      \"      \"   25, 1919\n5681 p.l.    \"      \"   13, 1920\n5682 p.      \"      Oct.    3, 1921\n5683 d.      \"      Sept.  23, 1922\n5684 r.l.    \"      \"   11, 1923\n5685 p.      \"      \"   29, 1924\n5686 p.      \"      \"   19, 1925\n5687 d.l.    \"      \"    9, 1926\n5688 r.      \"      \"   27, 1927\n5689 p.l.    \"      \"   15, 1928\n5690 d.      \"      Oct.    5, 1929\n5691 r.      \"      Sept.  23, 1930\n5692 p.l.    \"      \"   12, 1931\n5693 p.      \"      Oct.    1, 1932\n5694 r.      \"      Sept.  23, 1933\n5695 d.l.    \"      \"   10, 1934\n5696 p.      \"      \"   28, 1935\nd. = defective year; d.l. = defective leap year; p. = perfect year;\np.l. = perfect leap year; r. = regular year; r.l. = regular leap\nyear."
     ],
     "references": [
-      "HEBREW CALENDAR",
-      "JEWISH CALENDAR"
+      "HEBREW CALENDAR"
     ]
   },
   {
@@ -6161,9 +6135,7 @@
     "variants": [
       "JIM CROW\nJim Crow.\n\nDefn: A negro; -- said to be so called from a popular negro song and\ndance, the refrain of which is \"Wheel about and turn about and jump\nJim Crow,\" produced in 1835 by T. D. Rice, a famous negro minstrel.\n[Slang, U. S.]"
     ],
-    "references": [
-      "JIM CROW"
-    ]
+    "references": []
   },
   {
     "spellings": "JIMMY",
@@ -6186,9 +6158,7 @@
     "variants": [
       "JIMSON WEED\nJim\"son weed`\n\nDefn: . See Jamestown weed. [Local, U.S.]"
     ],
-    "references": [
-      "JIMSON WEED"
-    ]
+    "references": []
   },
   {
     "spellings": "JIN; JINN",
@@ -6303,9 +6273,7 @@
     "variants": [
       "JINNY ROAD\nJin\"ny road`. Etym: [Cf. Gin an engine, Ginnycarriage.] (Mining)\n\nDefn: An inclined road in a coal mine, on which loaded cars descend\nby gravity, drawing up empty ones. Knight."
     ],
-    "references": [
-      "JINNY ROAD"
-    ]
+    "references": []
   },
   {
     "spellings": "JINRIKISHA",
@@ -6791,8 +6759,7 @@
       "JOE MILLER\nJoe\" Mil\"ler. Etym: [From Joseph Miller, a comic actor, whose name\nwas attached, after his death, to a popular jest book published in\n1739.]\n\nDefn: A jest book; a stale jest; a worn-out joke. [Colloq.]\nIt is an old Joe Miller in whist circles, that there are only two\nreasons that can justify you in not returning trumps to your\npartner's lead; i. e., first, sudden illness; secondly, having none.\nPole."
     ],
     "references": [
-      "JEST",
-      "JOE MILLER"
+      "JEST"
     ]
   },
   {
@@ -6800,9 +6767,7 @@
     "variants": [
       "JOE-PYE WEED\nJoe`-Pye\" weed`. (Bot.)\n\nDefn: A tall composite plant of the genus Eupatorium (E. purpureum),\nwith purplish flowers, and whorled leaves."
     ],
-    "references": [
-      "JOE-PYE WEED"
-    ]
+    "references": []
   },
   {
     "spellings": "JOG",
@@ -7216,7 +7181,6 @@
     "references": [
       "ANDROPOGON",
       "GRASS",
-      "JOHNSON GRASS",
       "SORGHUM"
     ]
   },
@@ -8454,9 +8418,7 @@
     "variants": [
       "JOSEPH'S FLOWER\nJo\"seph's flow\"er. (Bot.)\n\nDefn: A composite herb (Tragopogon pratensis), of the same genus as\nthe salsify."
     ],
-    "references": [
-      "JOSEPH'S FLOWER"
-    ]
+    "references": []
   },
   {
     "spellings": "JOSO",
@@ -8486,9 +8448,7 @@
     "variants": [
       "JOSS PAPER\nJoss paper.\n\nDefn: Gold and silver paper burned by the Chinese, in the form of\ncoins or ingots, in worship and at funerals."
     ],
-    "references": [
-      "JOSS PAPER"
-    ]
+    "references": []
   },
   {
     "spellings": "JOSTLE",
@@ -8601,18 +8561,14 @@
     "variants": [
       "JOULE'S CYCLE\nJoule's cycle. (Thermodynamics)\n\nDefn: The cycle for the air engine proposed by Joule. In it air is\ntaken by a pump from a cold chamber and compressed adiabatically\nuntil its pressure is eqal to that of the air in a hot chamber, into\nwhich it is then delivered, thereby displacing an equal amount of hot\nair into the engine cylinder. Here it expands adiabatically to the\ntemperature of the cold chamber into which it is finally exhausted.\nThis cycle, reversed, is used in refrigerating machines."
     ],
-    "references": [
-      "JOULE'S CYCLE"
-    ]
+    "references": []
   },
   {
     "spellings": "JOULE'S LAW",
     "variants": [
       "JOULE'S LAW\nJoule's law.\n\n1. (Elec.)\n\nDefn: The law that the rate at which heat is produced in any part of\nan electric circuit is measured by the product of the square of the\ncurrent into the resistance of that part of the circuit. If the\ncurrent\n (i) is constant for an interval of time (t), the energy (H) in heat\nunits equals i2Rt, R being resistance.\n\n2. (Thermodynamics) The law that there is no change of temperature\nwhen a gas expands without doing external work and without receiving\nor rejecting heat."
     ],
-    "references": [
-      "JOULE'S LAW"
-    ]
+    "references": []
   },
   {
     "spellings": "JOUNCE",
@@ -11152,9 +11108,7 @@
     "variants": [
       "JUKES, THE\nJukes, The\n\nDefn: A pseudonym used to designate the descendants of two sisters,\nthe \"Jukes\" sisters, whose husbands were sons of a backwoodsman of\nDutch descent. They lived in the State of New York, and their history\nwas investigated by R. L. Dugdale as an example of the inheritance of\ncriminal and immoral tendencies, disease, and pauperism. Sixty per\ncent of those traced showed, degeneracy, and they are estimated to\nhave cost society $1,308,000 in 75 years."
     ],
-    "references": [
-      "JUKES, THE"
-    ]
+    "references": []
   },
   {
     "spellings": "JULACEOUS",
@@ -11441,7 +11395,6 @@
       "JUMPING DISEASE\nJump\"ing dis*ease\".\n\nDefn: A convulsive tic similar to or identical with miryachit,\nobserved among the woodsmen of Maine."
     ],
     "references": [
-      "JUMPING DISEASE",
       "LATA; LATAH"
     ]
   },
@@ -11451,7 +11404,6 @@
       "JUMP SPARK\nJump spark.\n\nDefn: A spark produced by the jumping of electricity across a\npermanent gap."
     ],
     "references": [
-      "JUMP SPARK",
       "SPARK GAP"
     ]
   },
@@ -11577,9 +11529,7 @@
     "variants": [
       "JUNCTION BOX\nJunc\"tion box. (Elec.)\n\nDefn: A box through which the main conductors of a system of electric\ndistribution pass, and where connection is made with branch circuits."
     ],
-    "references": [
-      "JUNCTION BOX"
-    ]
+    "references": []
   },
   {
     "spellings": "JUNCTURE",
@@ -11879,7 +11829,6 @@
       "JUPATI PALM\nJu`pa*ti\" palm`. (Bot.)\n\nDefn: A great Brazilian palm tree (Raphia tædigera), used by the\nnatives for many purposes."
     ],
     "references": [
-      "JUPATI PALM",
       "RAFFIA PALM"
     ]
   },
@@ -12534,8 +12483,7 @@
       "JURY MAST\nJu\"ry mast.\n (a) A temporary mast, in place of one that has been carried away, or\nbroken.\n (b) (Med.) An apparatus to support the trunk and head in spinal\ndisease."
     ],
     "references": [
-      "DESIGHTMENT",
-      "JURY MAST"
+      "DESIGHTMENT"
     ]
   },
   {
@@ -14785,9 +14733,7 @@
     "variants": [
       "KAURI RESIN; KAURI GUM; KAURI COPAL\nKauri resin, gum, or copal.\n\nDefn: A resinous product of the kauri, found in the form of yellow or\nbrown lumps in the ground where the trees have grown. It is used for\nmaking varnish, and as a substitute for amber."
     ],
-    "references": [
-      "KAURI RESIN; KAURI GUM; KAURI COPAL"
-    ]
+    "references": []
   },
   {
     "spellings": "KAVA",
@@ -16139,9 +16085,7 @@
     "variants": [
       "KEFIR GRAINS\nKefir grains.\n\nDefn: Small hard yellowish aggregations found in the Caucasus region,\nand containing various yeasts and bacteria. They are used as a\nferment in preparing kefir."
     ],
-    "references": [
-      "KEFIR GRAINS"
-    ]
+    "references": []
   },
   {
     "spellings": "KEG",
@@ -16390,9 +16334,7 @@
     "variants": [
       "KENDAL GREEN; KENDAL\nKen\"dal green`, or; Ken\"dal.\n\nDefn: A cloth colored green by dye obtained from the woad-waxen,\nformerly used by Flemish weavers at Kendal, in Westmoreland, England.\nJ. Smith (Dict. Econ. Plants).\nHow couldst thou know these men in Kendal green Shak."
     ],
-    "references": [
-      "KENDAL GREEN; KENDAL"
-    ]
+    "references": []
   },
   {
     "spellings": "KENNEL",
@@ -16423,9 +16365,7 @@
     "variants": [
       "KENNEL COAL\nKen\"nel coal`\n\nDefn: . See Cannel coal."
     ],
-    "references": [
-      "KENNEL COAL"
-    ]
+    "references": []
   },
   {
     "spellings": "KENNING",
@@ -16476,7 +16416,6 @@
     ],
     "references": [
       "BUGLE",
-      "KENT BUGLE",
       "KEY",
       "KEYED"
     ]
@@ -17169,9 +17108,7 @@
     "variants": [
       "KERN BABY\nKern baby.\n\nDefn: A doll or image decorated with corn (grain) flowers, etc.,\ncarried in the festivals of a kern, or harvest-home. Called also\nharvest queen."
     ],
-    "references": [
-      "KERN BABY"
-    ]
+    "references": []
   },
   {
     "spellings": "KERNED",
@@ -17831,7 +17768,6 @@
     ],
     "references": [
       "KEY",
-      "KEY FRUIT",
       "SAMARA"
     ]
   },
@@ -17897,8 +17833,7 @@
       "KEYSTONE STATE\nKey\"stone` State.\n\nDefn: Pennsylvania; -- a nickname alluding to its having been the\ncentral one of the 13 original United States."
     ],
     "references": [
-      "KEYSTONE",
-      "KEYSTONE STATE"
+      "KEYSTONE"
     ]
   },
   {
@@ -17911,7 +17846,6 @@
       "D",
       "KEY",
       "KEYNOTE",
-      "KEY TONE",
       "MAJOR",
       "TONIC"
     ]
@@ -18024,9 +17958,7 @@
     "variants": [
       "KIABOOCA WOOD\nKi`a*boo\"ca wood`\n\nDefn: . See Kyaboca wood."
     ],
-    "references": [
-      "KIABOOCA WOOD"
-    ]
+    "references": []
   },
   {
     "spellings": "KIANG",
@@ -18508,9 +18440,7 @@
     "variants": [
       "KILKENNY CATS\nKil*ken\"ny cats.\n\nDefn: Two cats fabled, in an Irish story, to have fought till nothing\nwas left but their tails. It is probably a parable of a local contest\nbetween Kilkenny and Irishtown, which impoverished both towns."
     ],
-    "references": [
-      "KILKENNY CATS"
-    ]
+    "references": []
   },
   {
     "spellings": "KILL",
@@ -18943,9 +18873,7 @@
     "variants": [
       "KILOWATT HOUR\nKil\"o*watt` hour. (Elec.)\n\nDefn: A unit of work or energy equal to that done by one kilowatt\nacting for one hour; --approx. = 1.34 horse-power hour."
     ],
-    "references": [
-      "KILOWATT HOUR"
-    ]
+    "references": []
   },
   {
     "spellings": "KILT",
@@ -22963,7 +22891,6 @@
       "KING CHARLES SPANIEL\nKing Charles span\"iel. (Zoöl.)\n\nDefn: A variety of small pet dogs, having, drooping ears, a high,\ndome-shaped forehead, pug nose, large, prominent eyes, and long, wavy\nhair. The color is usually black and tan."
     ],
     "references": [
-      "KING CHARLES SPANIEL",
       "SPANIEL"
     ]
   },
@@ -23307,7 +23234,6 @@
     "references": [
       "BENCH",
       "EXIGENTER",
-      "KING'S BENCH",
       "PROTHONOTARY; PROTONOTARY",
       "QUEEN",
       "SITTING",
@@ -23340,18 +23266,14 @@
     "variants": [
       "KINGSTON METAL\nKing\"ston met\"al\n\nDefn: . An alloy of tin, copper, and mercury, sometimes used for the\nbearings and packings of machinery. McElrath."
     ],
-    "references": [
-      "KINGSTON METAL"
-    ]
+    "references": []
   },
   {
     "spellings": "KINGSTON VALVE",
     "variants": [
       "KINGSTON VALVE\nKing\"ston valve. (Marine Steam Engin.)\n\nDefn: A conical valve, opening outward, to close the mouth of a pipe\nwhich passes through the side of a vessel below the water line."
     ],
-    "references": [
-      "KINGSTON VALVE"
-    ]
+    "references": []
   },
   {
     "spellings": "KINGTRUSS",
@@ -23775,8 +23697,7 @@
       "KISSING BUG\nKiss\"ing bug`. (Zoöl.)\n\nDefn: Any one of several species of blood-sucking, venomous Hemiptera\nthat sometimes bite the lip or other parts of the human body, causing\npainful sores, as the cone-nose (Conorhinus sanguisuga). [U. S.]"
     ],
     "references": [
-      "CONE-NOSE",
-      "KISSING BUG"
+      "CONE-NOSE"
     ]
   },
   {
@@ -23791,9 +23712,7 @@
     "variants": [
       "KISSING STRINGS\nKiss\"ing strings`.\n\nDefn: Cap or bonnet strings made long to tie under the chin.\n\nOne of her ladyship's kissing strings, once pink and fluttering and\nnow faded and soiled.\nPall Mall Mag."
     ],
-    "references": [
-      "KISSING STRINGS"
-    ]
+    "references": []
   },
   {
     "spellings": "KIST",
@@ -23932,7 +23851,6 @@
       "KITCHEN MIDDENS\nKitch\"en mid`dens. Etym: [Dan. kjök-kenmöddings kitchen leavings; cf.\nScot. midden a dunghill.]\n\nDefn: Relics of neolithic man found on the coast of Denmark,\nconsisting of shell mounds, some of which are ten feet high, one\nthousand feet long, and two hundred feet wide. The name is applied\nalso to similar mounds found on the American coast from Canada to\nFlorida, made by the North American Indians."
     ],
     "references": [
-      "KITCHEN MIDDENS",
       "KJOEKKEN MOEDDINGS",
       "MOUND",
       "NEOLITHIC"
@@ -24156,9 +24074,7 @@
     "variants": [
       "KJOEKKEN MOEDDINGS\nKjoek\"ken moed`dings. Etym: [Dan.]\n\nDefn: See Kitchen middens."
     ],
-    "references": [
-      "KJOEKKEN MOEDDINGS"
-    ]
+    "references": []
   },
   {
     "spellings": "KLAMATHS",
@@ -24811,7 +24727,6 @@
     ],
     "references": [
       "KNEE",
-      "KNEE JERK",
       "REFLEX",
       "TENDON"
     ]
@@ -24891,9 +24806,7 @@
     "variants": [
       "KNEIPPISM; KNEIPP'S CURE; KNEIPP CURE\nKneipp\"ism, n. Also Kneipp's, or Kneipp, cure.\n\nDefn: Treatment of disease by forms of hydrotherapy, as walking\nbarefoot in the morning dew, baths, wet compresses, cold affusions,\netc.; -- so called from its originator, Sebastian Kneipp (1821-97), a\nGerman priest."
     ],
-    "references": [
-      "KNEIPPISM; KNEIPP'S CURE; KNEIPP CURE"
-    ]
+    "references": []
   },
   {
     "spellings": "KNELL",
@@ -25209,9 +25122,7 @@
     "variants": [
       "KNIFE SWITCH\nKnife switch. (Elec.)\n\nDefn: A switch consisting of one or more knifelike pieces hinged at\none end and making contact near the other with flat gripping springs."
     ],
-    "references": [
-      "KNIFE SWITCH"
-    ]
+    "references": []
   },
   {
     "spellings": "KNIGHT",
@@ -25755,7 +25666,6 @@
       "KNIGHT BACHELOR\nKnight\" bach\"e*lor; pl. Knights bachelors (.\n\nDefn: A knight of the most ancient, but lowest, order of English\nknights, and not a member of any order of chivalry. See Bachelor, 4."
     ],
     "references": [
-      "KNIGHT BACHELOR",
       "KNIGHT BANNERET"
     ]
   },
@@ -25764,18 +25674,14 @@
     "variants": [
       "KNIGHT BANNERET\nKnight\" ban\"ner*et; pl. Knights bannerets.\n\nDefn: A knight who carried a banner, who possessed fiefs to a greater\namount than the knight bachelor, and who was obliged to serve in war\nwith a greater number of attendants. The dignity was sometimes\nconferred by the sovereign in person on the field of battle."
     ],
-    "references": [
-      "KNIGHT BANNERET"
-    ]
+    "references": []
   },
   {
     "spellings": "KNIGHT BARONET",
     "variants": [
       "KNIGHT BARONET\nKnight\" bar\"o-net.\n\nDefn: See Baronet."
     ],
-    "references": [
-      "KNIGHT BARONET"
-    ]
+    "references": []
   },
   {
     "spellings": "KNIGHT-ERRANT",
@@ -25882,7 +25788,6 @@
       "KNIGHT MARSHAL\nKnight\" mar\"shal. (Eng. Law)\n\nDefn: An officer in the household of the British sovereign, who has\ncognizance of transgressions within the royal household and verge,\nand of contracts made there, a member of the household being one of\nthe parties. Wharton."
     ],
     "references": [
-      "KNIGHT MARSHAL",
       "MARSHAL"
     ]
   },
@@ -25902,7 +25807,6 @@
       "CHIVALRY",
       "ESCUAGE",
       "KNIGHT SERVICE",
-      "KNIGHT SERVICE; KNIGHT'S SERVICE",
       "KNIGHT'S FEE",
       "SOCAGE"
     ]
@@ -25914,7 +25818,6 @@
     ],
     "references": [
       "FARTHING",
-      "KNIGHT'S FEE",
       "PRIMER",
       "TALLAGE; TALLIAGE"
     ]
@@ -25924,9 +25827,7 @@
     "variants": [
       "KNIGHT TEMPLAR\nKnight\" Tem\"plar; pl. Knights Templars (.\n\nDefn: See Commandery, n., 3, and also Templar, n., 1 and 3."
     ],
-    "references": [
-      "KNIGHT TEMPLAR"
-    ]
+    "references": []
   },
   {
     "spellings": "KNIT",
@@ -26204,9 +26105,7 @@
     "variants": [
       "KNOBBLING FIRE\nKnob\"bling fire\n\nDefn: . A bloomery fire. See Bloomery."
     ],
-    "references": [
-      "KNOBBLING FIRE"
-    ]
+    "references": []
   },
   {
     "spellings": "KNOBBY",
@@ -26389,9 +26288,7 @@
     "variants": [
       "KNOCK-OUT DROPS\nKnock-out drops.\n\nDefn: Drops of some drug put in one's drink to stupefy him for\npurpose of robbery, etc. [Slang, U. S.]"
     ],
-    "references": [
-      "KNOCK-OUT DROPS"
-    ]
+    "references": []
   },
   {
     "spellings": "KNOCKSTONE",
@@ -28761,7 +28658,6 @@
       "KOLA; KOLA NUT\nKo\"la, Kola nut .\n\nDefn: Same as Cola, Cola nut."
     ],
     "references": [
-      "KOLA; KOLA NUT",
       "KOLINSKY"
     ]
   },
@@ -29104,9 +29000,7 @@
     "variants": [
       "KRANGING HOOK\nKrang\"ing hook`. (Whaling)\n\nDefn: A hook for holding the blubber while cutting it away. [Written\nalso cranging hook.]"
     ],
-    "references": [
-      "KRANGING HOOK"
-    ]
+    "references": []
   },
   {
     "spellings": "KREATIC",
@@ -29261,8 +29155,7 @@
       "KRUPP GUN\nKrupp\" gun\"\n\nDefn: . A breech-loading steel cannon manufactured at the works of\nFriedrich Krupp, at Essen in Prussia. Guns of over eight-inch bore\nare made up of several concentric cylinders; those of a smaller size\nare forged solid. Knight."
     ],
     "references": [
-      "GUN",
-      "KRUPP GUN"
+      "GUN"
     ]
   },
   {
@@ -29278,8 +29171,7 @@
       "KRUPP PROCESS\nKrupp process. (Iron Metal.)\n (a) A process practiced by Friedrich Krupp,  Essen, Germany, for\nwashing pig iron, differing from the Bell process in using manganese\nas well as iron oxide, and performed in a Pernot furnace. Called also\nthe Bell-Krupp process.\n (b) A process for the manufacture of steel armor plates, invented or\npracticed by Krupp, the details of which are secret. It is understood\nto involve the addition of chromium as well as nickel to the metal,\nand to include a treatment like that of the Harvey process with\nunknown variations or additions. The product is mentioned by some\nauthors, as improved Harvey, or Harvey-Krupp armor plate."
     ],
     "references": [
-      "KRUPPIZE",
-      "KRUPP PROCESS"
+      "KRUPPIZE"
     ]
   },
   {
@@ -29542,8 +29434,7 @@
       "KYABOCA WOOD\nKy`a*bo\"ca wood`. (Bot.)\n(a) Amboyna wood.\n(b) Sandalwood (Santalum album)."
     ],
     "references": [
-      "KIABOOCA WOOD",
-      "KYABOCA WOOD"
+      "KIABOOCA WOOD"
     ]
   },
   {
@@ -29716,7 +29607,6 @@
     ],
     "references": [
       "KYRIE",
-      "KYRIE ELEISON",
       "KYRIELLE"
     ]
   },
@@ -35136,9 +35026,7 @@
     "variants": [
       "LABARRAQUE'S SOLUTION\nLa`bar`raque's\" so*lu\"tion. Etym: [From Labarraque, a Parisian\napothecary.] (Med.)\n\nDefn: An aqueous solution of hypochlorite of sodium, extensively used\nas a disinfectant."
     ],
-    "references": [
-      "LABARRAQUE'S SOLUTION"
-    ]
+    "references": []
   },
   {
     "spellings": "LABARUM",
@@ -35833,9 +35721,7 @@
     "variants": [
       "LABOR DAY\nLabor Day.\n\nDefn: In most of the States and Territories of the United States, a\nday, usually the first Monday of September, set aside as a legal\nholiday, in honor of, or in the interest of, workingmen as a class.\nAlso, a similar holiday in Canada, Australia, etc."
     ],
-    "references": [
-      "LABOR DAY"
-    ]
+    "references": []
   },
   {
     "spellings": "LABORED",
@@ -36700,9 +36586,7 @@
     "variants": [
       "LACHRYMAE CHRISTI\nLach\"ry*mæ Chris\"ti. Etym: [L., lit., Christ's tears.]\n\nDefn: A rich, sweet, red Neapolitan wine."
     ],
-    "references": [
-      "LACHRYMAE CHRISTI"
-    ]
+    "references": []
   },
   {
     "spellings": "LACHRYMAL",
@@ -37840,9 +37724,7 @@
     "variants": [
       "LADIES' EARDROPS\nLa\"dies' ear`drops`. (Bot.)\n\nDefn: The small-flowered Fuchsia (F. coccinea), and other closely\nrelated species."
     ],
-    "references": [
-      "LADIES' EARDROPS"
-    ]
+    "references": []
   },
   {
     "spellings": "LADIFY",
@@ -38171,7 +38053,6 @@
       "LADY DAY\nLa\"dy` Day` (da).\n\nDefn: The day of the annunciation of the Virgin Mary, March 25. See\nAnnunciation."
     ],
     "references": [
-      "LADY DAY",
       "QUARTER"
     ]
   },
@@ -38252,8 +38133,7 @@
       "LADY'S BEDSTRAW\nLa\"dy's bed\"straw`, (Bot.)\n\nDefn: The common bedstraw (Galium verum); also, a slender-leaved East\nIndian shrub (Pharnaceum Mollugo), with white flowers in umbels."
     ],
     "references": [
-      "BEDSTRAW",
-      "LADY'S BEDSTRAW"
+      "BEDSTRAW"
     ]
   },
   {
@@ -38262,8 +38142,7 @@
       "LADY'S BOWER\nLa\"dy's bow\"er. (Bot.)\n\nDefn: A climbing plant with fragrant blossoms (Clematis vitalba).\n\nNote: This term is sometimes applied to other plants of the same\ngenus."
     ],
     "references": [
-      "BURLY",
-      "LADY'S BOWER"
+      "BURLY"
     ]
   },
   {
@@ -38271,9 +38150,7 @@
     "variants": [
       "LADY'S CLOTH\nLa\"dy's cloth`\n\nDefn: A kind of broadcloth of light weight, used for women's dresses,\ncloaks, etc."
     ],
-    "references": [
-      "LADY'S CLOTH"
-    ]
+    "references": []
   },
   {
     "spellings": "LADY'S COMB",
@@ -38281,7 +38158,6 @@
       "LADY'S COMB\nLa\"dy's comb\", (Bot.)\n\nDefn: An umbelliferous plant (Scandix Pecten-Veneris), its clusters\nof long slender fruits remotely resembling a comb."
     ],
     "references": [
-      "LADY'S COMB",
       "SHEPHERD",
       "VENUS"
     ]
@@ -38291,18 +38167,14 @@
     "variants": [
       "LADY'S CUSHION\nLa\"dy's cush\"ion, (Bot.)\n\nDefn: An herb growing in dense tufts; the thrift (Armeria vulgaris)."
     ],
-    "references": [
-      "LADY'S CUSHION"
-    ]
+    "references": []
   },
   {
     "spellings": "LADY'S FINGER",
     "variants": [
       "LADY'S FINGER\nLa\"dy's fin\"ger,\n\n1. pl. (Bot.)\n\nDefn: The kidney vetch.\n\n2. (Cookery)\n\nDefn: A variety of small cake of about the dimensions of a finger.\n\n3. A long, slender variety of the potato.\n\n4. (Zoöl.)\n\nDefn: One of the branchiæ of the lobster."
     ],
-    "references": [
-      "LADY'S FINGER"
-    ]
+    "references": []
   },
   {
     "spellings": "LADY'S GARTERS",
@@ -38310,7 +38182,6 @@
       "LADY'S GARTERS\nLa\"dy's gar\"ters. (Bot.)\n\nDefn: Ribbon grass."
     ],
     "references": [
-      "LADY'S GARTERS",
       "RIBBON"
     ]
   },
@@ -38319,9 +38190,7 @@
     "variants": [
       "LADY'S HAIR\nLa\"dy's hair\". (Bot.)\n\nDefn: A plant of the genus Briza (B. media); a variety of quaking\ngrass."
     ],
-    "references": [
-      "LADY'S HAIR"
-    ]
+    "references": []
   },
   {
     "spellings": "LADYSHIP",
@@ -38339,18 +38208,14 @@
     "variants": [
       "LADY'S LACES\nLa\"dy's la\"ces. (Bot.)\n\nDefn: A slender climbing plant; dodder."
     ],
-    "references": [
-      "LADY'S LACES"
-    ]
+    "references": []
   },
   {
     "spellings": "LADY'S LOOKING-GLASS",
     "variants": [
       "LADY'S LOOKING-GLASS\nLa\"dy's look\"ing-glass`. (Bot.)\n\nDefn: See Venus's looking-glass, under Venus."
     ],
-    "references": [
-      "LADY'S LOOKING-GLASS"
-    ]
+    "references": []
   },
   {
     "spellings": "LADY'S MANTLE",
@@ -38358,7 +38223,6 @@
       "LADY'S MANTLE\nLa\"dy's man\"tle. (Bot.)\n\nDefn: A genus of rosaceous herbs (Alchemilla), esp. the European A.\nvulgaris, which has leaves with rounded and finely serrated lobes."
     ],
     "references": [
-      "LADY'S MANTLE",
       "PADELION"
     ]
   },
@@ -38367,9 +38231,7 @@
     "variants": [
       "LADY'S SEAL\nLa\"dy's seal\".(Bot.)\n(a) The European Solomon's seal (Polygonatum verticillatum).\n(b) The black bryony (Tamus communis)."
     ],
-    "references": [
-      "LADY'S SEAL"
-    ]
+    "references": []
   },
   {
     "spellings": "LADY'S SLIPPER",
@@ -38379,7 +38241,6 @@
     "references": [
       "CYPRIPEDIUM",
       "IMPATIENS",
-      "LADY'S SLIPPER",
       "MOCCASIN",
       "VENUS"
     ]
@@ -38390,8 +38251,7 @@
       "LADY'S SMOCK\nLa\"dy's smock\". (Bot.)\n\nDefn: A plant of the genus Cardamine (C. pratensis); cuckoo flower."
     ],
     "references": [
-      "CUCKOOFLOWER",
-      "LADY'S SMOCK"
+      "CUCKOOFLOWER"
     ]
   },
   {
@@ -38399,9 +38259,7 @@
     "variants": [
       "LADY'S THIMBLE\nLa\"dy's thim\"ble. (Bot.)\n\nDefn: The harebell."
     ],
-    "references": [
-      "LADY'S THIMBLE"
-    ]
+    "references": []
   },
   {
     "spellings": "LADY'S THUMB",
@@ -38409,7 +38267,6 @@
       "LADY'S THUMB\nLa\"dy's thumb\". (Bot.)\n\nDefn: An annual weed (Polygonum Persicaria), having a lanceolate leaf\nwith a dark spot in the middle."
     ],
     "references": [
-      "LADY'S THUMB",
       "PERSICARIA"
     ]
   },
@@ -38418,9 +38275,7 @@
     "variants": [
       "LADY'S TRACES; LADIES' TRESSES; LADIES TRESSES\nLa\"dy's tra\"ces, La\"dies' tress\"es. (Bot.)\n\nDefn: A name given to several species of the orchidaceous genus\nSpiranthes, in which the white flowers are set in spirals about a\nslender axis and remotely resemble braided hair."
     ],
-    "references": [
-      "LADY'S TRACES; LADIES' TRESSES; LADIES TRESSES"
-    ]
+    "references": []
   },
   {
     "spellings": "LAELAPS",
@@ -38462,9 +38317,7 @@
     "variants": [
       "LAETERE SUNDAY\nLæ*te\"re Sun\"day\n\nDefn: . The fourth Sunday of Lent; -- so named from the Latin word\nLætare (rejoice), the first word in the antiphone of the introit sung\nthat day in the Roman Catholic service."
     ],
-    "references": [
-      "LAETERE SUNDAY"
-    ]
+    "references": []
   },
   {
     "spellings": "LAEVIGATE",
@@ -38617,7 +38470,6 @@
     "references": [
       "BEER",
       "LAGER",
-      "LAGER BEER",
       "SCHOONER"
     ]
   },
@@ -38626,9 +38478,7 @@
     "variants": [
       "LAGER WINE\nLa\"ger wine`\n\nDefn: . Wine which has been kept for some time in the cellar.\nSimmonds."
     ],
-    "references": [
-      "LAGER WINE"
-    ]
+    "references": []
   },
   {
     "spellings": "LAGGARD",
@@ -39183,7 +39033,6 @@
       "LAISSEZ FAIRE\nLais`sez\" faire\". Etym: [F., let alone.]\n\nDefn: Noninterference; -- an axiom of some political economists,\ndeprecating interference of government by attempts to foster or\nregulate commerce, manufactures, etc., by bounty or by restriction;\nas, the doctrine of laissez faire; the laissez faire system\ngovernment."
     ],
     "references": [
-      "LAISSEZ FAIRE",
       "LET-ALONE"
     ]
   },
@@ -39860,9 +39709,7 @@
     "variants": [
       "LAMBERT PINE\nLam\"bert pine`. Etym: [So called from Lambert, an English botanist.]\n(Bot.)\n\nDefn: The gigantic sugar pine of California and Oregon (Pinus\nLambertiana). It has the leaves in fives, and cones a foot long. The\ntimber is soft, and like that of the white pine of the Eastern\nStates."
     ],
-    "references": [
-      "LAMBERT PINE"
-    ]
+    "references": []
   },
   {
     "spellings": "LAMBKILL",
@@ -40751,7 +40598,6 @@
     ],
     "references": [
       "EELPOUT",
-      "LAMPER EEL",
       "LAMPREY",
       "LUMPER"
     ]
@@ -40944,9 +40790,7 @@
     "variants": [
       "LANCASHIRE BOILER\nLa\"ca*shire boil\"er\n\nDefn: . A steam boiler having two flues which contain the furnaces\nand extend through the boiler from end to end."
     ],
-    "references": [
-      "LANCASHIRE BOILER"
-    ]
+    "references": []
   },
   {
     "spellings": "LANCASTERIAN",
@@ -41038,7 +40882,6 @@
     "references": [
       "BALANCE",
       "HAMMERHEAD",
-      "LANCE FISH",
       "RIGGLE"
     ]
   },
@@ -42355,7 +42198,6 @@
       "LAND LEAGUE\nLand League.\n\nDefn: In Ireland, a combination of tenant farmers and other,\norganized, with Charles Stewart Parnell as president, in 1879 with a\nview to the reduction of farm rents and a reconstruction of the land\nlaws. -- Land\"*lea`guer (#), n. -- Land\"*lea`guism (#), n.\n\nThe Land League, of which Machael Davitt was the founder, originated\nin Mayo in August, and at a Dublin in October the organization was\nextended to all Ireland, with Parnell as president.\nEncyc. Brit."
     ],
     "references": [
-      "LAND LEAGUE",
       "LEAGUE"
     ]
   },
@@ -42513,8 +42355,7 @@
       "LAND OF STEADY HABITS\nLand of Steady Habits.\n\nDefn: Connecticut; -- a nickname alluding to the moral character of\nits inhabitants, implied by the rigid laws (see Blue laws) of the\nearly period."
     ],
     "references": [
-      "LAND",
-      "LAND OF STEADY HABITS"
+      "LAND"
     ]
   },
   {
@@ -43517,7 +43358,6 @@
       "LANGUE D'OC\nLangue` d'oc\". Etym: [F., language of oc yes.]\n\nDefn: The dialect, closely akin to French, formerly spoken south of\nthe Loire (in which the word for \"yes\" was oc); Provencal."
     ],
     "references": [
-      "LANGUE D'OC",
       "PROVENCAL"
     ]
   },
@@ -43526,9 +43366,7 @@
     "variants": [
       "LANGUE D'OIL\nLangue` d'oïl\". Etym: [F., language of oïl yes.]\n\nDefn: The dialect formerly spoken north of the Loire (in which the\nword for \"yes\" was oïl, F. oui)."
     ],
-    "references": [
-      "LANGUE D'OIL"
-    ]
+    "references": []
   },
   {
     "spellings": "LANGUENTE",
@@ -44355,7 +44193,6 @@
       "ARMENIAN",
       "AZURE",
       "GELATINATE",
-      "LAPIS LAZULI",
       "LAZULI",
       "SAUNDERS-BLUE",
       "ULTRAMARINE"
@@ -44712,7 +44549,6 @@
       "LARAMIE GROUP\nLar\"a*mie group`. (Geol.)\n\nDefn: An extensive series of strata, principally developed in the\nRocky Mountain region, as in the Laramie Mountains, and formerly\nsupposed to be of the Tertiary age, but now generally regarded as\nCretaceous, or of intermediate and transitional character. It\ncontains beds of lignite, often valuable for coal, and is hence also\ncalled the lignitic group. See Chart of Geology."
     ],
     "references": [
-      "LARAMIE GROUP",
       "LIGNITIC"
     ]
   },
@@ -50127,9 +49963,7 @@
     "variants": [
       "LATIGO HALTER\nLa\"ti*go hal\"ter.\n\nDefn: A kind of halter usually made of raw hide."
     ],
-    "references": [
-      "LATIGO HALTER"
-    ]
+    "references": []
   },
   {
     "spellings": "LATIMER",
@@ -51222,7 +51056,6 @@
       "LATTER-DAY SAINT\nLat\"ter-day` saint\".\n\nDefn: A Mormon; -- the Church of Jesus Christ of Latter-day Saints\nbeing the name assumed by the whole body of Mormons."
     ],
     "references": [
-      "LATTER-DAY SAINT",
       "MORMON"
     ]
   },
@@ -51312,7 +51145,6 @@
       "LATUS RECTUM\nLa\"tus rec\"tum. Etym: [L., the right side.] (Conic Sections)\n\nDefn: The line drawn through a focus of a conic section parallel to\nthe directrix and terminated both ways by the curve. It is the\nparameter of the principal axis. See Focus, and Parameter."
     ],
     "references": [
-      "LATUS RECTUM",
       "PARAMETER",
       "QUADRATURE"
     ]
@@ -52141,9 +51973,7 @@
     "variants": [
       "LA VALLIERE; LAVALLIERE\nLa val`liere\", or  La`val`liere\", n.\n\nDefn: A neck ornament consisting of a chain and single pendant, or\ndrop."
     ],
-    "references": [
-      "LA VALLIERE; LAVALLIERE"
-    ]
+    "references": []
   },
   {
     "spellings": "LAVARET",
@@ -55383,18 +55213,14 @@
     "variants": [
       "LAY READER\nLay\" read\"er. (Eccl.)\n\nDefn: A layman authorized to read parts of the public service of the\nchurch."
     ],
-    "references": [
-      "LAY READER"
-    ]
+    "references": []
   },
   {
     "spellings": "LAY SHAFT; LAYSHAFT",
     "variants": [
       "LAY SHAFT; LAYSHAFT\nLay shaft, or Lay\"shaft`, n. (Mach.)\n\nDefn: A secondary shaft, as in a sliding change gear for an\nautomobile; a cam shaft operated by a two-to-one gear in an internal-\ncombustion engine. It is generally a shaft moving more or less\nindependently of the other parts of a machine, as, in some marine\nengines, a shaft, driven by a small auxiliary engine, for\nindependently operating the valves of the main engine to insure\nuniform motion."
     ],
-    "references": [
-      "LAY SHAFT; LAYSHAFT"
-    ]
+    "references": []
   },
   {
     "spellings": "LAYSHIP",
@@ -55434,9 +55260,7 @@
     "variants": [
       "LAZARET FEVER\nLazaret fever. (Med.)\n\nDefn: Typhus fever."
     ],
-    "references": [
-      "LAZARET FEVER"
-    ]
+    "references": []
   },
   {
     "spellings": "LAZARIST; LAZARITE",
@@ -56440,9 +56264,7 @@
     "variants": [
       "LEADING EDGE\nLead\"ing edge. (Aëronautics)\n\nDefn: same as Advancing edge, above."
     ],
-    "references": [
-      "LEADING EDGE"
-    ]
+    "references": []
   },
   {
     "spellings": "LEADMAN",
@@ -57741,7 +57563,6 @@
       "GREGORIAN",
       "INTERCALARY",
       "JEWISH CALENDAR",
-      "LEAP YEAR",
       "MOHAMMEDAN CALENDAR",
       "MONTH",
       "YEAR"
@@ -62341,9 +62162,7 @@
     "variants": [
       "LEG BRIDGE\nLeg bridge.\n\nDefn: A type of bridge for small spans in which the floor girders are\nrigidly secured at their extremities to supporting steel legs, driven\ninto the round as piling, or resting on mudsills."
     ],
-    "references": [
-      "LEG BRIDGE"
-    ]
+    "references": []
   },
   {
     "spellings": "LEGE",
@@ -63635,7 +63454,6 @@
       "LENARD RAYS\nLe*nard\" rays. (Physics.)\n\nDefn: Rays emanating from the outer surface of a plate composed of\nany material permeable by cathode rays, as aluminium, which forms a\nportion of a wall of a vacuum tube, or which is mounted within the\ntube and exposed to radiation from the cathode. Lenard rays are\nsimilar in all their known properties to cathode rays. So called from\nthe German physicist Philipp Lenard (b. 1862), who first described\nthem."
     ],
     "references": [
-      "LENARD RAYS",
       "LENARD TUBE"
     ]
   },
@@ -63644,9 +63462,7 @@
     "variants": [
       "LENARD TUBE\nLenard tube. (Elec.)\n\nDefn: A tube for producing Lenard rays."
     ],
-    "references": [
-      "LENARD TUBE"
-    ]
+    "references": []
   },
   {
     "spellings": "LEND",
@@ -64846,9 +64662,7 @@
     "variants": [
       "LENT LILY\nLent lily (Bot.),\n\nDefn: the daffodil; -- so named from its blossoming in spring."
     ],
-    "references": [
-      "LENT LILY"
-    ]
+    "references": []
   },
   {
     "spellings": "LENTO",
@@ -65005,7 +64819,6 @@
       "LEOPARD'S BANE\nLeop\"ard's bane`. (Bot.)\n\nDefn: A name of several harmless plants, as Arnica montana, Senecio\nDoronicum, and Paris quadrifolia."
     ],
     "references": [
-      "LEOPARD'S BANE",
       "LIBBARD'S BANE",
       "MOUNTAIN"
     ]
@@ -65620,9 +65433,7 @@
     "variants": [
       "LESBIAN LOVE\nLesbian love.\n\nDefn: See Lesbianism."
     ],
-    "references": [
-      "LESBIAN LOVE"
-    ]
+    "references": []
   },
   {
     "spellings": "LESE",
@@ -68759,9 +68570,7 @@
     "variants": [
       "LEVARI FACIAS\nLe*va`ri fa\"ci*as. Etym: [Law L., cause to be levied.]\n\nDefn: A writ of execution at common law."
     ],
-    "references": [
-      "LEVARI FACIAS"
-    ]
+    "references": []
   },
   {
     "spellings": "LEVATION",
@@ -68826,9 +68635,7 @@
     "variants": [
       "LEVEE EN MASSE\nLe*vée\" en` masse\". Etym: [F.]\n\nDefn: See Levy in mass, under Levy, n."
     ],
-    "references": [
-      "LEVEE EN MASSE"
-    ]
+    "references": []
   },
   {
     "spellings": "LEVEFUL",
@@ -69920,7 +69727,6 @@
       "DISCHARGE",
       "DISCHARGER",
       "JAR",
-      "LEYDEN JAR; LEYDEN PHIAL",
       "UNIT"
     ]
   },
@@ -69937,8 +69743,7 @@
       "LEZE MAJESTY\nLeze` maj\"es*ty. Etym: [F. lese-majesté, fr. L. laesus, fem. laesa,\ninjured (see Lesion) + majestas majesty; that is, crimen laesae\nmajestatis.] [Written also lese majesty.] (Law)\n\nDefn: Any crime committed against the sovereign power."
     ],
     "references": [
-      "LESE-MAJESTY",
-      "LEZE MAJESTY"
+      "LESE-MAJESTY"
     ]
   },
   {
@@ -70617,9 +70422,7 @@
     "variants": [
       "LIBBARD'S BANE\nLib\"bard's bane`\n\nDefn: . Leopard's bane. [Obs.]"
     ],
-    "references": [
-      "LIBBARD'S BANE"
-    ]
+    "references": []
   },
   {
     "spellings": "LIBEL",
@@ -70678,9 +70481,7 @@
     "variants": [
       "LI BELLA\nLi *bel\"la, n. Etym: [L., dim. of libra balance. See Level, n.]\n\n1. A small balance.\n\n2. A level, or leveling instrument."
     ],
-    "references": [
-      "LI BELLA"
-    ]
+    "references": []
   },
   {
     "spellings": "LIBELLEE",
@@ -72359,9 +72160,7 @@
     "variants": [
       "LIEBERKUHN'S GLANDS; LIEBERKUEHN'S GLANDS\nLie\"ber*kühn's glands`. Etym: [See Lieberkühn.] (Anat.)\n\nDefn: The simple tubular glands of the small intestines; -- called\nalso crypts of Lieberkühn."
     ],
-    "references": [
-      "LIEBERKUHN'S GLANDS; LIEBERKUEHN'S GLANDS"
-    ]
+    "references": []
   },
   {
     "spellings": "LIED",
@@ -72558,9 +72357,7 @@
     "variants": [
       "LIERNE RIB\nLierne\" rib`. Etym: [F. lierne.] (Arch.)\n\nDefn: In Gothic vaulting, any rib which does not spring from the\nimpost and is not a ridge rib, but passes from one boss or\nintersection of the principal ribs to another."
     ],
-    "references": [
-      "LIERNE RIB"
-    ]
+    "references": []
   },
   {
     "spellings": "LIEU",
@@ -72649,7 +72446,6 @@
     "references": [
       "GENERAL",
       "LIEUTENANT",
-      "LIEUTENANT GENERAL",
       "MAJOR GENERAL"
     ]
   },
@@ -76644,9 +76440,7 @@
     "variants": [
       "LIGHT YEAR\nLight year. (Astron.)\n\nDefn: The distance over which light can travel in a year's time; --\nused as a unit in expressing stellar distances. It is more than\n63,000 times as great as the distance from the earth to the sun."
     ],
-    "references": [
-      "LIGHT YEAR"
-    ]
+    "references": []
   },
   {
     "spellings": "LIGN-ALOES",
@@ -76818,9 +76612,7 @@
     "variants": [
       "LIGNUM RHODIUM\nLig\"num rho\"di*um. Etym: [NL., fr. L. lignum wood + Gr. (Bot.)\n\nDefn: The fragrant wood of several shrubs and trees, especially of\nspecies of Rhodorhiza from the Canary Islands, and of the West Indian\nAmyris balsamifera."
     ],
-    "references": [
-      "LIGNUM RHODIUM"
-    ]
+    "references": []
   },
   {
     "spellings": "LIGNUM-VITAE",
@@ -81854,9 +81646,7 @@
     "variants": [
       "LIMBURG CHEESE; LIMBURGER; LIMBURGER CHEESE\nLim\"burg cheese, Lim\"burg*er, n., Lim\"burg*er cheese.\n\nDefn: A soft cheese made in the Belgian province of Limburg\n(Limbourg), and usually not eaten until the curing has developed a\npeculiar and, to most people, unpleasant odor."
     ],
-    "references": [
-      "LIMBURG CHEESE; LIMBURGER; LIMBURGER CHEESE"
-    ]
+    "references": []
   },
   {
     "spellings": "LIME",
@@ -82239,8 +82029,7 @@
       "LIME TWIG\nLime twig\n\nDefn: . See under 4th Lime."
     ],
     "references": [
-      "LIME",
-      "LIME TWIG"
+      "LIME"
     ]
   },
   {
@@ -82868,9 +82657,7 @@
     "variants": [
       "LIM NAEA\nLim *næ\"a, n. Etym: [NL., fr. Gr. (Zoöl.)\n\nDefn: A genus of fresh-water air-breathing mollusks, abundant in\nponds and streams; -- called also pond snail. [Written also Lymnæa.]"
     ],
-    "references": [
-      "LIM NAEA"
-    ]
+    "references": []
   },
   {
     "spellings": "LIMNER",
@@ -83305,9 +83092,7 @@
     "variants": [
       "LINCOLN GREEN\nLin\"coln green\"\n\nDefn: . A color of cloth formerly made in Lincoln, England; the cloth\nitself."
     ],
-    "references": [
-      "LINCOLN GREEN"
-    ]
+    "references": []
   },
   {
     "spellings": "LINCTURE; LINCTUS",
@@ -84989,9 +84774,7 @@
     "variants": [
       "LINGOA WOOD\nLin*go\"a wood`\n\nDefn: . Amboyna wood."
     ],
-    "references": [
-      "LINGOA WOOD"
-    ]
+    "references": []
   },
   {
     "spellings": "LINGOT",
@@ -85059,7 +84842,6 @@
       "LINGUA FRANCA\nLin\"gua Fran\"ca. Etym: [It., prop., language of the Franks.]\n\nDefn: The commercial language of the Levant, -- a mixture of the\nlanguage of the people of the region and foreign traders."
     ],
     "references": [
-      "LINGUA FRANCA",
       "YAKUT"
     ]
   },
@@ -85390,7 +85172,6 @@
     "references": [
       "EXPANSION",
       "LINK",
-      "LINK MOTION",
       "VALVE"
     ]
   },
@@ -85440,9 +85221,7 @@
     "variants": [
       "LINNAEA BOREALIS\nLin*næ\"a bo`re*a\"lis. Etym: [NL.Linnaeus Linnæan + L. borealis\nnorthern.] (Bot.)\n\nDefn: The twin flower which grows in cold northern climates."
     ],
-    "references": [
-      "LINNAEA BOREALIS"
-    ]
+    "references": []
   },
   {
     "spellings": "LINNAEAN; LINNEAN",
@@ -85870,9 +85649,7 @@
     "variants": [
       "LION'S EAR\nLi\"on's ear`. (Bot.)\n\nDefn: A name given in Western South America to certain plants with\nshaggy tomentose leaves, as species of Culcitium, and Espeletia."
     ],
-    "references": [
-      "LION'S EAR"
-    ]
+    "references": []
   },
   {
     "spellings": "LION'S FOOT",
@@ -85880,7 +85657,6 @@
       "LION'S FOOT\nLi\"on's foot`. (Bot.)\n(a) A composite plant of the genus Prenanthes, of which several\nspecies are found in the United States.\n(b) The edelweiss."
     ],
     "references": [
-      "LION'S FOOT",
       "RATTLESNAKE"
     ]
   },
@@ -85896,9 +85672,7 @@
     "variants": [
       "LION'S LEAF\nLi\"on's leaf`. (Bot.)\n\nDefn: A South European plant of the genus Leontice (L.\nleontopetalum), the tuberous roots of which contain so much alkali\nthat they are sometimes used as a substitute for soap."
     ],
-    "references": [
-      "LION'S LEAF"
-    ]
+    "references": []
   },
   {
     "spellings": "LION'S TAIL",
@@ -85906,7 +85680,6 @@
       "LION'S TAIL\nLi\"on's tail`. (Bot.)\n\nDefn: A genus of labiate plants (Leonurus); -- so called from a\nfancied resemblance of its flower spikes to the tuft of a lion's\ntail. L. Cardiaca is the common motherwort."
     ],
     "references": [
-      "LION'S TAIL",
       "MOTHERWORT"
     ]
   },
@@ -85917,8 +85690,7 @@
     ],
     "references": [
       "DANDELION",
-      "LEONTODON",
-      "LION'S TOOTH"
+      "LEONTODON"
     ]
   },
   {
@@ -86934,8 +86706,7 @@
     ],
     "references": [
       "DEWAR VESSEL",
-      "LIQUID",
-      "LIQUID AIR"
+      "LIQUID"
     ]
   },
   {
@@ -92128,8 +91899,7 @@
     ],
     "references": [
       "BOARD",
-      "LIVERYMAN",
-      "LIVERY STABLE"
+      "LIVERYMAN"
     ]
   },
   {
@@ -92978,9 +92748,7 @@
     "variants": [
       "LIVING PICTURE\nLiv\"ing pic\"ture.\n\nDefn: A tableau in which persons take part; also, specif., such a\ntableau as imitating a work of art."
     ],
-    "references": [
-      "LIVING PICTURE"
-    ]
+    "references": []
   },
   {
     "spellings": "LIVONIAN",
@@ -93152,9 +92920,7 @@
     "variants": [
       "LIZARD'S TAIL\nLiz\"ard's tail`. (Bot.)\n\nDefn: A perennial plant of the genus Saururus (S. cernuus), growing\nin marshes, and having white flowers crowded in a slender terminal\nspike, somewhat resembling in form a lizard's tail; whence the name.\nGray."
     ],
-    "references": [
-      "LIZARD'S TAIL"
-    ]
+    "references": []
   },
   {
     "spellings": "LLAMA",
@@ -93177,9 +92943,7 @@
     "variants": [
       "LLANDEILO GROUP\nLlan*dei\"lo group`. (Geol.)\n\nDefn: A series of strata in the lower Silurian formations of Great\nBritain; -- so named from Llandeilo in Southern Wales. See Chart of\nGeology."
     ],
-    "references": [
-      "LLANDEILO GROUP"
-    ]
+    "references": []
   },
   {
     "spellings": "LLANERO",
@@ -94684,9 +94448,7 @@
     "variants": [
       "LOCHABER AX; LOCHABER AXE\nLoch*a\"ber ax\", Loch*a\"ber axe\". Etym: [So called from Lochaber, in\nScotland.]\n\nDefn: A weapon of war, consisting of a pole armed with an axhead at\nits end, formerly used by the Scotch Highlanders."
     ],
-    "references": [
-      "LOCHABER AX; LOCHABER AXE"
-    ]
+    "references": []
   },
   {
     "spellings": "LOCHAGE",
@@ -94950,9 +94712,7 @@
     "variants": [
       "LOCK HOSPITAL\nLock\" hos\"pi*tal\n\nDefn: . A hospital for the treatment of venereal diseases. [Eng.]"
     ],
-    "references": [
-      "LOCK HOSPITAL"
-    ]
+    "references": []
   },
   {
     "spellings": "LOCKJAW",
@@ -95007,9 +94767,7 @@
     "variants": [
       "LOCK STEP\nLock\" step`\n\nDefn: . A mode of marching by a body of men going one after another\nas closely as possible, in which the leg of each moves at the same\ntime with the corresponding leg of the person before him."
     ],
-    "references": [
-      "LOCK STEP"
-    ]
+    "references": []
   },
   {
     "spellings": "LOCK STITCH",
@@ -95018,7 +94776,6 @@
     ],
     "references": [
       "CHAIN STITCH",
-      "LOCK STITCH",
       "STITCH"
     ]
   },
@@ -95067,9 +94824,7 @@
     "variants": [
       "LOCO DISEASE\nLoco disease. (Veter.)\n\nDefn: A chronic nervous affection of cattle, horses, and sheep,\ncaused by eating the loco weed and characterized by a slow, measured\ngait, high step, glassy eyes with defective vision, delirium, and\ngradual emaciation."
     ],
-    "references": [
-      "LOCO DISEASE"
-    ]
+    "references": []
   },
   {
     "spellings": "LOCOFOCO",
@@ -95294,9 +95049,7 @@
     "variants": [
       "LOCUM TENENS\nLo\"cum te\"nens. Etym: [L., holding the place; locus place + tenens,\np. pr. of tenere to hold. Cf. Lieutenant.]\n\nDefn: A substitute or deputy; one filling an office for a time."
     ],
-    "references": [
-      "LOCUM TENENS"
-    ]
+    "references": []
   },
   {
     "spellings": "LOCUS",
@@ -95393,8 +95146,7 @@
     ],
     "references": [
       "LEGUMINOUS",
-      "LOCUST",
-      "LOCUST TREE"
+      "LOCUST"
     ]
   },
   {
@@ -95747,7 +95499,6 @@
       "LOEVEN'S LARVA\nLoev\"en's lar\"va. Etym: [Named after the Swedish zoölogist, S. F.\nLöven, who discovered it.] (Zoöl.)\n\nDefn: The peculiar larva of Polygordius. See Polygordius."
     ],
     "references": [
-      "LOEVEN'S LARVA",
       "METAMERE",
       "POLYGORDIUS"
     ]
@@ -95835,9 +95586,7 @@
     "variants": [
       "LOFTING IRON\nLoft\"ing iron. (Golf)\n\nDefn: Same as Lofter."
     ],
-    "references": [
-      "LOFTING IRON"
-    ]
+    "references": []
   },
   {
     "spellings": "LOFTY",
@@ -97208,18 +96957,14 @@
     "variants": [
       "LONDON SMOKE\nLon\"don smoke.\n\nDefn: A neutral tint given to spectacles, shade glasses for optical\ninstruments, etc., which reduces the intensity without materially\nchanging the color of the transmitted light."
     ],
-    "references": [
-      "LONDON SMOKE"
-    ]
+    "references": []
   },
   {
     "spellings": "LONDON TUFT",
     "variants": [
       "LONDON TUFT\nLondon tuft. (Bot.)\n\nDefn: The Sweet William (Dianthus barbatus)."
     ],
-    "references": [
-      "LONDON TUFT"
-    ]
+    "references": []
   },
   {
     "spellings": "LONE",
@@ -97309,9 +97054,7 @@
     "variants": [
       "LONE-STAR STATE\nLone-Star State.\n\nDefn: Texas; -- a nickname alluding to the single star on its coat of\narms, being the device used on its flag and seal when it was a\nrepublic."
     ],
-    "references": [
-      "LONE-STAR STATE"
-    ]
+    "references": []
   },
   {
     "spellings": "LONG",
@@ -99694,9 +99437,7 @@
     "variants": [
       "LONGMYND ROCKS\nLong\"mynd rocks\". (Geol.)\n\nDefn: The sparingly fossiliferous conglomerates, grits, schists, and\nstates of Great Britain, which lie at the base of the Cambrian\nsystem; -- so called, because typically developed in the Longmynd\nHills, Shropshire."
     ],
-    "references": [
-      "LONGMYND ROCKS"
-    ]
+    "references": []
   },
   {
     "spellings": "LONGNESS",
@@ -99721,7 +99462,6 @@
     ],
     "references": [
       "BOURGEOIS",
-      "LONG PRIMER",
       "PICA",
       "PRIMER",
       "TYPE"
@@ -102442,8 +102182,7 @@
     "references": [
       "ARUM",
       "ASIDE",
-      "CREW",
-      "LORDS AND LADIES"
+      "CREW"
     ]
   },
   {
@@ -102552,9 +102291,7 @@
     "variants": [
       "LORETO NUNS; LORETTO NUNS\nLo*ret\"o, or Lo*ret\"to, nuns. [From Loreto, a city in Italy famous\nfor its Holy House, said to be that in which Jesus lived, brought by\nangels from Nazareth.] (R. C. Ch.)\n\nDefn: Members of a congregation of nuns founded by Mrs. Mary Teresa\nBall, near Dublin, Ireland, in 1822, and now spread over Ireland,\nIndia, Canada, and the United States. The nuns are called also Ladies\nof Loreto. They are engaged in teaching girls."
     ],
-    "references": [
-      "LORETO NUNS; LORETTO NUNS"
-    ]
+    "references": []
   },
   {
     "spellings": "LORETTE",
@@ -104135,9 +103872,7 @@
     "variants": [
       "LOUIS D'OR\nLou\"is d'or`. Etym: [F., gold louis.]\n\nDefn: Formerly, a gold coin of France nominally worth twenty\nshillings sterling, but of varying value; -- first struck in 1640."
     ],
-    "references": [
-      "LOUIS D'OR"
-    ]
+    "references": []
   },
   {
     "spellings": "LOUIS QUATORZE",
@@ -104145,8 +103880,7 @@
       "LOUIS QUATORZE\nLon\"is qua*torze\". Etym: [F., Louis fourteenth.]\n\nDefn: Of, pertaining to, or resembling, the art or style of the times\nof Louis XIV. of France; as, Louis quatorze architecture."
     ],
     "references": [
-      "CHIPPENDALE",
-      "LOUIS QUATORZE"
+      "CHIPPENDALE"
     ]
   },
   {
@@ -105404,9 +105138,7 @@
     "variants": [
       "LOVING CUP\nLov\"ing cup`.\n\nDefn: A large ornamental drinking vessel having two or more handles,\nintended to pass from hand to hand, as at a banquet."
     ],
-    "references": [
-      "LOVING CUP"
-    ]
+    "references": []
   },
   {
     "spellings": "LOVING-KINDNESS",
@@ -107244,8 +106976,7 @@
       "LOW STEEL\nLow steel.\n\nDefn: See under Low."
     ],
     "references": [
-      "LOW",
-      "LOW STEEL"
+      "LOW"
     ]
   },
   {
@@ -108047,8 +107778,7 @@
       "LUCKY PROACH\nLuck`y proach\". (Zoöl.)\n\nDefn: See Fatherlasher."
     ],
     "references": [
-      "FATHER-LASHER",
-      "LUCKY PROACH"
+      "FATHER-LASHER"
     ]
   },
   {
@@ -108275,9 +108005,7 @@
     "variants": [
       "LUDLOW GROUP\nLud\"low group`. (Geol.)\n\nDefn: A subdivision of the British Upper Silurian lying below the Old\nRed Sandstone; -- so named from the Ludlow, in Western England. See\nthe Chart of Geology."
     ],
-    "references": [
-      "LUDLOW GROUP"
-    ]
+    "references": []
   },
   {
     "spellings": "LUDWIGITE",
@@ -108814,9 +108542,7 @@
     "variants": [
       "LUMBER STATE\nLum\"ber State.\n\nDefn: Maine; -- a nickname."
     ],
-    "references": [
-      "LUMBER STATE"
-    ]
+    "references": []
   },
   {
     "spellings": "LUMBOSACRAL",
@@ -110523,9 +110249,7 @@
     "variants": [
       "LUSUS NATURAE\nLu\"sus na*tu\"ræ. Etym: [L., fr. lusus sport + naturae, gen. of natura\nnature.]\n\nDefn: Sport or freak of nature; a deformed or unnatural production."
     ],
-    "references": [
-      "LUSUS NATURAE"
-    ]
+    "references": []
   },
   {
     "spellings": "LUTANIST",
@@ -111148,9 +110872,7 @@
     "variants": [
       "LYCH GATE\nLych\" gate`\n\nDefn: . See under Lich."
     ],
-    "references": [
-      "LYCH GATE"
-    ]
+    "references": []
   },
   {
     "spellings": "LYCHNIS",
@@ -111632,9 +111354,7 @@
     "variants": [
       "LYME GRASS\nLyme\" grass`. (Bot.)\n\nDefn: A coarse perennial grass of several species of Elymus, esp. E.\nCanadensis, and the European E. arenarius."
     ],
-    "references": [
-      "LYME GRASS"
-    ]
+    "references": []
   },
   {
     "spellings": "LYMPH",
@@ -111764,9 +111484,7 @@
     "variants": [
       "LYMPH NODE\nLymph node. (Anat.)\n\nDefn: A lymphatic gland."
     ],
-    "references": [
-      "LYMPH NODE"
-    ]
+    "references": []
   },
   {
     "spellings": "LYMPHOGENIC",
@@ -111853,7 +111571,6 @@
     "references": [
       "CLUB",
       "LYNCH",
-      "LYNCH LAW",
       "MOB"
     ]
   },
@@ -111993,8 +111710,7 @@
     ],
     "references": [
       "BULLEN-BULLEN",
-      "LYRATE; LYRATED",
-      "LYRE BIRD"
+      "LYRATE; LYRATED"
     ]
   },
   {

--- a/output/wordDisplayData#M.json
+++ b/output/wordDisplayData#M.json
@@ -1253,9 +1253,7 @@
     "variants": [
       "MAARA SHELL\nMa\"a*ra shell`. (Zoöl.)\n\nDefn: A large, pearly, spiral, marine shell (Turbo margaritaceus),\nfrom the Pacific Islands. It is used as an ornament."
     ],
-    "references": [
-      "MAARA SHELL"
-    ]
+    "references": []
   },
   {
     "spellings": "MAASHA",
@@ -1428,7 +1426,6 @@
       "MACADAM ROAD\nMac*ad\"am road`. [See Macadamize.]\n\nDefn: A macadamized road."
     ],
     "references": [
-      "MACADAM ROAD",
       "TELFORD"
     ]
   },
@@ -1455,9 +1452,7 @@
     "variants": [
       "MACARANGA GUM\nMac`a*ran\"ga gum`.\n\nDefn: A gum of a crimson color, obtained from a tree (Macaranga\nIndica) that grows in the East Indies. It is used in taking\nimpressions of coins, medallions, etc., and sometimes as a medicine.\nBalfour (Cyc. of India)."
     ],
-    "references": [
-      "MACARANGA GUM"
-    ]
+    "references": []
   },
   {
     "spellings": "MACARIZE",
@@ -1517,9 +1512,7 @@
     "variants": [
       "MACASSAR OIL\nMa*cas`sar oil\".\n\nDefn: A kind of oil formerly used in dressing the hair; -- so called\nbecause originally obtained from Macassar, a district of the Island\nof Celebes. Also, an imitation of the same, of perfumed castor oil\nand olive oil."
     ],
-    "references": [
-      "MACASSAR OIL"
-    ]
+    "references": []
   },
   {
     "spellings": "MACAUCO",
@@ -2553,7 +2546,6 @@
       "MACKINAW BLANKET; MACKINAW\nMack\"i*naw blan\"ket, Mack\"i*naw.Etym: [From Mackinac,the State of\nMichigan, where blankets and other stores were distributed to the\nIndians.]\n\nDefn: A thick blanket formerly in common use in the western part of\nthe United States."
     ],
     "references": [
-      "MACKINAW BLANKET; MACKINAW",
       "MACKINAW BOAT",
       "MACKINAW COAT",
       "MACKINAW TROUT",
@@ -2566,18 +2558,14 @@
     "variants": [
       "MACKINAW BOAT\nMack\"i*naw boat.\n\nDefn: A flat-bottomed boat with a pointed prow and square stern,\nusing oars or sails or both, used esp. on the upper Great Lakes and\ntheir tributaries."
     ],
-    "references": [
-      "MACKINAW BOAT"
-    ]
+    "references": []
   },
   {
     "spellings": "MACKINAW COAT",
     "variants": [
       "MACKINAW COAT\nMackinaw coat.\n\nDefn: A short, heavy, double-breasted plaid coat, the design of which\nis large and striking. [Local, U. S.]"
     ],
-    "references": [
-      "MACKINAW COAT"
-    ]
+    "references": []
   },
   {
     "spellings": "MACKINAW TROUT",
@@ -2585,7 +2573,6 @@
       "MACKINAW TROUT\nMackinaw trout.\n\nDefn: The namaycush."
     ],
     "references": [
-      "MACKINAW TROUT",
       "NAMAYCUSH"
     ]
   },
@@ -2657,9 +2644,7 @@
     "variants": [
       "MACRAME LACE\nMac\"ra*me lace\".\n\nDefn: A coarse lace made of twine, used especially in decorating\nfurniture."
     ],
-    "references": [
-      "MACRAME LACE"
-    ]
+    "references": []
   },
   {
     "spellings": "MACRENCEPHALIC; MACRENCEPHALOUS",
@@ -6680,18 +6665,14 @@
     "variants": [
       "MADEIRA VINE\nMa*dei\"ra vine. (Bot.)\n\nDefn: A herbaceous climbing vine (Boussingaultia baselloides) very\npopular in cultivation, having shining entire leaves and racemes of\nsmall fragrant white flowers."
     ],
-    "references": [
-      "MADEIRA VINE"
-    ]
+    "references": []
   },
   {
     "spellings": "MADEIRA WOOD",
     "variants": [
       "MADEIRA WOOD\nMadeira wood. (Bot.)\n (a) The mahogany tree (Swietenia Mahogoni).\n (b) A West Indian leguminous tree (Lysiloma Latisiliqua) the wood of\nwhich is used for boat trimming."
     ],
-    "references": [
-      "MADEIRA WOOD"
-    ]
+    "references": []
   },
   {
     "spellings": "MADEMOISELLE",
@@ -7083,9 +7064,7 @@
     "variants": [
       "MAESTRICHT MONITOR\nMaes\"tricht mon\"i*tor. Etym: [So called from Maestricht, a town in\nHolland.] (Paleon.)\n\nDefn: The Mosasaurus Hofmanni. See Mosasaurus."
     ],
-    "references": [
-      "MAESTRICHT MONITOR"
-    ]
+    "references": []
   },
   {
     "spellings": "MAESTRO",
@@ -7183,9 +7162,7 @@
     "variants": [
       "MAGAZINE CAMERA\nMagazine camera. (Photog.)\n\nDefn: A camera in which a number of plates can be exposed without\nreloading."
     ],
-    "references": [
-      "MAGAZINE CAMERA"
-    ]
+    "references": []
   },
   {
     "spellings": "MAGAZINER",
@@ -7747,8 +7724,7 @@
       "MAGNA CHARTA\nMag\"na Char\"ta. Etym: [L., great charter.]\n\n1. The great Charter, so called, obtained by the English barons from\nKing John, A. D. 1215. This name is also given to the charter granted\nto the people of England in the ninth year of Henry III., and\nconfirmed by Edward I.\n\n2. Hence, a fundamental constitution which guaranties rights and\nprivileges."
     ],
     "references": [
-      "GREAT",
-      "MAGNA CHARTA"
+      "GREAT"
     ]
   },
   {
@@ -7817,9 +7793,7 @@
     "variants": [
       "MAGNASE BLACK\nMag\"nase black`. (Paint.)\n\nDefn: A black pigment which dries rapidly when mixed with oil, and is\nof intense body. Fairholt."
     ],
-    "references": [
-      "MAGNASE BLACK"
-    ]
+    "references": []
   },
   {
     "spellings": "MAGNATE",
@@ -8977,7 +8951,6 @@
       "MAHON STOCK\nMa*hon\" stock`. (Bot.)\n\nDefn: An annual cruciferous plant with reddish purple or white\nflowers (Malcolmia maritima). It is called in England Virginia stock,\nbut the plant comes from the Mediterranean."
     ],
     "references": [
-      "MAHON STOCK",
       "VIRGINIA"
     ]
   },
@@ -9047,7 +9020,6 @@
       "MAHWA TREE\nMah\"wa tree`. (Bot.)\n\nDefn: An East Indian sapotaceous tree (Bassia latifolia, and also B.\nbutyracea), whose timber is used for wagon wheels, and the flowers\nfor food and in preparing an intoxicating drink. It is one of the\nbutter trees. The oil, known as mahwa and yallah, is obtained from\nthe kernels of the fruit."
     ],
     "references": [
-      "MAHWA TREE",
       "YALAH"
     ]
   },
@@ -9329,9 +9301,7 @@
     "variants": [
       "MAID'S HAIR\nMaid's\" hair`. (Bot.)\n\nDefn: The yellow bedstraw (Galium verum)."
     ],
-    "references": [
-      "MAID'S HAIR"
-    ]
+    "references": []
   },
   {
     "spellings": "MAIEUTIC; MAIEUTICAL",
@@ -10374,8 +10344,7 @@
       "MAIN YARD\nMain\" yard`. (Naut.)\n\nDefn: The yard on which the mainsail is extended, supported by the\nmainmast."
     ],
     "references": [
-      "MAIN",
-      "MAIN YARD"
+      "MAIN"
     ]
   },
   {
@@ -10767,8 +10736,7 @@
       "BRIGADE",
       "FRANGIPANE",
       "GENERAL",
-      "LIEUTENANT GENERAL",
-      "MAJOR GENERAL"
+      "LIEUTENANT GENERAL"
     ]
   },
   {
@@ -13994,8 +13962,7 @@
       "MAKE AND BREAK\nMake and break. (Elec.)\n\nDefn: Any apparatus for making and breaking an electric circuit; a\ncircuit breaker."
     ],
     "references": [
-      "INTERRUPTER",
-      "MAKE AND BREAK"
+      "INTERRUPTER"
     ]
   },
   {
@@ -15878,7 +15845,6 @@
       "MALARIA PARASITE\nMalaria parasite.\n\nDefn: Any of several minute protozoans of the genus Plasmodium (syn.\nHæmatozoön) which in their adult condition live in the tissues of\nmosquitoes of the genus Anopheles (which see) and when transferred to\nthe blood of man, by the bite of the mosquito, produce malaria. The\nyoung parasites, or sporozoites, enter the red blood corpuscles,\ngrowing at their expense, undergoing sporulation, and finally\ndestroying the corpuscles, thus liberating in the blood plasma an\nimmense number of small spores called merozoites. An indefinite but\nnot ultimated number of such generations may follow, but if meanwhile\nthe host is bitten by a mosquito, the parasites develop into gametes\nin the stomach of the insect. These conjugate, the zygote thus\nproduced divides, forming spores, and eventually sporozoites, which,\npenetrating to the salivary glands of the mosquito, may be introduced\ninto a new host. The attacks of the disease coincide with the\ndissolution of the corpuscles and liberation of the spores and\nproducts of growth of the parasites into the blood plasma. Several\nspecies of the parasite are distinguished, as P. vivax, producing\ntertian malaria; P. malariæ, quartan malaria; and P. (subgenus\nLaverania) falciferum, the malarial fever of summer and autumn common\nin the tropics."
     ],
     "references": [
-      "MALARIA PARASITE",
       "MEROZOITE"
     ]
   },
@@ -17363,9 +17329,7 @@
     "variants": [
       "MALLEE BIRD\nMal*lee\" bird`. (Zoöl.) Etym: [From native name.]\n\nDefn: The leipoa. See Leipoa."
     ],
-    "references": [
-      "MALLEE BIRD"
-    ]
+    "references": []
   },
   {
     "spellings": "MALLEMOCK; MALLEMOKE",
@@ -21300,7 +21264,6 @@
       "MANCONA BARK\nMan*co\"na bark`\n\nDefn: . See Sassy bark."
     ],
     "references": [
-      "MANCONA BARK",
       "SASSY BARK"
     ]
   },
@@ -21990,9 +21953,7 @@
     "variants": [
       "MANGANESE STEEL\nMan`ga*nese\" steel.\n\nDefn: Cast steel containing a considerable percentage of manganese,\nwhich makes it very hard and tough. See Alloy steel, above."
     ],
-    "references": [
-      "MANGANESE STEEL"
-    ]
+    "references": []
   },
   {
     "spellings": "MANGANESIAN",
@@ -22317,9 +22278,7 @@
     "variants": [
       "MANHES PROCESS\nMan`hès\" proc\"ess. (Copper Metal.)\n\nDefn: A process by which copper matte is treated by passing through\nit a blast of air, to oxidize and remove sulphur. It is analogous in\napparatus to the Bessemer process for decarbonizing cast iron. So\ncalled from Pierre Manhès, a French metallurgist, who invented it."
     ],
-    "references": [
-      "MANHES PROCESS"
-    ]
+    "references": []
   },
   {
     "spellings": "MANHOLE",
@@ -23200,9 +23159,7 @@
     "variants": [
       "MANNA CROUP\nMan\"na croup`. Etym: [Manna + Russ. & Pol. krupa groats, grits.]\n\n1. The portions of hard wheat kernels not ground into flour by the\nmillstones: a kind of semolina prepared in Russia and used for\npuddings, soups, etc.\n -- called also manna groats.\n\n2. The husked grains of manna grass."
     ],
-    "references": [
-      "MANNA CROUP"
-    ]
+    "references": []
   },
   {
     "spellings": "MANNER",
@@ -26279,9 +26236,7 @@
     "variants": [
       "MANNHEIM GOLD\nMann\"heim gold\". Etym: [From Mannheim in Germany, where much of it\nwas made.]\n\nDefn: A kind of brass made in imitation of gold. It contains eighty\nper cent of copper and twenty of zinc. Ure."
     ],
-    "references": [
-      "MANNHEIM GOLD"
-    ]
+    "references": []
   },
   {
     "spellings": "MANNIDE",
@@ -26547,8 +26502,7 @@
     ],
     "references": [
       "DECK",
-      "FRENCH",
-      "MANSARD ROOF"
+      "FRENCH"
     ]
   },
   {
@@ -30570,9 +30524,7 @@
     "variants": [
       "MARCONI'S LAW\nMar*co\"ni's law. (Wireless Teleg.)\n\nDefn: The law that the maximum good signaling distance varies\ndirectly as the square of the height of the transmitting antenna."
     ],
-    "references": [
-      "MARCONI'S LAW"
-    ]
+    "references": []
   },
   {
     "spellings": "MARCONISM",
@@ -30586,9 +30538,7 @@
     "variants": [
       "MARCONI SYSTEM\nMar*co\"ni system. (Elec.)\n\nDefn: A system or wireless telegraphy developed by G. Marconi, an\nItalian physicist, in which Hertzian waves are used in transmission\nand a coherer is used as the receiving instrument."
     ],
-    "references": [
-      "MARCONI SYSTEM"
-    ]
+    "references": []
   },
   {
     "spellings": "MARCOR",
@@ -30609,9 +30559,7 @@
     "variants": [
       "MARDI GRAS\nMar\"di` gras\", n. Etym: [F., literally, fat Tuesday.]\n\nDefn: The last day of Carnival; Shrove Tuesday; -- in some cities a\ngreat day of carnival and merrymaking."
     ],
-    "references": [
-      "MARDI GRAS"
-    ]
+    "references": []
   },
   {
     "spellings": "MARE",
@@ -30666,9 +30614,7 @@
     "variants": [
       "MARECHAL NIEL\nMare\"chal Niel\". Etym: [F.]\n\nDefn: A kind of large yellow rose. [Written also Marshal Niel.]"
     ],
-    "references": [
-      "MARECHAL NIEL"
-    ]
+    "references": []
   },
   {
     "spellings": "MARE CLAUSUM",
@@ -30677,7 +30623,6 @@
     ],
     "references": [
       "BERING SEA CONTROVERSY",
-      "MARE CLAUSUM",
       "OPEN SEA"
     ]
   },
@@ -30821,9 +30766,7 @@
     "variants": [
       "MARGARYIZE; MARGARY'S FLUID\nMar\"ga*ry*ize, v. t.  [imp. & p. p. -ized; p. pr. & vb. n. -izing.]\n[(J. J. Lloyd) Margary, inventor of the process + -ize.]\n\nDefn: To impregnate (wood) with a preservative solution of copper\nsulphate (often called Mar\"ga*ry's flu\"id [-riz])."
     ],
-    "references": [
-      "MARGARYIZE; MARGARY'S FLUID"
-    ]
+    "references": []
   },
   {
     "spellings": "MARGATE FISH",
@@ -30831,7 +30774,6 @@
       "MARGATE FISH\nMar\"gate fish\". (Zoöl.)\n\nDefn: A sparoid fish (Diabasis aurolineatus) of the Gulf of Mexico,\nesteemed as a food fish; -- called also red-mouth grunt."
     ],
     "references": [
-      "MARGATE FISH",
       "PORGY"
     ]
   },
@@ -31709,8 +31651,7 @@
       "MARIOTTE'S LAW\nMa`ri*otte's law`. (Physics.)\n\nDefn: See Boyle's law, under Law."
     ],
     "references": [
-      "LAW",
-      "MARIOTTE'S LAW"
+      "LAW"
     ]
   },
   {
@@ -31719,8 +31660,7 @@
       "MARIPOSA LILY\nMa`ri*po\"sa lil`y. Etym: [Sp. mariposa a butterfly + E. lily. So\ncalled from the gay apperance of the blossoms.] (Bot.)\n\nDefn: One of a genus (Calochortus) of tuliplike bulbous herbs with\nlarge, and often gaycolored, blossoms. Called also butterfly lily.\nMost of them are natives of California."
     ],
     "references": [
-      "LILY",
-      "MARIPOSA LILY"
+      "LILY"
     ]
   },
   {
@@ -33320,9 +33260,7 @@
     "variants": [
       "MARMORATUM OPUS\nMar`mo*ra`tum o\"pus. Etym: [L. See Marmorate, and Opus.] (Arch.)\n\nDefn: A kind of hard finish for plasterwork, made of plaster of Paris\nand marble dust, and capable of taking a high polish."
     ],
-    "references": [
-      "MARMORATUM OPUS"
-    ]
+    "references": []
   },
   {
     "spellings": "MARMOREAL; MARMOREAN",
@@ -33387,9 +33325,7 @@
     "variants": [
       "MARMOTTES OIL\nMar\"mottes oil`\n\nDefn: . A fine oil obtained from the kernel of Prunus brigantiaca. It\nis used instead of olive or almond oil. De Colange."
     ],
-    "references": [
-      "MARMOTTES OIL"
-    ]
+    "references": []
   },
   {
     "spellings": "MARMOZET",
@@ -34380,7 +34316,6 @@
       "COWSLIP",
       "MARIGOLD",
       "MARSH",
-      "MARSH MARIGOLD",
       "PIONED"
     ]
   },
@@ -34588,9 +34523,7 @@
     "variants": [
       "MARTEL DE FER\nMar`tel` de fer\". Etym: [OF., hammer of iron.]\n\nDefn: A weapon resembling a hammer, often having one side of the head\npointed; -- used by horsemen in the Middle Ages to break armor.\nFairholt."
     ],
-    "references": [
-      "MARTEL DE FER"
-    ]
+    "references": []
   },
   {
     "spellings": "MARTELINE",
@@ -34604,9 +34537,7 @@
     "variants": [
       "MARTELLO TOWER\nMar*tel\"lo tow`er. Etym: [It. martello hammer. The name was orig.\ngiven to towers erected on the coasts of Sicily and Sardinia for\nprotection against the pirates in the time of Charles the Fifth,\nwhich prob. orig. contained an alarm bell to be struck with a hammer.\nSee Martel.] (Fort.)\n\nDefn: A building of masonry, generally circular, usually erected on\nthe seacoast, with a gun on the summit mounted on a traversing\nplatform, so as to be fired in any direction.\n\nNote: The English borrowed the name of the tower from Corsica in\n1794."
     ],
-    "references": [
-      "MARTELLO TOWER"
-    ]
+    "references": []
   },
   {
     "spellings": "MARTEN",
@@ -35398,9 +35329,7 @@
     "variants": [
       "MASK SHELL\nMask\" shell`. (Zoöl.)\n\nDefn: Any spiral marine shell of the genus Persona, having a\ncuriously twisted aperture."
     ],
-    "references": [
-      "MASK SHELL"
-    ]
+    "references": []
   },
   {
     "spellings": "MASLACH",
@@ -35580,7 +35509,6 @@
       "MASOOLA BOAT\nMa*soo\"la boat`\n\nDefn: . A kind of boat used on the coast of Madras, India. The planks\nare sewed together with strands of coir which cross over a wadding of\nthe same material, so that the shock on taking the beach through surf\nis much reduced. [Written also masula, masulah, etc.]"
     ],
     "references": [
-      "MASOOLA BOAT",
       "MASSOOLA BOAT",
       "MASULA BOAT"
     ]
@@ -36315,8 +36243,7 @@
       "LEVEE EN MASSE",
       "LEVY",
       "MACE",
-      "MASS",
-      "MASSE; MASSE SHOT"
+      "MASS"
     ]
   },
   {
@@ -36511,9 +36438,7 @@
     "variants": [
       "MASSOOLA BOAT\nMas*soo\"la boat`.\n\nDefn: See Masoola boat."
     ],
-    "references": [
-      "MASSOOLA BOAT"
-    ]
+    "references": []
   },
   {
     "spellings": "MASSORA",
@@ -37133,9 +37058,7 @@
     "variants": [
       "MASTER VIBRATOR\nMas\"ter vi\"bra*tor.\n\nDefn: In an internal-combustion engine with two or more cylinders, an\ninduction coil and vibrator placed in the circuit between the battery\nor magneto and the coils for the different cylinders, which are used\nwithout vibrators of their own."
     ],
-    "references": [
-      "MASTER VIBRATOR"
-    ]
+    "references": []
   },
   {
     "spellings": "MASTERWORT",
@@ -37510,9 +37433,7 @@
     "variants": [
       "MASULA BOAT\nMa*su\"la boat`.\n\nDefn: Same as Masoola boat."
     ],
-    "references": [
-      "MASULA BOAT"
-    ]
+    "references": []
   },
   {
     "spellings": "MAT",
@@ -37652,9 +37573,7 @@
     "variants": [
       "MATAJUELO BLANCO\nMa`ta*jue\"lo blan\"co. [Sp. blanco white.]\n\nDefn: A West Indian food fish (Malacanthus plumieri) related to the\ntilefish."
     ],
-    "references": [
-      "MATAJUELO BLANCO"
-    ]
+    "references": []
   },
   {
     "spellings": "MATAMATA",
@@ -37815,8 +37734,7 @@
       "MATCH GAME\nMatch game.\n\nDefn: A game arranged as a test of superiority; also, one of a series\nof such games."
     ],
     "references": [
-      "MATCH",
-      "MATCH GAME"
+      "MATCH"
     ]
   },
   {
@@ -37874,9 +37792,7 @@
     "variants": [
       "MATCH PLAY\nMatch play. (Golf)\n\nDefn: Play in which the score is reckoned by counting the holes won\nor lost by each side; -- disting. from medal play."
     ],
-    "references": [
-      "MATCH PLAY"
-    ]
+    "references": []
   },
   {
     "spellings": "MATE",
@@ -38809,8 +38725,7 @@
     ],
     "references": [
       "ACOLOGY",
-      "IAMATOLOGY",
-      "MATERIA MEDICA"
+      "IAMATOLOGY"
     ]
   },
   {
@@ -41320,9 +41235,7 @@
     "variants": [
       "MAUNDY COINS; MAUNDY MONEY\nMaundy coins or money.\n\nDefn: Silver coins or money of the nominal value of 1d., 2d., 3d.,\nand 4d., struck annually for the Maundy alms."
     ],
-    "references": [
-      "MAUNDY COINS; MAUNDY MONEY"
-    ]
+    "references": []
   },
   {
     "spellings": "MAUNDY THURSDAY",
@@ -41332,7 +41245,6 @@
     "references": [
       "CHRISM",
       "HOLY",
-      "MAUNDY THURSDAY",
       "TWOPENCE"
     ]
   },
@@ -41433,9 +41345,7 @@
     "variants": [
       "MAVERICK BRAND\nMaverick brand.\n\nDefn: A brand originated by a dishonest cattleman, who, without\nowning any stock, gradually accumulates a herd by finding mavericks.\n[Western U. S.]"
     ],
-    "references": [
-      "MAVERICK BRAND"
-    ]
+    "references": []
   },
   {
     "spellings": "MAVIS",
@@ -41737,7 +41647,6 @@
       "MAXIM GUN\nMax\"im gun`.\n\nDefn: A kind of machine gun; -- named after its inventor, Hiram S.\nMaxim."
     ],
     "references": [
-      "MAXIM GUN",
       "VICKERS' GUN",
       "VICKERS-MAXIM GUN"
     ]
@@ -43883,9 +43792,7 @@
     "variants": [
       "MAYAN ARCH; MAYA ARCH\nMayan arch, or Maya arch .\n\nDefn: A form of corbel arch employing regular small corbels."
     ],
-    "references": [
-      "MAYAN ARCH; MAYA ARCH"
-    ]
+    "references": []
   },
   {
     "spellings": "MAYBE",
@@ -43977,8 +43884,7 @@
       "MAY LAWS\nMay laws.\n\n1. See Kulturkampf, above.\n\n2.  In Russia, severe oppressive laws against Jews, which have given\noccasion for great persecution; -- so called because they received\nthe assent of the czar in May, 1882, and because likened to the\nPrussian May laws (see Kulturkampf)."
     ],
     "references": [
-      "KULTURKAMPF",
-      "MAY LAWS"
+      "KULTURKAMPF"
     ]
   },
   {
@@ -49410,8 +49316,7 @@
       "MEDAL PLAY\nMed\"al play`. (Golf)\n\nDefn: Play in which the score is reckoned by counting the number of\nstrokes."
     ],
     "references": [
-      "MATCH PLAY",
-      "MEDAL PLAY"
+      "MATCH PLAY"
     ]
   },
   {
@@ -50684,9 +50589,7 @@
     "variants": [
       "MEDINA EPOCH\nMe*di\"na ep\"och. Etym: [From Medina in New York.] (Geol.)\n\nDefn: A subdivision of the Niagara period in the American upper\nSilurian, characterized by the formations known as the Oneida\nconglomerate, and the Medina sandstone. See the Chart of Geology."
     ],
-    "references": [
-      "MEDINA EPOCH"
-    ]
+    "references": []
   },
   {
     "spellings": "MEDINO",
@@ -50961,9 +50864,7 @@
     "variants": [
       "MEDITERRANEAN FRUIT FLY\nMediterranean fruit fly.\n\nDefn: A two-winged fly (Ceratitis capitata) with black and white\nmarkings, native of the Mediterranean countries, but now widely\ndistributed. Its larva lives in ripening oranges, peaches, and other\nfruits, causing them to decay and fall."
     ],
-    "references": [
-      "MEDITERRANEAN FRUIT FLY"
-    ]
+    "references": []
   },
   {
     "spellings": "MEDITERRANEOUS",
@@ -53073,9 +52974,7 @@
     "variants": [
       "MELIC GRASS\nMel\"ic grass`. (Bot.)\n\nDefn: A genus of grasses (Melica) of little agricultural importance."
     ],
-    "references": [
-      "MELIC GRASS"
-    ]
+    "references": []
   },
   {
     "spellings": "MELICOTOON",
@@ -54736,9 +54635,7 @@
     "variants": [
       "MEMENTO MORI\nMe*men\"to mo\"ri. [L.]\n\nDefn: Lit., remember to die, i.e., that you must die; a warning to be\nprepared for death; an object, as a death's-head or a personal\nornament, usually emblematic, used as a reminder of death."
     ],
-    "references": [
-      "MEMENTO MORI"
-    ]
+    "references": []
   },
   {
     "spellings": "MEMINNA",
@@ -54930,8 +54827,7 @@
       "DECORATION",
       "DECORATION DAY",
       "HOLIDAY",
-      "MEMORIAL",
-      "MEMORIAL DAY"
+      "MEMORIAL"
     ]
   },
   {
@@ -54960,9 +54856,7 @@
     "variants": [
       "MEMORIAL ROSE\nMemorial rose.\n\nDefn: A Japanese evergreen rose (Rosa wichuraiana) with creeping\nbranches, shining leaves, and single white flowers. It is often\nplanted in cemeteries."
     ],
-    "references": [
-      "MEMORIAL ROSE"
-    ]
+    "references": []
   },
   {
     "spellings": "MEMORIST",
@@ -56721,7 +56615,6 @@
       "MENDELIAN CHARACTER\nMendelian character. (Biol.)\n\nDefn: A character which obeys Mendel's law in regard to its\nhereditary transmission."
     ],
     "references": [
-      "MENDELIAN CHARACTER",
       "TRIHYBRID"
     ]
   },
@@ -56733,8 +56626,7 @@
     "references": [
       "ALLELOMORPH",
       "MENDELIAN",
-      "MENDELIAN CHARACTER",
-      "MENDEL'S LAW"
+      "MENDELIAN CHARACTER"
     ]
   },
   {
@@ -56933,9 +56825,7 @@
     "variants": [
       "MENIERE'S DISEASE\nMé`nière's\" dis*ease\". (Med.)\n\nDefn: A disease characterized by deafness and vertigo, resulting in\nincoördination of movement. It is supposed to depend upon a morbid\ncondition of the semicircular canals of the internal ear. Named after\nMénière, a French physician."
     ],
-    "references": [
-      "MENIERE'S DISEASE"
-    ]
+    "references": []
   },
   {
     "spellings": "MENILITE",
@@ -57956,8 +57846,7 @@
       "MERCATOR'S CHART\nMer*ca\"tor's chart\".\n\nDefn: See under Chart, and see Mercator's projection, under\nProjection."
     ],
     "references": [
-      "CHART",
-      "MERCATOR'S CHART"
+      "CHART"
     ]
   },
   {
@@ -59699,7 +59588,6 @@
       "MERO; MERO DE LOALTO; MERO CABROLLA\nMe\"ro, n. [Sp.; cf. Pg. mero.]\n\nDefn: Any of several large groupers of warm seas, esp. the guasa\n(Epinephelus guaza), the red grouper (E. morio), the black grouper\n(E. nigritas), distinguished as Me\"ro de lo al\"to, and a species\ncalled also rock hind, distinguished as Me\"ro ca*brol\"la."
     ],
     "references": [
-      "MERO; MERO DE LOALTO; MERO CABROLLA",
       "MORE"
     ]
   },
@@ -61230,9 +61118,7 @@
     "variants": [
       "MESQUITE BEAN\nMes*qui\"te bean.\n\nDefn: The pod or seed of the mesquite."
     ],
-    "references": [
-      "MESQUITE BEAN"
-    ]
+    "references": []
   },
   {
     "spellings": "MESS",
@@ -61342,18 +61228,14 @@
     "variants": [
       "MESSAGE STICK\nMes\"sage stick.\n\nDefn: A stick, carved with lines and dots, used, esp. by Australian\naborigines, to convey information."
     ],
-    "references": [
-      "MESSAGE STICK"
-    ]
+    "references": []
   },
   {
     "spellings": "MESS BEEF",
     "variants": [
       "MESS BEEF\nMess beef.\n\nDefn: Barreled salt beef, packed with about 80 pounds chuck and rump,\ntwo flanks, and the rest plates."
     ],
-    "references": [
-      "MESS BEEF"
-    ]
+    "references": []
   },
   {
     "spellings": "MESSENGER",
@@ -65837,7 +65719,6 @@
       "METER; METRE",
       "METRIC",
       "METRICAL",
-      "METRIC SYSTEM",
       "MICRO-; MICR-",
       "MILLI-",
       "MILLIER",
@@ -65859,7 +65740,6 @@
       "METRIC TON\nMet\"ric ton.\n\nDefn: A weight of 1,000 kilograms, or 2,204.6 pounds avoirdupois."
     ],
     "references": [
-      "METRIC TON",
       "MILLIER"
     ]
   },
@@ -66343,9 +66223,7 @@
     "variants": [
       "MEZZA MAJOLICA\nMez\"za ma*jol\"i*ca. [It. See Mezzo; Majolica.] (Ceramics)\n\nDefn: Italian pottery of the epoch and general character of majolica,\nbut less brilliantly decorated, esp. such pottery without tin enamel,\nbut painted and glazed."
     ],
-    "references": [
-      "MEZZA MAJOLICA"
-    ]
+    "references": []
   },
   {
     "spellings": "MEZZANINE",
@@ -66361,9 +66239,7 @@
     "variants": [
       "MEZZA VOCE\nMez\"za vo\"ce. Etym: [It., fr. mezzo, fem. mezza middle, half + voce\nvoice, L. vox.] (Mus.)\n\nDefn: With a medium fullness of sound."
     ],
-    "references": [
-      "MEZZA VOCE"
-    ]
+    "references": []
   },
   {
     "spellings": "MEZZO",
@@ -67996,9 +67872,7 @@
     "variants": [
       "MIDAS'S EAR\nMi\"das's ear\". Etym: [See Midas.] (Zoöl.)\n\nDefn: A pulmonate mollusk (Auricula, or Ellobium, aurismidæ); -- so\ncalled from resemblance to a human ear."
     ],
-    "references": [
-      "MIDAS'S EAR"
-    ]
+    "references": []
   },
   {
     "spellings": "MIDBRAIN",
@@ -68060,9 +67934,7 @@
     "variants": [
       "MIDDEN CROW\nMid\"den crow\". (Zoöl.)\n\nDefn: The common European crow. [Prov. Eng.]"
     ],
-    "references": [
-      "MIDDEN CROW"
-    ]
+    "references": []
   },
   {
     "spellings": "MIDDEST",
@@ -68835,9 +68707,7 @@
     "variants": [
       "MIDNIGHT SUN\nMid\"night` sun.\n\nDefn: The sun shining at midnight in the arctic or antarctic summer."
     ],
-    "references": [
-      "MIDNIGHT SUN"
-    ]
+    "references": []
   },
   {
     "spellings": "MIDRASH",
@@ -68891,7 +68761,6 @@
       "MID SEA; MID-SEA\nMid\" sea\", or; Mid\"-sea\".\n\nDefn: The middle part of the sea or ocean. Milton. The Mid-sea, the\nMediterranean Sea. [Obs.]"
     ],
     "references": [
-      "MID SEA; MID-SEA",
       "NIMBLE"
     ]
   },
@@ -70958,7 +70827,6 @@
     ],
     "references": [
       "MILK",
-      "MILK SICKNESS",
       "SLOWS"
     ]
   },
@@ -70979,7 +70847,6 @@
     ],
     "references": [
       "ASTRAGALUS",
-      "MILK VETCH",
       "RATTLEWEED",
       "VETCH"
     ]
@@ -71373,8 +71240,7 @@
       "MILLEFIORE GLASS\nMil`le*fi*o\"re glass`. Etym: [It. mille thousand + flore flower.]\n\nDefn: Slender rods or tubes of colored glass fused together and\nembedded in clear glass; -- used for paperweights and other small\narticles."
     ],
     "references": [
-      "GLASS",
-      "MILLEFIORE GLASS"
+      "GLASS"
     ]
   },
   {
@@ -72283,7 +72149,6 @@
     ],
     "references": [
       "MINCE-MEAT",
-      "MINCE PIE",
       "PIE"
     ]
   },
@@ -74657,7 +74522,6 @@
       "MINIE BALL\nMin\"ie ball`. Etym: [From the inventor, Captain Minié, of France.]\n\nDefn: A conical rifle bullet, with a cavity in its base plugged with\na piece of iron, which, by the explosion of the charge, is driven\nfarther in, expanding the sides to fit closely the grooves of the\nbarrel."
     ],
     "references": [
-      "MINIE BALL",
       "MINIE RIFLE"
     ]
   },
@@ -74666,9 +74530,7 @@
     "variants": [
       "MINIE RIFLE\nMin\"ie ri\"fle.\n\nDefn: A rifle adapted to minie balls."
     ],
-    "references": [
-      "MINIE RIFLE"
-    ]
+    "references": []
   },
   {
     "spellings": "MINIFY",
@@ -74764,9 +74626,7 @@
     "variants": [
       "MINIMUM THERMOMETER\nMinimum thermometer\n\nDefn: , a thermometer for recording the lowest temperature since its\nlast adjustment."
     ],
-    "references": [
-      "MINIMUM THERMOMETER"
-    ]
+    "references": []
   },
   {
     "spellings": "MINIMUS",
@@ -75266,7 +75126,6 @@
       "MINO BIRD\nMi\"no bird\". Etym: [Hind. maina.] (Zoöl.)\n\nDefn: An Asiatic bird (Gracula musica), allied to the starlings. It\nis black, with a white spot on the wings, and a pair of flat yellow\nwattles on the head. It is often tamed and taught to pronounce words."
     ],
     "references": [
-      "MINO BIRD",
       "MYNA",
       "TEEONG"
     ]
@@ -75636,7 +75495,6 @@
     ],
     "references": [
       "MINT",
-      "MINT SAUCE",
       "SAUCE"
     ]
   },
@@ -82342,7 +82200,6 @@
       "MITIS CASTING\nMi\"tis cast`ing. [Perh. fr. L. mitis mild.]\n\nDefn: A process, invented by P. Ostberg, for producing malleable iron\ncastings by melting wrought iron, to which from 0.05 to 0.1 per cent\nof aluminium is added to lower the melting point, usually in a\npetroleum furnace, keeping the molten metal at the bubbling point\nuntil it becomes quiet, and then pouring the molten metal into a mold\nlined with a special mixture consisting essentially of molasses and\nground burnt fire clay; also, a casting made by this process; --\ncalled also wrought-iron casting."
     ],
     "references": [
-      "MITIS CASTING",
       "MITIS METAL"
     ]
   },
@@ -82351,9 +82208,7 @@
     "variants": [
       "MITIS METAL\nMitis metal.\n\nDefn: The malleable iron produced by mitis casting; -- called also\nsimply mitis."
     ],
-    "references": [
-      "MITIS METAL"
-    ]
+    "references": []
   },
   {
     "spellings": "MITOME",
@@ -82495,9 +82350,7 @@
     "variants": [
       "MITTLER'S GREEN\nMitt\"ler's green`. (Chem.)\n\nDefn: A pigment of a green color, the chief constituent of which is\noxide of chromium."
     ],
-    "references": [
-      "MITTLER'S GREEN"
-    ]
+    "references": []
   },
   {
     "spellings": "MITTY",
@@ -82966,9 +82819,7 @@
     "variants": [
       "MIXOLYDIAN MODE\nMix`o*lyd\"i*an mode`. Etym: [Gr. Lydian.] (Mus.)\n\nDefn: The seventh ecclesiastical mode, whose scale commences on G."
     ],
-    "references": [
-      "MIXOLYDIAN MODE"
-    ]
+    "references": []
   },
   {
     "spellings": "MIXTILINEAL; MIXTILINEAR",
@@ -83749,9 +83600,7 @@
     "variants": [
       "MOABITE STONE\nMo\"ab*ite stone. (Archæol.)\n\nDefn: A block of black basalt, found at Dibon in Moab by Rev. F. A.\nKlein, Aug. 19, 1868, which bears an inscription of thirty-four\nlines, dating from the 9th century b. c., and written in the Moabite\nalphabet, the oldest Phonician type of the Semitic alphabet. It\nrecords the victories of Mesha, king of Moab, esp. those over Israel\n(2 Kings iii. 4, 5, 27)."
     ],
-    "references": [
-      "MOABITE STONE"
-    ]
+    "references": []
   },
   {
     "spellings": "MOABITISH",
@@ -86012,9 +85861,7 @@
     "variants": [
       "MODUS VIVENDI\nMo\"dus vi*ven\"di. [L.]\n\nDefn: Mode, or manner, of living; hence, a temporary arrangement of\naffairs until disputed matters can be settled."
     ],
-    "references": [
-      "MODUS VIVENDI"
-    ]
+    "references": []
   },
   {
     "spellings": "MODY",
@@ -86208,9 +86055,7 @@
     "variants": [
       "MOHAMMEDAN CALENDAR\nMo*ham\"med*an cal\"en*dar.\n\nDefn: A lunar calendar reckoning from the year of the hegira, 622 a.\nd. Thirty of its years constitute a cycle, of which the 2d, 5th, 7th,\n10th, 13th, 16th, 18th, 21st, 24th, 26th, and 29th are leap years,\nhaving 355 days; the others are common, having 354 days. By the\nfollowing tables any Mohammedan date may be changed into the\nChristian date, or vice versa, for the years 1900-1935 a. d.\n\nMonths of the Mohammedan year.\n\n1 Muharram . . . .. 30 2 Safar . . . . . . .. 29 3 Rabia I . . . . .\n. 30 4 Rabia II . . . .. 29 5 Jumada I . . . .. 30 6 Jumada II . . .\n. 29 7 Rajab . . . . . . .. 30 8 Shaban . . . . . . . 29 9 Ramadan .\n. . . . . 30 10 Shawwal . . . . . . 29 11 Zu'lkadah . . . . 30 12\nZu'lhijjah . . . 29* * in leap year, 30 days\n\na. h. a. d. a. h.    a. d.\n\n1317  begins May 12, 1899      1336* begins Oct.17, 1917 1318\nMay  1, 1900      1337         Oct. 7, 1918 1319*        Apr.20, 1901\n1338*        Sept.26,1919 1320         Apr.10, 1902      1339\nSept.15,1920 1321+        Mar.30, 1903      1340         Sept.4, 1921\n1322*        Mar.18, 1904      1341*        Aug.24, 1922 1323\nMar. 8, 1905      1342         Aug.14, 1923 1324         Feb.25, 1906\n1343         Aug. 2, 1924 1325*        Feb.14, 1907      1344*\nJuly 22,1925 1326         Feb. 4, 1908      1345         July 12,1926\n1327*        Jan.23, 1909      1346*        July 1, 1927 1328\nJan.13, 1910      1347         June 20,1928 1329         Jan. 2, 1911\n1348         June 9, 1929 1330*        Dec.22, 1911      1349*\nMay 29, 1930 1331         Dec.11, 1912      1350         May 19, 1931\n1332         Nov.30, 1913      1351++       May  7, 1932 1333*\nNov.19, 1914      1352*        Apr.26, 1933 1334         Nov. 9, 1915\n1353         Apr.16, 1934 1335         Oct.28, 1916      1354\nApr. 5, 1935 * Leap year  + First year of the 45th cycle ++ First\nyear of the 46th cycle\n\nThe following general rule for finding the date of commencement of\nany Mohammedan year has a maximum error of a day: Multiply 970,224 by\nthe Mohammedan year, point off six decimal places, and add 621.5774.\nThe whole number will be the year a. d., and the decimal multiplied\nby 365 will give the day of the year."
     ],
-    "references": [
-      "MOHAMMEDAN CALENDAR"
-    ]
+    "references": []
   },
   {
     "spellings": "MOHAMMEDAN ERA",
@@ -86218,7 +86063,6 @@
       "MOHAMMEDAN ERA\nMohammedan Era.\n\nDefn: The era in use in Mohammedan countries. See Mohammedan year,\nbelow."
     ],
     "references": [
-      "MOHAMMEDAN ERA",
       "MOHAMMEDAN YEAR"
     ]
   },
@@ -86262,7 +86106,6 @@
     "references": [
       "MOHAMMEDAN CALENDAR",
       "MOHAMMEDAN ERA",
-      "MOHAMMEDAN YEAR",
       "MOHURRUM; MUHARRAM"
     ]
   },
@@ -86418,9 +86261,7 @@
     "variants": [
       "MOIRE METALLIQUE\nMoi`ré\" mé`tal`lique\". Etym: [F.]\n\nDefn: A crystalline or frosted appearance produced by some acids on\ntin plate; also, the tin plate thus treated."
     ],
-    "references": [
-      "MOIRE METALLIQUE"
-    ]
+    "references": []
   },
   {
     "spellings": "MOIST",
@@ -90328,9 +90169,7 @@
     "variants": [
       "MONITOR NOZZLE\nMonitor nozzle.\n\nDefn: A nozzle capable of turning completely round in a horizontal\nplane and having a limited play in a vertical plane, used in\nhydraulic mining, fire-extinguishing apparatus, etc."
     ],
-    "references": [
-      "MONITOR NOZZLE"
-    ]
+    "references": []
   },
   {
     "spellings": "MONITORSHIP",
@@ -90570,7 +90409,6 @@
       "MONKEY'S PUZZLE\nMon\"key's puz\"zle. (Bot.)\n\nDefn: A lofty coniferous Chilian tree (Araucaria imbricata), the\nbranches of which are so crowded and intertwisted \"as to puzzle a\nmonkey to climb.\" The edible nuts are over an inch long, and are\ncalled piñon by the Chilians."
     ],
     "references": [
-      "MONKEY'S PUZZLE",
       "PINON; PINYON",
       "PION"
     ]
@@ -90650,9 +90488,7 @@
     "variants": [
       "MONK'S SEAM\nMonk's\" seam`. (Naut.)\n\nDefn: An extra middle seam made at the junction of two breadths of\ncanvas, ordinarily joined by only two rows of stitches."
     ],
-    "references": [
-      "MONK'S SEAM"
-    ]
+    "references": []
   },
   {
     "spellings": "MONO-; MON-",
@@ -92393,8 +92229,7 @@
       "MONROE DOCTRINE\nMon*roe\" doc\"trine.\n\nDefn: See under Doctrine."
     ],
     "references": [
-      "DOCTRINE",
-      "MONROE DOCTRINE"
+      "DOCTRINE"
     ]
   },
   {
@@ -92413,7 +92248,6 @@
       "MONSEL'S SALT\nMon\"sel's salt`. (Med.)\n\nDefn: A basic sulphate of iron; -- so named from Monsel, a Frenchman."
     ],
     "references": [
-      "MONSEL'S SALT",
       "MONSEL'S SOLUTION"
     ]
   },
@@ -92422,9 +92256,7 @@
     "variants": [
       "MONSEL'S SOLUTION\nMon\"sel's so*lu\"tion. Etym: [See Monsel's salt.] (Med.)\n\nDefn: An aqueous solution of Monsel's salt, having valuable styptic\nproperties."
     ],
-    "references": [
-      "MONSEL'S SOLUTION"
-    ]
+    "references": []
   },
   {
     "spellings": "MONSIEUR",
@@ -92664,9 +92496,7 @@
     "variants": [
       "MONT DE PIETE\nMont\" de pi`é`té\". Etym: [F., fr. It. monte di pietà mount of piety.]\n\nDefn: One of certain public pawnbroking establishments which\noriginated in Italy in the 15th century, the object of which was to\nlend money at a low rate of interest to poor people in need; --\ncalled also mount of piety. The institution has been adopted in other\ncountries, as in Spain and France. See Lombard-house."
     ],
-    "references": [
-      "MONT DE PIETE"
-    ]
+    "references": []
   },
   {
     "spellings": "MONTE",
@@ -92728,9 +92558,7 @@
     "variants": [
       "MONTESSORI METHOD\nMon`tes*so\"ri Meth\"od. (Pedagogy)\n\nDefn: A system of training and instruction, primarily for use with\nnormal children aged from three to six years, devised by Dr. Maria\nMontessori while teaching in the \"Houses of Childhood\" (schools in\nthe poorest tenement districts of Rome, Italy), and first fully\ndescribed by her in 1909. Leading features are freedom for physical\nactivity (no stationary desks and chairs), informal and individual\ninstruction, the very early development of writing, and an extended\nsensory and motor training (with special emphasis on vision, touch,\nperception of movement, and their interconnections), mediated by a\npatented, standardized system of \"didactic apparatus,\" which is\ndeclared to be \"auto-regulative.\" Most of the chief features of the\nmethod are borrowed from current methods used in many institutions\nfor training feeble-minded children, and dating back especially to\nthe work of the French-American physician Edouard O. Seguin (1812-\n80)."
     ],
-    "references": [
-      "MONTESSORI METHOD"
-    ]
+    "references": []
   },
   {
     "spellings": "MONTETH; MONTEITH",
@@ -99412,18 +99240,14 @@
     "variants": [
       "MORSE ALPHABET\nMorse\" al\"pha*bet.\n\nDefn: A telegraphic alphabet in very general use, inventing by Samuel\nF.B.Morse, the inventor of Morse's telegraph. The letters are\nrepresented by dots and dashes impressed or printed on paper, as, .-\n(A), -... (B), -.. (D), . (E), .. (O), ... (R), -- (T), etc., or by\nsounds, flashes of light, etc., with greater or less intervals\nbetween them."
     ],
-    "references": [
-      "MORSE ALPHABET"
-    ]
+    "references": []
   },
   {
     "spellings": "MORSE CODE",
     "variants": [
       "MORSE CODE\nMorse\" code\". (Teleg.)\n\nDefn: The telegraphic code, consisting of dots, dashes, and spaces,\ninvented by Samuel B. Morse. The Alphabetic code which is in use in\nNorth America is given below. In length, or duration, one dash is\ntheoretically equal to three dots; the space between the elements of\na letter is equal to one dot; the interval in spaced letters, as O .\n., is equal to three dots. There are no spaces in any letter composed\nwholly or in part of dashes.\n\nAlphabet\nmapping: A .-          H ....       O . .          V ...-\nmapping: B - . . .     I ..         P .....        W .--\nmapping: C .. .        J -.-.       Q ..-.         X .-..\nmapping: D -..         K -.-        R . ..         Y .. ..\nmapping: E .           L ---    S ...          Z ... .\nmapping: F .-.         M --         T --           & . ...\nmapping: G --.         N -.         U ..-\n\nNumerals\nmapping: 1 .--.        4 . . . .-          7 --..\nmapping: 2 ..-..       5 ---               8 - . . . .\nmapping: 3 . . . -.    6 . . . . . .       9 -..-\nmapping: 0 ----     Period ..--..   Comma .-.-\n\nThe International (Morse) code used elsewhere is the same as the\nabove with the following exceptions.\nmapping: C -.-.     L .-..     Q --.-     Y -.--\nmapping: F ..-.     O ---      R .-.      Z --..\nmapping: J .---     P .--.     X -..-\n\nThe Morse code is used chiefly with the electric telegraph, but is\nalso employed in signalling with flags, lights, etc."
     ],
-    "references": [
-      "MORSE CODE"
-    ]
+    "references": []
   },
   {
     "spellings": "MORSEL",
@@ -99467,9 +99291,7 @@
     "variants": [
       "MORSING HORN\nMor\"sing horn`.\n\nDefn: A horn or flask for holding powder, as for priming. [Scot.] Sir\nW. Scott."
     ],
-    "references": [
-      "MORSING HORN"
-    ]
+    "references": []
   },
   {
     "spellings": "MORSITATION",
@@ -102814,9 +102636,7 @@
     "variants": [
       "MOTHER'S DAY\nMoth\"er's Day.\n\nDefn: A day appointed for the honor and uplift of motherhood by the\nloving remembrance of each person of his mother through the\nperformance of some act of kindness, visit, tribute, or letter. The\nfounder of the day is Anna Jarvis, of Philadelphia, who designated\nthe second Sunday in May, or for schools the second Friday, as the\ntime, and a white carnation as the badge."
     ],
-    "references": [
-      "MOTHER'S DAY"
-    ]
+    "references": []
   },
   {
     "spellings": "MOTHERWORT",
@@ -103792,9 +103612,7 @@
     "variants": [
       "MOTION PICTURE\nMo\"tion pic\"ture.\n\nDefn: A moving picture."
     ],
-    "references": [
-      "MOTION PICTURE"
-    ]
+    "references": []
   },
   {
     "spellings": "MOTIVATE",
@@ -104188,7 +104006,6 @@
     "references": [
       "ARCHIBALD WHEEL",
       "AUTOMOBILE",
-      "MOTOR CAR; MOTORCAR",
       "MOTOR CYCLE; MOTORCYCLE",
       "MOTORING",
       "TROLLEY CAR"
@@ -104199,9 +104016,7 @@
     "variants": [
       "MOTOR CYCLE; MOTORCYCLE\nMotor cycle, or Mo\"tor*cy`cle, n.\n\nDefn: A bicycle having a motor attached so as to be self-propelled.\nIn Great Britain the term motor cycle is treated by statute (3 Ed\nVII. c. 36) as limited to motor cars (self-propelled vehicles)\ndesigned to travel on not more than three wheels, and weighing\nunladen (that is, without water, fuel, or accumulators necessary for\npropulsion) not more than three hundred weight (336 lbs.)."
     ],
-    "references": [
-      "MOTOR CYCLE; MOTORCYCLE"
-    ]
+    "references": []
   },
   {
     "spellings": "MOTOR-DRIVEN",
@@ -104217,9 +104032,7 @@
     "variants": [
       "MOTOR GENERATOR\nMotor generator.\n\nDefn: The combination consisting of a generator and a driving motor\nmechanically connected, usually on a common bedplate and with the two\nshafts directly coupled or combined into a single shaft."
     ],
-    "references": [
-      "MOTOR GENERATOR"
-    ]
+    "references": []
   },
   {
     "spellings": "MOTORING",
@@ -104999,8 +104812,7 @@
       "MOUNTAIN SPECTER\nMoun\"tain spec\"ter.\n\nDefn: An optical phenomenon sometimes seen on the summit of mountains\n(as on the Brocken) when the observer is between the sun and a mass\nof cloud. The figures of the observer and surrounding objects are\nseen projected on the cloud, greatly enlarged and often encircled by\nrainbow colors."
     ],
     "references": [
-      "BROCKEN SPECTER; BROCKEN SPECTRE",
-      "MOUNTAIN SPECTER"
+      "BROCKEN SPECTER; BROCKEN SPECTRE"
     ]
   },
   {
@@ -105008,9 +104820,7 @@
     "variants": [
       "MOUNTAIN STATE\nMoun\"tain State.\n\nDefn: Montana; -- a nickname."
     ],
-    "references": [
-      "MOUNTAIN STATE"
-    ]
+    "references": []
   },
   {
     "spellings": "MOUNTANCE",
@@ -105575,18 +105385,14 @@
     "variants": [
       "MOUSQUETAIRE CUFF\nMousquetaire cuff.\n\nDefn: A deep flaring cuff."
     ],
-    "references": [
-      "MOUSQUETAIRE CUFF"
-    ]
+    "references": []
   },
   {
     "spellings": "MOUSQUETAIRE GLOVE",
     "variants": [
       "MOUSQUETAIRE GLOVE\nMousquetaire glove.\n\nDefn: A woman's glove with a long, loosely fitting wrist."
     ],
-    "references": [
-      "MOUSQUETAIRE GLOVE"
-    ]
+    "references": []
   },
   {
     "spellings": "MOUSSE",
@@ -105615,9 +105421,7 @@
     "variants": [
       "MOUSSELINE DE SOIE\nMousse`line de soie\". [F.]\n\nDefn: A soft thin silk fabric with a weave like that of muslin."
     ],
-    "references": [
-      "MOUSSELINE DE SOIE"
-    ]
+    "references": []
   },
   {
     "spellings": "MOUSTACHE",
@@ -107715,7 +107519,6 @@
       "CINEMATOGRAPHER",
       "MOTION PICTURE",
       "MOVIE",
-      "MOVING PICTURE",
       "NICKELODEON",
       "PHOTOPLAY"
     ]
@@ -109456,7 +109259,6 @@
       "MUCK RAKE\nMuck rake.\n\nDefn: A rake for scraping up muck or dung. See Muckrake, v. i.,\nbelow."
     ],
     "references": [
-      "MUCK RAKE",
       "MUCK-RAKE; MUCKRAKE; MUCKRAKER"
     ]
   },
@@ -110496,9 +110298,7 @@
     "variants": [
       "MULE KILLER\nMule killer.\n\nDefn: Any of several arthropods erroneously supposed to kill live\nstock, in the southern United States, by stinging or by being\nswallowed; as:\n (a) A whip scorpion. [Florida]\n (b) A walking-stick insect. [Texas]\n (c) A mantis.\n (d) A wheel bug."
     ],
-    "references": [
-      "MULE KILLER"
-    ]
+    "references": []
   },
   {
     "spellings": "MULETEER",
@@ -111901,9 +111701,7 @@
     "variants": [
       "MUMBO JUMBO\nMum\"bo Jum`bo.\n\nDefn: An object of superstitious homage and fear. Carlyle.\nThe miserable Mumbo Jumbo they paraded. Dickens."
     ],
-    "references": [
-      "MUMBO JUMBO"
-    ]
+    "references": []
   },
   {
     "spellings": "MUM-CHANCE",
@@ -112498,7 +112296,6 @@
     ],
     "references": [
       "METAL",
-      "MUNTZ METAL",
       "YELLOW"
     ]
   },
@@ -113706,9 +113503,7 @@
     "variants": [
       "MUSCLE READING\nMus\"cle read`ing.\n\nDefn: The art of making discriminations between objects of choice, of\ndiscovering the whereabouts of hidden objects, etc., by inference\nfrom the involuntary movements of one whose hand the reader holds or\nwith whom he is otherwise in muscular contact."
     ],
-    "references": [
-      "MUSCLE READING"
-    ]
+    "references": []
   },
   {
     "spellings": "MUSCLING",
@@ -113784,7 +113579,6 @@
       "MUSCOVY DUCK\nMus\"co*vy duck`. Etym: [A corruption of musk duck.] (Zoöl.)\n\nDefn: A duck (Cairina moschata), larger than the common duck, often\nraised in poultry yards. Called also musk duck. It is native of\ntropical America, from Mexico to Southern Brazil."
     ],
     "references": [
-      "MUSCOVY DUCK",
       "MUSK"
     ]
   },
@@ -113794,8 +113588,7 @@
       "MUSCOVY GLASS\nMus\"co*vy glass`. Etym: [From Muscovy, the old name of Russia: cf. F.\nverre de Moscovie.]\n\nDefn: Mica; muscovite. See Mica."
     ],
     "references": [
-      "MUSCOVITE",
-      "MUSCOVY GLASS"
+      "MUSCOVITE"
     ]
   },
   {
@@ -114877,8 +114670,7 @@
       "MUSIC DRAMA\nMu\"sic dra`ma.\n\nDefn: An opera in which the text and action are not interrupted by\nset arias, duets, etc., the music being determined throughout by\ndramatic appropriateness; musical drama of this character, in\ngeneral. It involves the use of a kind of melodious declamation, the\ndevelopment of leitmotif, great orchestral elaboration, and a fusion\nof poetry, music, action, and scene into an organic whole. The term\nis applied esp. to the later works of Wagner: \"Tristan und Isolde,\"\n\"Die Meistersinger,\" \"Rheingold,\" \"Walküre,\" \"Siegfried,\"\n\"Götterdämmerung,\" and \"Parsifal.\""
     ],
     "references": [
-      "LEADING",
-      "MUSIC DRAMA"
+      "LEADING"
     ]
   },
   {
@@ -114890,7 +114682,6 @@
       "DIVE",
       "MELODEON",
       "MUSIC",
-      "MUSIC HALL",
       "PARQUET",
       "SALOON"
     ]
@@ -118901,7 +118692,6 @@
       "MYALL WOOD\nMy*all\" wood`. (Bot.)\n\nDefn: A durable, fragrant, and dark-colored Australian wood, used by\nthe natives for spears. It is obtained from the small tree Acacia\nhomolophylla."
     ],
     "references": [
-      "MYALL WOOD",
       "VIOLET"
     ]
   },

--- a/output/wordDisplayData#N-O.json
+++ b/output/wordDisplayData#N-O.json
@@ -8610,9 +8610,7 @@
     "variants": [
       "NAPHA WATER\nNa\"pha wa`ter. Etym: [Sp. nafa, from Ar. napha odor.]\n\nDefn: A perfume distilled from orange flowers."
     ],
-    "references": [
-      "NAPHA WATER"
-    ]
+    "references": []
   },
   {
     "spellings": "NAPHEW",
@@ -8803,7 +8801,6 @@
       "NAPIER'S BONES; NAPIER'S RODS\nNa\"pi*er's bones`, Na\"pi*er's rods`.\n\nDefn: A set of rods, made of bone or other material, each divided\ninto nine spaces, and containing the numbers of a column of the\nmultiplication table; -- a contrivance of Baron Napier, the inventor\nof logarithms, for facilitating the operations of multiplication and\ndivision."
     ],
     "references": [
-      "NAPIER'S BONES; NAPIER'S RODS",
       "RABDOLOGY"
     ]
   },
@@ -8850,7 +8847,6 @@
       "NAPLES YELLOW\nNa\"ples yel\"low.\n\nDefn: See under Yellow."
     ],
     "references": [
-      "NAPLES YELLOW",
       "YELLOW"
     ]
   },
@@ -10437,9 +10433,7 @@
     "variants": [
       "NATAL BOIL\nNa*tal\" boil. (Med.)\n\nDefn: = Aleppo boil."
     ],
-    "references": [
-      "NATAL BOIL"
-    ]
+    "references": []
   },
   {
     "spellings": "NATALITIAL; NATALITIOUS",
@@ -10460,9 +10454,7 @@
     "variants": [
       "NATAL PLUM\nNa*tal\" plum`. (Bot.)\n\nDefn: The drupaceous fruit of two South African shrubs of the genus\nArduina (A. bispinosa and A. grandiflora)."
     ],
-    "references": [
-      "NATAL PLUM"
-    ]
+    "references": []
   },
   {
     "spellings": "NATALS",
@@ -11960,9 +11952,7 @@
     "variants": [
       "NATIVE STEEL\nNa\"tive steel.\n\nDefn: A sort of steel which has been found where a burning coal seam\nhad reduced and carbonized adjacent iron ore."
     ],
-    "references": [
-      "NATIVE STEEL"
-    ]
+    "references": []
   },
   {
     "spellings": "NATIVISM",
@@ -13040,9 +13030,7 @@
     "variants": [
       "NATURAL STEEL\nNat\"u*ral steel.\n\nDefn: Steel made by the direct refining of cast iron in a finery, or,\nas wootz, by a direct process from the ore."
     ],
-    "references": [
-      "NATURAL STEEL"
-    ]
+    "references": []
   },
   {
     "spellings": "NATURE",
@@ -14471,9 +14459,7 @@
     "variants": [
       "NAUHEIM TREATMENT; NAUHEIM BATH\nNau\"heim treat`ment. (Med.)\n\nDefn: Orig., a method of therapeutic treatment administered, esp. for\nchronic diseases of the curculatory system, at Bad Nauheim, Germany,\nby G. Schott, consisting in baths in the natural mineral waters of\nthat place, which are charged with carbonic acid, and the use of a\ngraduated course of rest, physical exercises, massage, etc.; hence,\nany similar treatment using waters artificially charged with the\nessential ingredients of the natural mineral waters of Bad Nauheim.\nHence, Nauheim bath, etc."
     ],
-    "references": [
-      "NAUHEIM TREATMENT; NAUHEIM BATH"
-    ]
+    "references": []
   },
   {
     "spellings": "NAUMACHY",
@@ -14918,7 +14904,6 @@
       "NAVEL ORANGE\nNa\"vel or\"ange.\n\nDefn: A type of orange in which the fruit incloses a small secondary\nfruit, the rind showing on the exterior a navel-like pit or\ndepression at the apex. There are several varieties; they are usually\nseedless, or nearly so, and are much grown in California."
     ],
     "references": [
-      "NAVEL ORANGE",
       "ORANGE"
     ]
   },
@@ -15182,9 +15167,7 @@
     "variants": [
       "NAVY BLUE\nNa\"vy blue`.\n\nDefn: Prussian blue."
     ],
-    "references": [
-      "NAVY BLUE"
-    ]
+    "references": []
   },
   {
     "spellings": "NAWAB",
@@ -15583,7 +15566,6 @@
       "NEANDERTHAL; NEANDERTHAL RACE; NEANDERTHAL MAN\nNe*an\"der*thal`, a. (Anthropol.)\n\nDefn: Of, pertaining to, or named from, the Neanderthal, a valley in\nthe Rhine Province, in which were found parts of a skeleton of an\nearly type of man. The skull is characterized by extreme\ndolichocephaly, flat, retreating forehead, with closed frontal\nsutures, and enormous superciliary ridges. The cranial capacity is\nestimated at about 1,220 cubic centimeters, being about midway\nbetween that of the Pithecanthropus and modern man. Hence,\ndesignating the Neanderthal race, or man, a species supposed to have\nbeen widespread in paleolithic Europe."
     ],
     "references": [
-      "NEANDERTHAL; NEANDERTHAL RACE; NEANDERTHAL MAN",
       "NEANDERTHALOID",
       "PITHECANTHROPUS"
     ]
@@ -15633,9 +15615,7 @@
     "variants": [
       "NEAPOLITAN ICE; NEAPOLITAN ICE CREAM\nNe`a*pol\"i*tan ice, Neapolitan ice cream.\n (a) An ice or ice cream containing eggs as well as cream.\n (b) An ice or ice cream prepared in layers, as vanilla, strawberry,\nand chocolate ice cream, and orange or lemon water ice."
     ],
-    "references": [
-      "NEAPOLITAN ICE; NEAPOLITAN ICE CREAM"
-    ]
+    "references": []
   },
   {
     "spellings": "NEAR",
@@ -16262,9 +16242,7 @@
     "variants": [
       "NEAR BEER\nNear beer.\n\nDefn: Any of various malt liquors (see Citation).\n\nNear beer is a term of common currency used to designate all that\nclass of malt liquors which contain so little alcohol that they will\nnot produce intoxication, though drunk to excess, and includes in its\nmeaning all malt liquors which are not within the purview of the\ngeneral prohibition law.\nCambell v. City of Thomasville, Georgia Appeal Records, 6 212."
     ],
-    "references": [
-      "NEAR BEER"
-    ]
+    "references": []
   },
   {
     "spellings": "NEARCTIC",
@@ -18095,7 +18073,6 @@
       "NECKAR NUT\nNeck\"ar nut`. (Bot.)\n\nDefn: See Nicker nut."
     ],
     "references": [
-      "NECKAR NUT",
       "NICKER NUT"
     ]
   },
@@ -19264,9 +19241,7 @@
     "variants": [
       "NEEM TREE\nNeem\" tree`. Etym: [Hind. nim.] (Bot.)\n\nDefn: An Asiatic name for Melia Azadirachta, and M. Azedarach. See\nMargosa."
     ],
-    "references": [
-      "NEEM TREE"
-    ]
+    "references": []
   },
   {
     "spellings": "NEER",
@@ -19348,9 +19323,7 @@
     "variants": [
       "NE EXEAT\nNe` ex\"e*at. Etym: [L. ne exeat regno let him not go out of the\nkingdom.] (Law)\n\nDefn: A writ to restrain a person from leaving the country, or the\njurisdiction of the court. The writ was originally applicable to\npurposes of state, but is now an ordinary process of courts of\nequity, resorted to for the purpose of obtaining bail, or security to\nabide a decree. Kent."
     ],
-    "references": [
-      "NE EXEAT"
-    ]
+    "references": []
   },
   {
     "spellings": "NEF",
@@ -21037,9 +21010,7 @@
     "variants": [
       "NEOCLASSIC ARCHITECTURE\nNeoclassic architecture.\n\nDefn: All that architecture which, since the beginning of the Italian\nRenaissance, about 1420, has been designed with deliberate imitation\nof Greco-Roman buildings."
     ],
-    "references": [
-      "NEOCLASSIC ARCHITECTURE"
-    ]
+    "references": []
   },
   {
     "spellings": "NEOCOMIAN",
@@ -21796,9 +21767,7 @@
     "variants": [
       "NE PLUS ULTRA\nNe plus ul\"tra. [L., no further; ne no, not + plus more + ultra\nbeyond.]\n\n1. The uttermost point to which one can go or attain; hence, the\nsummit of achievement; the highest point or degree; the acme.\n\n2.  A prohibition against proceeding further; an insuperable obstacle\nor limiting condition. [Obs. or R.]"
     ],
-    "references": [
-      "NE PLUS ULTRA"
-    ]
+    "references": []
   },
   {
     "spellings": "NEPOTAL",
@@ -22861,9 +22830,7 @@
     "variants": [
       "NE TEMERE\nNe Te\"me*re. [So named from L. ne not + temere rashly, the first two\nwords in the decree.] (R. C. Ch.)\n\nDefn: A decree of the Congregation of the Council declaring invalid\n[so far as the laws of the Roman Catholic Church are concerned] any\nmarriage of a Roman Catholic, or of a person who has ever been a\nRoman Catholic, if not contracted before a duty qualified priest (or\nthe bishop of the diocese) and at least two witnesses. The decree was\nissued Aug. 2, 1907, and took effect on Easter Apr. 19, 1908. The\ndecree by its terms does not affect mixed marriages (those between\nRoman Catholics and persons of another faith) in Germany."
     ],
-    "references": [
-      "NE TEMERE"
-    ]
+    "references": []
   },
   {
     "spellings": "NETFISH",
@@ -25833,7 +25800,6 @@
       "HEAVEN",
       "HIGHER THOUGHT",
       "HOPE",
-      "NEW THOUGHT",
       "ORIGINAL"
     ]
   },
@@ -25862,8 +25828,7 @@
       "NEW YEAR'S DAY\nNew\" Year's` Day\".\n\nDefn: the first day of a calendar year; the first day of January.\nOften colloquially abbreviated to New year's or new year."
     ],
     "references": [
-      "HOLIDAY",
-      "NEW YEAR'S DAY"
+      "HOLIDAY"
     ]
   },
   {
@@ -25900,7 +25865,6 @@
       "LING",
       "MAORI",
       "MOA",
-      "NEW ZEALAND",
       "NOTORNIS",
       "OAK",
       "PAH",
@@ -26344,9 +26308,7 @@
     "variants": [
       "NEZ PERCES\nNez\" Per`cés\", pl.; sing. Nez PercÉ (. Etym: [F., pierced noses.]\n(Ethnol.)\n\nDefn: A tribe of Indians, mostly inhabiting Idaho."
     ],
-    "references": [
-      "NEZ PERCES"
-    ]
+    "references": []
   },
   {
     "spellings": "NGINA",
@@ -26361,8 +26323,7 @@
       "NIAGARA PERIOD\nNi*ag\"a*ra pe\"ri*od. (Geol.)\n\nDefn: A subdivision or the American Upper Silurian system, embracing\nthe Medina, Clinton, and Niagara epoch. The rocks of the Niagara\nepoch, mostly limestones, are extensively distributed, and at Niagara\nFalls consist of about eighty feet of shale supporting a greater\nthickness of limestone, which is gradually undermined by the removal\nof the shale. See Chart of Geology."
     ],
     "references": [
-      "MEDINA EPOCH",
-      "NIAGARA PERIOD"
+      "MEDINA EPOCH"
     ]
   },
   {
@@ -26469,9 +26430,7 @@
     "variants": [
       "NICARAGUA WOOD\nNic`a*ra\"gua wood`.\n\nDefn: Brazil wood."
     ],
-    "references": [
-      "NICARAGUA WOOD"
-    ]
+    "references": []
   },
   {
     "spellings": "NICCOLITE",
@@ -26777,7 +26736,6 @@
       "NICKAR NUT; NICKAR TREE\nNick\"ar nut`, Nick\"ar tree`. (Bot.)\n\nDefn: Same as Nicker nut, Nicker tree."
     ],
     "references": [
-      "NICKAR NUT; NICKAR TREE",
       "NICKER NUT",
       "NICKER TREE"
     ]
@@ -26876,9 +26834,7 @@
     "variants": [
       "NICKEL STEEL\nNickel steel.\n\nDefn: A kind of cast steel containing nickel, which greatly increases\nits strength. It is used for armor plate, bicycle tubing, propeller\nshafts, etc."
     ],
-    "references": [
-      "NICKEL STEEL"
-    ]
+    "references": []
   },
   {
     "spellings": "NICKER",
@@ -26902,7 +26858,6 @@
     "references": [
       "NECKAR NUT",
       "NICKAR NUT; NICKAR TREE",
-      "NICKER NUT",
       "NICKER TREE"
     ]
   },
@@ -26913,8 +26868,7 @@
     ],
     "references": [
       "BONDUC",
-      "NICKAR NUT; NICKAR TREE",
-      "NICKER TREE"
+      "NICKAR NUT; NICKAR TREE"
     ]
   },
   {
@@ -27351,9 +27305,7 @@
     "variants": [
       "NIEPCE'S PROCESS\nNiep\"ce's proc\"ess. (Photog.)\n\nDefn: A process, now no longer used, invented by J. N. Niepce, a\nFrench chemist, in 1829. It depends upon the action of light in\nrendering a thin layer of bitumen, with which the plate is coated,\ninsoluble."
     ],
-    "references": [
-      "NIEPCE'S PROCESS"
-    ]
+    "references": []
   },
   {
     "spellings": "NIFLE",
@@ -28170,9 +28122,7 @@
     "variants": [
       "NIGHT LETTER; NIGHT LETTERGRAM\nNight letter, Night lettergram.\n\nDefn: See Letter, above."
     ],
-    "references": [
-      "NIGHT LETTER; NIGHT LETTERGRAM"
-    ]
+    "references": []
   },
   {
     "spellings": "NIGHTLONG",
@@ -28284,9 +28234,7 @@
     "variants": [
       "NIGHT TERRORS\nNight terrors. (Med.)\n\nDefn: A sudden awkening associated with a sensation of terror,\noccurring in children, esp. those of unstable nervous constitution."
     ],
-    "references": [
-      "NIGHT TERRORS"
-    ]
+    "references": []
   },
   {
     "spellings": "NIGHTTIME",
@@ -30307,9 +30255,7 @@
     "variants": [
       "NIXIE CLERK\nNixie clerk.\n\nDefn: A post-office clerk in charge of the nixies."
     ],
-    "references": [
-      "NIXIE CLERK"
-    ]
+    "references": []
   },
   {
     "spellings": "NIZAM",
@@ -32665,18 +32611,14 @@
     "variants": [
       "NOBEL PRIZES\nNo*bel\" prizes.\n\nDefn: Prizes for the encouragement of men and women who work for the\ninterests of humanity, established by the will of A. B. Nobel (1833-\n96), the Swedish inventor of dynamite, who left his entire estate for\nthis purpose. They are awarded yearly for what is regarded as the\nmost important work during the year in physics, chemistry, medicine\nor physiology, idealistic literature, and service in the interest of\npeace. The prizes, averaging $40,000 each, were first awarded in\n1901."
     ],
-    "references": [
-      "NOBEL PRIZES"
-    ]
+    "references": []
   },
   {
     "spellings": "NOBERT'S LINES",
     "variants": [
       "NOBERT'S LINES\nNo\"bert's lines. [After F. A. Nobert, German manufacturer in\nPomerania.]\n\nDefn: Fine lines ruled on glass in a series of groups of different\ncloseness of line, and used to test the power of a microscope."
     ],
-    "references": [
-      "NOBERT'S LINES"
-    ]
+    "references": []
   },
   {
     "spellings": "NOBILIARY",
@@ -32698,9 +32640,7 @@
     "variants": [
       "NOBILI'S RINGS\nNo\"bi*li's rings. [After Leopoldo Nobili, an Italian physicist who\nfirst described them in 1826.] (Physics)\n\nDefn: Colored rings formed upon a metal plate by the electrolytic\ndisposition of copper, lead peroxide, etc. They may be produced by\ntouching with a pointed zinc rod a silver plate on which is a\nsolution of copper sulphate."
     ],
-    "references": [
-      "NOBILI'S RINGS"
-    ]
+    "references": []
   },
   {
     "spellings": "NOBILITATE",
@@ -34437,7 +34377,6 @@
       "NOLLE PROSEQUI\nNol\"le pros\"e*qui. Etym: [L., to be unwilling to prosecute.] (Law)\n\nDefn: Will not prosecute; -- an entry on the record, denoting that a\nplaintiff discontinues his suit, or the attorney for the public a\nprosecution; either wholly, or as to some count, or as to some of\nseveral defendants."
     ],
     "references": [
-      "NOLLE PROSEQUI",
       "NOL. PROS.; NOL PROS",
       "NOL-PROS",
       "NON PROSEQUITUR"
@@ -34448,18 +34387,14 @@
     "variants": [
       "NOLO CONTENDERE\nNo\"lo con*ten\"de*re. Etym: [L., I do not wish to contend.] (Law)\n\nDefn: A plea, by the defendant, in a criminal prosecution, which,\nwithout admitting guilt, subjects him to all the consequences of a\nplea of quilty."
     ],
-    "references": [
-      "NOLO CONTENDERE"
-    ]
+    "references": []
   },
   {
     "spellings": "NOL. PROS.; NOL PROS",
     "variants": [
       "NOL. PROS.; NOL PROS\nNol. pros.\n\nDefn: An abbrev. of Nolle prosequi."
     ],
-    "references": [
-      "NOL. PROS.; NOL PROS"
-    ]
+    "references": []
   },
   {
     "spellings": "NOL-PROS",
@@ -34626,9 +34561,7 @@
     "variants": [
       "NO-MAN'S LAND\nNo\"-man's` land`.\n\n1. (Naut.)\n\nDefn: A space amidships used to keep blocks, ropes, etc.; a space on\na ship belonging to no one in particular to care for.\n\n2. Fig.: An unclaimed space or time.\nThat no-man's land of twilight. W. Black."
     ],
-    "references": [
-      "NO-MAN'S LAND"
-    ]
+    "references": []
   },
   {
     "spellings": "NOMARCH",
@@ -35392,9 +35325,7 @@
     "variants": [
       "NON ASSUMPSIT\nNon` as*sump\"sit. Etym: [L., he did not undertake.] (Law)\n\nDefn: The general plea or denial in an action of assumpsit."
     ],
-    "references": [
-      "NON ASSUMPSIT"
-    ]
+    "references": []
   },
   {
     "spellings": "NONATTENDANCE",
@@ -35559,8 +35490,7 @@
       "NON COMPOS; NON COMPOS MENTIS\nNon com\"pos. Non com\"pos men\"tis.Etym: [L.]\n\nDefn: Not of sound mind; not having the regular use of reason; hence,\nalso, as a noun, an idiot; a lunati"
     ],
     "references": [
-      "NINCOMPOOP",
-      "NON COMPOS; NON COMPOS MENTIS"
+      "NINCOMPOOP"
     ]
   },
   {
@@ -36059,18 +35989,14 @@
     "variants": [
       "NON EST FACTUM\nNon` est` fac\"tum. Etym: [Law L. it is not (his) deed.] (Law)\n\nDefn: The plea of the general issue in an action of debt on bond."
     ],
-    "references": [
-      "NON EST FACTUM"
-    ]
+    "references": []
   },
   {
     "spellings": "NON EST INVENTUS",
     "variants": [
       "NON EST INVENTUS\nNon` est` in*ven\"tus. Etym: [L., he is not found.] (Law)\n\nDefn: The return of a sheriff on a writ, when the defendant is not\nfound in his county. Bouvier."
     ],
-    "references": [
-      "NON EST INVENTUS"
-    ]
+    "references": []
   },
   {
     "spellings": "NONESUCH",
@@ -36260,9 +36186,7 @@
     "variants": [
       "NON LIQUET\nNon` li\"quet. Etym: [L.]\n\nDefn: It is not clear; -- a verdict given by a jury when a matter is\nto be deferred to another day of trial."
     ],
-    "references": [
-      "NON LIQUET"
-    ]
+    "references": []
   },
   {
     "spellings": "NONMALIGNANT",
@@ -36418,7 +36342,6 @@
       "NON OBSTANTE\nNon` ob*stan\"te. Etym: [L.]\n\n1. Notwithstanding; in opposition to, or in spite of, what has been\nstated, or is to be stated or admitted.\n\n2. (Law)\n\nDefn: A clause in old English statutes and letters patent, importing\na license from the crown to do a thing notwithstanding any statute to\nthe contrary. This dispensing power was abolished by the Bill of\nRights.\nIn this very reign [Henry III.] the practice of dispensing with\nstatutes by a non obstante was introduced. Hallam.\nNon obstante veredicto Etym: [LL.] (Law), a judgment sometimes\nentered by order of the court, for the plaintiff, notwithstanding a\nverdict for the defendant. Stephen."
     ],
     "references": [
-      "NON OBSTANTE",
       "NOTWITHSTANDING"
     ]
   },
@@ -36578,9 +36501,7 @@
     "variants": [
       "NON PROS.\nNon\" pros.` (.\n\nDefn: An abbreviation of Non prosequitur."
     ],
-    "references": [
-      "NON PROS."
-    ]
+    "references": []
   },
   {
     "spellings": "NON-PROS",
@@ -36595,8 +36516,7 @@
       "NON PROSEQUITUR\nNon\" pro*seq\"ui*tur. Etym: [L. he does not prosecute.] (Law)\n\nDefn: A judgment entered against the plaintiff in a suit where he\ndoes not appear to prosecute. See Nolle prosequi."
     ],
     "references": [
-      "NON PROS.",
-      "NON PROSEQUITUR"
+      "NON PROS."
     ]
   },
   {
@@ -36785,9 +36705,7 @@
     "variants": [
       "NON SEQUITUR\nNon seq\"ui*tur. Etym: [L., it does not follow.] (Logic)\n\nDefn: An inference which does not follow from the premises."
     ],
-    "references": [
-      "NON SEQUITUR"
-    ]
+    "references": []
   },
   {
     "spellings": "NONSEXUAL",
@@ -37822,9 +37740,7 @@
     "variants": [
       "NORFOLK DUMPLING\nNorfolk dumpling. (Eng.)\n (a) A kind of boiled dumpling made in Norfolk.\n (b) A native or inhabitant of Norfolk."
     ],
-    "references": [
-      "NORFOLK DUMPLING"
-    ]
+    "references": []
   },
   {
     "spellings": "NORFOLK JACKET",
@@ -37832,8 +37748,7 @@
       "NORFOLK JACKET\nNorfolk jacket.\n\nDefn: A kind of loose-fitting plaited jacket, having a loose belt."
     ],
     "references": [
-      "NORFOLK",
-      "NORFOLK JACKET"
+      "NORFOLK"
     ]
   },
   {
@@ -37841,18 +37756,14 @@
     "variants": [
       "NORFOLK PLOVER\nNorfolk plover.\n\nDefn: The stone curlew."
     ],
-    "references": [
-      "NORFOLK PLOVER"
-    ]
+    "references": []
   },
   {
     "spellings": "NORFOLK SPANIEL",
     "variants": [
       "NORFOLK SPANIEL\nNorfolk spaniel.\n\nDefn: One of a breed of field spaniels similar to the clumbers, but\nshorter in body and of a liver-and-white or black-and-white color."
     ],
-    "references": [
-      "NORFOLK SPANIEL"
-    ]
+    "references": []
   },
   {
     "spellings": "NORIA",
@@ -39327,9 +39238,7 @@
     "variants": [
       "NORTH STAR STATE\nNorth Star State.\n\nDefn: Minnesota; -- a nickname."
     ],
-    "references": [
-      "NORTH STAR STATE"
-    ]
+    "references": []
   },
   {
     "spellings": "NORTHUMBRIAN",
@@ -49141,8 +49050,7 @@
     ],
     "references": [
       "COMMERCIAL",
-      "LETTER",
-      "NOTE PAPER"
+      "LETTER"
     ]
   },
   {
@@ -50779,9 +50687,7 @@
     "variants": [
       "NOUVEAU RICHE; NOUVELLE RICHE\nNou`veau\" riche\", m., Nou`velle\" riche\", f.; pl. m. Noveaux riches\n(#), f. Nouvelles riches (#). [F.]\n\nDefn: A person newly rich."
     ],
-    "references": [
-      "NOUVEAU RICHE; NOUVELLE RICHE"
-    ]
+    "references": []
   },
   {
     "spellings": "NOVA",
@@ -53467,8 +53373,7 @@
       "NUDUM PACTUM\nNu\"dum pac\"tum. Etym: [L., a nude pact.] (Law)\n\nDefn: A bare, naked contract, without any consideration. Tomlins."
     ],
     "references": [
-      "NUDE",
-      "NUDUM PACTUM"
+      "NUDE"
     ]
   },
   {
@@ -55914,9 +55819,7 @@
     "variants": [
       "NUNC DIMITTIS\nNunc\" di*mit\"tis. [L. nunc now + dimittis thou lettest depart.]\n(Eccl.)\n\nDefn: The song of Simeon (Luke ii. 29-32), used in the ritual of many\nchurches. It begins with these words in the Vulgate."
     ],
-    "references": [
-      "NUNC DIMITTIS"
-    ]
+    "references": []
   },
   {
     "spellings": "NUNCHION",
@@ -56875,7 +56778,6 @@
       "BRUCINE",
       "IGASURIC",
       "IGASURINE",
-      "NUX VOMICA",
       "POISON",
       "QUAKER",
       "STRYCHNINE",
@@ -62904,9 +62806,7 @@
     "variants": [
       "OBSERVATION CAR\nOb`ser*va\"tion car.\n\nDefn: A railway passenger car made so as to facilitate seeing the\nscenery en route; a car open, or with glass sides, or with a kind of\nopen balcony at the rear."
     ],
-    "references": [
-      "OBSERVATION CAR"
-    ]
+    "references": []
   },
   {
     "spellings": "OBSERVATIVE",
@@ -67477,7 +67377,6 @@
       "ODD FELLOW\nOdd\" Fel`low.\n\nDefn: A member of a secret order, or fraternity, styled the\nIndependent Order of Odd Fellows, established for mutual aid and\nsocial enjoyment."
     ],
     "references": [
-      "ODD FELLOW",
       "REGALIA"
     ]
   },
@@ -77506,9 +77405,7 @@
     "variants": [
       "OFFICE WIRE\nOf\"fice wire`. (Elec.)\n\nDefn: Copper wire with a strong but light insulation, used in wiring\nhouses, etc."
     ],
-    "references": [
-      "OFFICE WIRE"
-    ]
+    "references": []
   },
   {
     "spellings": "OFFICIAL",
@@ -80249,7 +80146,6 @@
       "OGEECHEE LIME\nO*gee\"chee lime`. Etym: [So named from the Ogeechee River in\nGeorgia.] (Bot.)\n(a) The acid, olive-shaped, drupaceous fruit of a species of tupelo\n(Nyssa capitata) which grows in swamps in Georgia and Florida.\n(b) The tree which bears this fruit."
     ],
     "references": [
-      "OGEECHEE LIME",
       "PLUM",
       "TUPELO",
       "WATER TUPELO"
@@ -82575,9 +82471,7 @@
     "variants": [
       "OLD DOMINION\nOld Dominion.\n\nDefn: Virginia; -- a name of uncertain origin, perh. from the old\ndesignation of the colony as \"the Colony and Dominion of Virginia.\""
     ],
-    "references": [
-      "OLD DOMINION"
-    ]
+    "references": []
   },
   {
     "spellings": "OLDEN",
@@ -82639,18 +82533,14 @@
     "variants": [
       "OLD LANG SYNE\nOld` lang syne\".\n\nDefn: See Auld lang syne."
     ],
-    "references": [
-      "OLD LANG SYNE"
-    ]
+    "references": []
   },
   {
     "spellings": "OLD LINE STATE",
     "variants": [
       "OLD LINE STATE\nOld Line State.\n\nDefn: Maryland; a nickname, alluding to the fact that its northern\nboundary in Mason and Dixon's line."
     ],
-    "references": [
-      "OLD LINE STATE"
-    ]
+    "references": []
   },
   {
     "spellings": "OLD-MAIDISH",
@@ -82916,9 +82806,7 @@
     "variants": [
       "OLEO OIL\nO`le*o oil.\n\nDefn: An oil expressed from certain animal fats (esp. beef suet), the\ngreater portion of the solid fat, or stearin, being left behind. It\nis mixture of olein, palmitin, and a little stearin."
     ],
-    "references": [
-      "OLEO OIL"
-    ]
+    "references": []
   },
   {
     "spellings": "OLEOPTENE",
@@ -83525,7 +83413,6 @@
     "references": [
       "DECATHLON",
       "OLYMPIAD",
-      "OLYMPIC GAMES; OLYMPIAN GAMES",
       "OLYMPIONIC"
     ]
   },
@@ -83625,9 +83512,7 @@
     "variants": [
       "OMANDER WOOD\nO*man\"der wood`. Etym: [Etymol. uncertain.] (Bot.)\n\nDefn: The wood of Diospyros ebenaster, a kind of ebony found in\nCeylon."
     ],
-    "references": [
-      "OMANDER WOOD"
-    ]
+    "references": []
   },
   {
     "spellings": "OMASUM",
@@ -89985,7 +89870,6 @@
       "ON DIT\nOn` dit\". Etym: [F.]\n\nDefn: They say, or it is said.\n -- n.\n\nDefn: A flying report; rumor; as, it is a mere on dit."
     ],
     "references": [
-      "ON DIT",
       "THEY"
     ]
   },
@@ -97536,9 +97420,7 @@
     "variants": [
       "OOZE LEATHER\nOoze leather.\n\nDefn: Leather made from sheep and calf skins by mechanically forcing\nooze through them; esp., such leather with a soft, finely granulated\nfinish (called sometimes velvet finish) put on the flesh side for\nspecial purposes. Ordinary ooze leather is used for shoe uppers, in\nbookbinding, etc. Hence Ooze calf, Ooze finish, etc."
     ],
-    "references": [
-      "OOZE LEATHER"
-    ]
+    "references": []
   },
   {
     "spellings": "OOZOA; OOEZOA",
@@ -98525,7 +98407,6 @@
     "references": [
       "JIMMY",
       "OPEN",
-      "OPEN DOOR",
       "STARVEDLY"
     ]
   },
@@ -98582,7 +98463,6 @@
     "references": [
       "BASIC PROCESS",
       "OPEN",
-      "OPEN-HEARTH STEEL",
       "SIEMENS-MARTIN STEEL"
     ]
   },
@@ -99061,7 +98941,6 @@
       "HIGH",
       "MARE CLAUSUM",
       "OPEN",
-      "OPEN SEA",
       "PIRACY",
       "POLYNIA",
       "QUARREL",
@@ -99075,9 +98954,7 @@
     "variants": [
       "OPEN VERDICT\nOpen verdict. (Law)\n\nDefn: A verdict on a preliminary investigation, finding the fact of a\ncrime but not stating the criminal, or finding the fact of a violent\ndeath without disclosing the cause."
     ],
-    "references": [
-      "OPEN VERDICT"
-    ]
+    "references": []
   },
   {
     "spellings": "OPENWORK",
@@ -100975,9 +100852,7 @@
     "variants": [
       "OPLE TREE\nO\"ple tree`. Etym: [L. opulus a kind of maple tree.]\n\nDefn: The witch-hazel. [Obs.] Ainsworth."
     ],
-    "references": [
-      "OPLE TREE"
-    ]
+    "references": []
   },
   {
     "spellings": "OPOBALSAM; OPOBALSAMUM",
@@ -109217,9 +109092,7 @@
     "variants": [
       "ORCHILLA WEED\nOr*chil\"la weed`. (Bot.)\n\nDefn: The lichen from which archil is obtained. See Archil."
     ],
-    "references": [
-      "ORCHILLA WEED"
-    ]
+    "references": []
   },
   {
     "spellings": "ORCHIS",
@@ -112164,8 +112037,7 @@
       "OREGON GRAPE\nOr\"e*gon grape`. (Bot.)\n\nDefn: An evergreen species of barberry (Berberis Aquifolium), of\nOregon and California; also, its roundish, blue-black berries."
     ],
     "references": [
-      "MAHONIA",
-      "OREGON GRAPE"
+      "MAHONIA"
     ]
   },
   {
@@ -118960,8 +118832,7 @@
     ],
     "references": [
       "BODOCK",
-      "BOIS D'ARC",
-      "OSAGE ORANGE"
+      "BOIS D'ARC"
     ]
   },
   {
@@ -119063,7 +118934,6 @@
       "OSCILLATING CURRENT\nOs\"cil*lat`ing current. (Elec.)\n\nDefn: A current alternating in direction."
     ],
     "references": [
-      "OSCILLATING CURRENT",
       "TESLA COIL; TESLA TRANSFORMER"
     ]
   },
@@ -120671,7 +120541,6 @@
       "OSWEGO TEA\nOs*we\"go tea\". (Bot.)\n\nDefn: An American aromatic herb (Monarda didyma), with showy, bright\nred, labiate flowers."
     ],
     "references": [
-      "OSWEGO TEA",
       "TEA"
     ]
   },
@@ -120695,7 +120564,6 @@
       "OTAHEITE APPLE\nO`ta*hei\"te ap\"ple. Etym: [So named from Otaheite, or Tahiti, one of\nthe Society Islands.] (Bot.)\n(a) The fruit of a Polynesian anacardiaceous tree (Spondias dulcis),\nalso called vi-apple. It is rather larger than an apple, and the rind\nhas a flavor of turpentine, but the flesh is said to taste like\npineapples.\n(b) A West Indian name for a myrtaceous tree (Jambosa Malaccensis)\nwhich bears crimson berries."
     ],
     "references": [
-      "OTAHEITE APPLE",
       "VI-APPLE"
     ]
   },
@@ -125437,8 +125305,7 @@
       "OTOBA FAT\nO*to\"ba fat`. (Chem.)\n\nDefn: A colorless buttery substance obtained from the fruit of\nMyristica otoba, a species of nutmeg tree."
     ],
     "references": [
-      "MYRISTIC",
-      "OTOBA FAT"
+      "MYRISTIC"
     ]
   },
   {
@@ -125588,9 +125455,7 @@
     "variants": [
       "OTTAVA RIMA\nOt*ta\"va ri\"ma. [It. See Octave, and Rhyme.] (Pros.)\n\nDefn: A stanza of eight lines of heroic verse, with three rhymes, the\nfirst six lines rhyming alternately and the last two forming a\ncouplet. It was used by Byron in \"Don Juan,\" by Keats in \"Isabella,\"\nby Shelley in \"The Witch of Atlas,\" etc."
     ],
-    "references": [
-      "OTTAVA RIMA"
-    ]
+    "references": []
   },
   {
     "spellings": "OTTAWAS",
@@ -125644,7 +125509,6 @@
     ],
     "references": [
       "FOUR-CYCLE",
-      "OTTO CYCLE",
       "OTTO ENGINE"
     ]
   },
@@ -125653,9 +125517,7 @@
     "variants": [
       "OTTO ENGINE\nOtto engine.\n\nDefn: An engine using the Otto cycle."
     ],
-    "references": [
-      "OTTO ENGINE"
-    ]
+    "references": []
   },
   {
     "spellings": "OTTOMAN",
@@ -137472,9 +137334,7 @@
     "variants": [
       "OVERHEAD CHARGES; OVERHEAD EXPENSES\nO\"ver*head\" charges, expenses, etc. (Accounting)\n\nDefn: Those general charges or expenses in any business which cannot\nbe charged up as belonging exclusively to any particular part of the\nwork or product, as where different kinds of goods are made, or where\nthere are different departments in a business; -- called also fixed,\nestablishment, or (in a manufacturing business) administration,\nselling, and distribution, charges, etc."
     ],
-    "references": [
-      "OVERHEAD CHARGES; OVERHEAD EXPENSES"
-    ]
+    "references": []
   },
   {
     "spellings": "OVERHEAR",
@@ -143700,9 +143560,7 @@
     "variants": [
       "OXYHYDROGEN LIGHT\nOxyhydrogen light.\n\nDefn: A light produced by the incandescence of some substances, esp.\nlime, in the oxyhydrogen flame. Coal gas (producing the oxygas\nlight), or the vapor of ether (oxyether light) or methylated spirit\n(oxyspirit light), may be substituted for hydrogen."
     ],
-    "references": [
-      "OXYHYDROGEN LIGHT"
-    ]
+    "references": []
   },
   {
     "spellings": "OXYMEL",
@@ -144050,9 +143908,7 @@
     "variants": [
       "OZONE PAPER\nO\"zone pa\"per. (Chem.)\n\nDefn: Paper coated with starch and potassium iodine. It turns blue\nwhen exposed to ozone.>-- also called starch-iodide paper -->"
     ],
-    "references": [
-      "OZONE PAPER"
-    ]
+    "references": []
   },
   {
     "spellings": "OZONIC",

--- a/output/wordDisplayData#P.json
+++ b/output/wordDisplayData#P.json
@@ -5612,9 +5612,7 @@
     "variants": [
       "PACHUCA TANK\nPa*chu\"ca tank. (Metallurgy)\n\nDefn: A high and narrow tank, with a central cylinder for the\nintroduction of compressed air, used in the agitation and settling of\npulp (pulverized ore and water) during treatment by the cyanide\nprocess; -- so named because, though originally devised in New\nZealand, it was first practically introduced in Pachuca, Mexico."
     ],
-    "references": [
-      "PACHUCA TANK"
-    ]
+    "references": []
   },
   {
     "spellings": "PACHY-",
@@ -6109,9 +6107,7 @@
     "variants": [
       "PACK HERSE\nPack herse.\n\nDefn: See under 2d Pack."
     ],
-    "references": [
-      "PACK HERSE"
-    ]
+    "references": []
   },
   {
     "spellings": "PACKHOUSE",
@@ -6177,7 +6173,6 @@
     "references": [
       "APAREJO",
       "CACOLET",
-      "PACK SADDLE; PACK THREAD",
       "SUMPTER",
       "WAG"
     ]
@@ -6455,9 +6450,7 @@
     "variants": [
       "PAD ELEPHANT\nPad elephant.\n\nDefn: An elephant that is furnished with a pad for carrying burdens\ninstead of with a howdah for carrying passengers."
     ],
-    "references": [
-      "PAD ELEPHANT"
-    ]
+    "references": []
   },
   {
     "spellings": "PADELION",
@@ -6946,9 +6939,7 @@
     "variants": [
       "PAGODA SLEEVE\nPa*go\"da sleeve. (Costume)\n\nDefn: A funnel-shaped sleeve arranged to show the sleeve lining and\nan inner sleeve."
     ],
-    "references": [
-      "PAGODA SLEEVE"
-    ]
+    "references": []
   },
   {
     "spellings": "PAGODITE",
@@ -10120,7 +10111,6 @@
       "PALEOZOIC ERA\nPa`le*o*zo*ic e*ra, n. (Geol.)\n\nDefn: The Paleozoic time or strata."
     ],
     "references": [
-      "PALEOZOIC ERA",
       "PERMIAN",
       "SILURIAN"
     ]
@@ -11007,7 +10997,6 @@
     "references": [
       "CASTOR BEAN",
       "CASTOR OIL",
-      "PALMA CHRISTI",
       "PALMCRIST",
       "PALMIC",
       "PALMIN",
@@ -11178,18 +11167,14 @@
     "variants": [
       "PALMETTO FLAG\nPal*met\"to flag.\n\nDefn: Any of several flags adopted by South California after its\nsecession. That adopted in November, 1860, had a green cabbage\npalmetto in the center of a white field; the final one, January,\n1861, had a white palmetto in the center of a blue field and a white\ncrescent in the upper left-hand corner."
     ],
-    "references": [
-      "PALMETTO FLAG"
-    ]
+    "references": []
   },
   {
     "spellings": "PALMETTO STATE",
     "variants": [
       "PALMETTO STATE\nPalmetto State.\n\nDefn: South California; -- a nickname alluding to the State Arms,\nwhich contain a representation of a palmetto tree."
     ],
-    "references": [
-      "PALMETTO STATE"
-    ]
+    "references": []
   },
   {
     "spellings": "PALMIC",
@@ -11342,7 +11327,6 @@
       "PALM SUNDAY\nPalm\" Sun`day. (Eccl.)\n\nDefn: The Sunday next before Easter; -- so called in commemoration of\nour Savior's triumphal entry into Jerusalem, when the multitude\nstrewed palm branches in the way."
     ],
     "references": [
-      "PALM SUNDAY",
       "TRADITION"
     ]
   },
@@ -11386,9 +11370,7 @@
     "variants": [
       "PALO BLANCO\nPa\"lo blan\"co. [Sp. blanco white.]\n (a) A western American hackberry (Celtis reticulata), having light-\ncolored bark.\n (b) A Mexican mimosaceous tree (Lysiloma candida), the bark of which\nis used in tanning."
     ],
-    "references": [
-      "PALO BLANCO"
-    ]
+    "references": []
   },
   {
     "spellings": "PALOLA",
@@ -11402,9 +11384,7 @@
     "variants": [
       "PALOLO; PALOLO WORM\nPa*lo\"lo, n., or Palolo worm . [From native name.]\n\nDefn: A polystome worm (Palolo viridis) that burrows in the coral\nreefs of certain of the Pacific Islands. A little before the last\nquarter of the moon in October and November, they swarm in vast\nnumbers at the surface of the sea for breeding, and are gathered and\nhighly esteemed as food by the natives. An allied species inhabits\nthe tropical Atlantic and swarms in June or July."
     ],
-    "references": [
-      "PALOLO; PALOLO WORM"
-    ]
+    "references": []
   },
   {
     "spellings": "PALOMETA; PALLOMETA",
@@ -12475,9 +12455,7 @@
     "variants": [
       "PANAMA HAT\nPan`a*ma\" hat`.\n\nDefn: A fine plaited hat, made in Central America of the young leaves\nof a plant (Carludovica palmata)."
     ],
-    "references": [
-      "PANAMA HAT"
-    ]
+    "references": []
   },
   {
     "spellings": "PANAMANIAN",
@@ -12500,9 +12478,7 @@
     "variants": [
       "PAN-AMERICAN CONGRESS\nPan-American Congress. Any of several meetings of delegates from\nvarious American states; esp.:\n (a) One held in 1889-90 in the United States, at which all the\nindependent states except Santo Domingo were represented and of which\nthe practical result was the establishment of the Bureau of American\nRepublics for the promotion of trade relations.\n (b) One held in Mexico in 1901-1902.\n (c) One held at Rio de Janeiro in 1906."
     ],
-    "references": [
-      "PAN-AMERICAN CONGRESS"
-    ]
+    "references": []
   },
   {
     "spellings": "PAN-AMERICANISM",
@@ -13206,9 +13182,7 @@
     "variants": [
       "PANHANDLE STATE\nPanhandle State.\n\nDefn: West Virginia; -- a nickname."
     ],
-    "references": [
-      "PANHANDLE STATE"
-    ]
+    "references": []
   },
   {
     "spellings": "PANHELLENIC",
@@ -16332,9 +16306,7 @@
     "variants": [
       "PARA CRESS\nPará cress.\n\nDefn: An annual asteraceous herb (Spilances oleracea) grown in\ntropical countries as a pungent salad, and also used medicinally."
     ],
-    "references": [
-      "PARA CRESS"
-    ]
+    "references": []
   },
   {
     "spellings": "PARACROSTIC",
@@ -16881,9 +16853,7 @@
     "variants": [
       "PARA GRASS\nPa*ra\" grass`. (Bot.)\n\nDefn: A valuable pasture grass (Panicum barbinode) introduced into\nthe Southern United States from Brazil."
     ],
-    "references": [
-      "PARA GRASS"
-    ]
+    "references": []
   },
   {
     "spellings": "PARAGRELE",
@@ -16906,7 +16876,6 @@
     ],
     "references": [
       "MATE",
-      "PARAGUAY TEA",
       "TEA"
     ]
   },
@@ -17407,27 +17376,21 @@
     "variants": [
       "PARALLEL STANDARDS\nParallel standards. (Numismatics)\n\nDefn: Two or more metals coined without any attempt by the government\nto regulate their values."
     ],
-    "references": [
-      "PARALLEL STANDARDS"
-    ]
+    "references": []
   },
   {
     "spellings": "PARALLEL SULCUS",
     "variants": [
       "PARALLEL SULCUS\nParallel sulcus. (Anat.)\n\nDefn: A sulcus parallel to, but some distance below, the horizontal\nlimb of the fissure of Sylvius."
     ],
-    "references": [
-      "PARALLEL SULCUS"
-    ]
+    "references": []
   },
   {
     "spellings": "PARALLEL TRANSFORMER",
     "variants": [
       "PARALLEL TRANSFORMER\nParallel transformer. (Elec.)\n\nDefn: A transformer connected in parallel."
     ],
-    "references": [
-      "PARALLEL TRANSFORMER"
-    ]
+    "references": []
   },
   {
     "spellings": "PARALLEL VISE",
@@ -17435,8 +17398,7 @@
       "PARALLEL VISE\nParallel vise.\n\nDefn: A vise with jaws so guided as to remain parallel."
     ],
     "references": [
-      "PARALLEL",
-      "PARALLEL VISE"
+      "PARALLEL"
     ]
   },
   {
@@ -17805,9 +17767,7 @@
     "variants": [
       "PARA NUT\nPa*ra\" nut`. (Bot.)\n\nDefn: The Brazil nut."
     ],
-    "references": [
-      "PARA NUT"
-    ]
+    "references": []
   },
   {
     "spellings": "PARANYMPH",
@@ -18086,9 +18046,7 @@
     "variants": [
       "PARA RUBBER\nPará rubber.\n\nDefn: The caoutchouc obtained from the South American euphorbiaceous\ntree Hevea brasiliensis, hence called the Pará rubber tree, from the\nBrazilian river and seaport named Pará; also, the similar product of\nother species of Hevea. It is usually exported in flat round cakes,\nand is a chief variety of commercial India rubber."
     ],
-    "references": [
-      "PARA RUBBER"
-    ]
+    "references": []
   },
   {
     "spellings": "PARASANG",
@@ -18612,8 +18570,7 @@
       "PARCEL POST\nPar\"cel post.\n\nDefn: That branch of the post office having to do with the\ncollection, transmission, and delivery of parcels. The British Inland\nParcel Post was established in 1883. The present rates, dating from\n1897, are 3d. for parcels not exceeding one pound and 1d. for each\nadditional pound up to the limit of 10 pounds. A general parcel post\nwas established in the United States by Act of August 24, 1912, which\ntook effect Jan. 1, 1913. Parcels must not exceed 11 pounds in weight\nnor 72 inches in length and girth combined. Provision is made from\ninsuring parcels up to $50.00, and also for sending parcels C.O.D.\nThe rates of postage vary with the distance. See Zone, below."
     ],
     "references": [
-      "PARCEL",
-      "PARCEL POST"
+      "PARCEL"
     ]
   },
   {
@@ -20422,9 +20379,7 @@
     "variants": [
       "PARLOR MATCH\nPar\"lor match`.\n\nDefn: A friction match that contains little or no sulphur."
     ],
-    "references": [
-      "PARLOR MATCH"
-    ]
+    "references": []
   },
   {
     "spellings": "PARLOUS",
@@ -20852,9 +20807,7 @@
     "variants": [
       "PARQUET CIRCLE\nParquet circle.\n\nDefn: That part of the lower floor of a theater with seats at the\nrear of the parquet and beneath the galleries; -- called also, esp.\nin U. S., orchestra circle or parterre."
     ],
-    "references": [
-      "PARQUET CIRCLE"
-    ]
+    "references": []
   },
   {
     "spellings": "PARQUETED",
@@ -28813,7 +28766,6 @@
       "PASSENGER MILE\nPas\"sen*ger mile. (Railroads)\n\nDefn: A unit of measurement of the passenger transportation performed\nby a railroad during a given period, usually a year, the total of\nwhich consists of the sum of the miles traversed by all the\npassengers on the road in the period in question."
     ],
     "references": [
-      "PASSENGER MILE",
       "PASSENGER MILEAGE",
       "TRAFFIC MILE"
     ]
@@ -28823,9 +28775,7 @@
     "variants": [
       "PASSENGER MILEAGE\nPassenger mileage. (Railroads)\n\nDefn: Passenger miles collectively; the total number of miles\ntraveled by passengers on a railroad during a given period."
     ],
-    "references": [
-      "PASSENGER MILEAGE"
-    ]
+    "references": []
   },
   {
     "spellings": "PASSE PARTOUT",
@@ -28833,7 +28783,6 @@
       "PASSE PARTOUT\nPasse\" par`tout\", n. Etym: [F., from passer to pass + partout\neverywhere.]\n\n1. That by which one can pass anywhere; a safe-conduct. [Obs.]\nDryden.\n\n2. A master key; a latchkey.\n\n3. A light picture frame or mat of cardboard, wood, or the like,\nusually put between the picture and the glass, and sometimes serving\nfor several pictures."
     ],
     "references": [
-      "PASSE PARTOUT",
       "SPANDREL"
     ]
   },
@@ -29867,18 +29816,14 @@
     "variants": [
       "PASSIVE BALLOON; PASSIVE AEROPLANE\nPas\"sive bal*loon\" or a\"ër*o*plane.\n\nDefn: One unprovided with motive power."
     ],
-    "references": [
-      "PASSIVE BALLOON; PASSIVE AEROPLANE"
-    ]
+    "references": []
   },
   {
     "spellings": "PASSIVE FLIGHT",
     "variants": [
       "PASSIVE FLIGHT\nPassive flight.\n\nDefn: Flight, such as gliding and soaring, accomplished without the\nuse of motive power."
     ],
-    "references": [
-      "PASSIVE FLIGHT"
-    ]
+    "references": []
   },
   {
     "spellings": "PASSIVELY",
@@ -30437,9 +30382,7 @@
     "variants": [
       "PASTEUR'S FLUID\nPas`teur's\" flu\"id. (Biol.)\n\nDefn: An artificial nutrient fluid invented by Pasteur for the study\nof alcoholic fermentation, but used also for the cultivation of\nbacteria and other organisms. It contains all the elements of\nprotoplasm, and was originally made of the ash of yeast, some ammonia\ncompound, sugar, and water."
     ],
-    "references": [
-      "PASTEUR'S FLUID"
-    ]
+    "references": []
   },
   {
     "spellings": "PASTICCIO",
@@ -32305,9 +32248,7 @@
     "variants": [
       "PATRIOTS' DAY\nPa\"tri*ots' Day.\n\nDefn: A legal holiday in the States of Massachusetts and Maine, April\n19, the anniversary of the battle of Lexington in 1775. It was first\nobserved in 1894. [U. S.]"
     ],
-    "references": [
-      "PATRIOTS' DAY"
-    ]
+    "references": []
   },
   {
     "spellings": "PATRIPASSIAN",
@@ -32832,9 +32773,7 @@
     "variants": [
       "PATTINSON'S PROCESS\nPat\"tin*son's proc\"ess. (Metal.)\n\nDefn: A process of desilverizing argentiferous lead by repeated\nmeltings and skimmings, which concentrate the silver in the molten\nbath, the final skimmings being nearly pure lad. The processwas\ninvented in 1833 by Hugh Lee Pattinson, an English metallurgist."
     ],
-    "references": [
-      "PATTINSON'S PROCESS"
-    ]
+    "references": []
   },
   {
     "spellings": "PATTY",
@@ -34105,9 +34044,7 @@
     "variants": [
       "PAY CERPS\nPay Cerps.\n\nDefn: A staff corps in the United States navy, consisting of pay\ndirectors, pay inspectors, paymasters, passed assistant paymasters,\nand assistant paymasters, having relative rank from captain to\nensign, respectively."
     ],
-    "references": [
-      "PAY CERPS"
-    ]
+    "references": []
   },
   {
     "spellings": "PAY DIRT; PAY ROCK",
@@ -34115,8 +34052,7 @@
       "PAY DIRT; PAY ROCK\nPay dirt, Pay rock, etc. (Mining)\n\nDefn: Earth, rock, etc., which yields a profit to the miner. [Western\nU. S.]"
     ],
     "references": [
-      "PAY",
-      "PAY DIRT; PAY ROCK"
+      "PAY"
     ]
   },
   {
@@ -34421,9 +34357,7 @@
     "variants": [
       "PAYNE'S PROCESS\nPayne's process.\n\nDefn: A process for preserving timber and rendering it incombustible\nby impregnating it successively with solutions of sulphate of iron\nand calcium chloride in vacuo. --Payn\"ize, v. t."
     ],
-    "references": [
-      "PAYNE'S PROCESS"
-    ]
+    "references": []
   },
   {
     "spellings": "PAYNIM",
@@ -34460,9 +34394,7 @@
     "variants": [
       "PAY STREAK\nPay streak.\n\n1. (Mining) The zone, parallel to the walls of a vein, in which the\nore is concentrated, or any narrow streak of paying ore in less\nvaluable material.\n\n2.  (Oil Boring) A stratum of oil sand thick enough to make a well\npay."
     ],
-    "references": [
-      "PAY STREAK"
-    ]
+    "references": []
   },
   {
     "spellings": "PAYTINE",
@@ -34550,7 +34482,6 @@
       "PEABODY BIRD\nPea\"bod*y bird`. (Zoöl.)\n\nDefn: An American sparrow (Zonotrichia albicollis) having a\nconspicuous white throat. The name is imitative of its note. Called\nalso White-throated sparrow."
     ],
     "references": [
-      "PEABODY BIRD",
       "SPARROW"
     ]
   },
@@ -35023,9 +34954,7 @@
     "variants": [
       "PEACOCK THRONE\nPea\"cock` Throne.\n\n1. A famous throne formerly of the kings of Delhi, India, but since\n1739, when it was carried off by Nadir Shah, held by the shahs of\nPersia (later Iran); -- so called from its bearing a fully expanded\npeacock's tail done in gems."
     ],
-    "references": [
-      "PEACOCK THRONE"
-    ]
+    "references": []
   },
   {
     "spellings": "PEAFOWL",
@@ -35223,9 +35152,7 @@
     "variants": [
       "PEANUT BUTTER\nPea\"nut but\"ter.\n\nDefn: A paste made by mixing ground fresh roasted peanuts with a\nsmall quantity of water or oil, and used chiefly as a relish on\nsandwiches, etc."
     ],
-    "references": [
-      "PEANUT BUTTER"
-    ]
+    "references": []
   },
   {
     "spellings": "PEAR",
@@ -37776,9 +37703,7 @@
     "variants": [
       "PEDIGREE CLAUSE\nPed\"i*gree clause.\n\nDefn: A clause sometimes inserted in contracts or specifications,\nrequiring that a material of construction, as cement, must be of a\nbrand that has stood the test of a specified number of years' use in\nan important public work. [Cant, U. S.]"
     ],
-    "references": [
-      "PEDIGREE CLAUSE"
-    ]
+    "references": []
   },
   {
     "spellings": "PEDILUVY",
@@ -38267,9 +38192,7 @@
     "variants": [
       "PEEPING HOLE\nPeep\"ing hole`.\n\nDefn: See Peephole."
     ],
-    "references": [
-      "PEEPING HOLE"
-    ]
+    "references": []
   },
   {
     "spellings": "PEEP SIGHT",
@@ -38278,7 +38201,6 @@
     ],
     "references": [
       "PEEP",
-      "PEEP SIGHT",
       "SIGHT"
     ]
   },
@@ -38290,7 +38212,6 @@
     "references": [
       "BO TREE",
       "FICUS",
-      "PEEPUL TREE",
       "PIPAL TREE",
       "PIPPUL TREE"
     ]
@@ -38889,9 +38810,7 @@
     "variants": [
       "PELE'S HAIR\nPe\"le's hair. [After a Hawaiian goddess associated with the crater\nKilauea.]\n\nDefn: Glass threads or fibers formed by the wind from bits blown from\nfrothy lava or from the tips of lava jets or from bits of liquid lava\nthrown into the air. It often collects in thick masses resembling\ntow."
     ],
-    "references": [
-      "PELE'S HAIR"
-    ]
+    "references": []
   },
   {
     "spellings": "PELF",
@@ -38938,9 +38857,7 @@
     "variants": [
       "PELICAN STATE\nPel\"i*can State.\n\nDefn: Louisiana; -- a nickname alluding to the device on its seal."
     ],
-    "references": [
-      "PELICAN STATE"
-    ]
+    "references": []
   },
   {
     "spellings": "PELICK",
@@ -39319,7 +39236,6 @@
       "PELTIER EFFECT\nPel`tier\" ef*fect\". [After Jean C. A. Peltier, French physicist, the\ndiscoverer.] (Elec.)\n\nDefn: The production or absorption of heat at the junction of two\nmetals on the passage of a current. Heat generated by the passage of\nthe current in one direction will be absorbed if the current is\nreversed."
     ],
     "references": [
-      "PELTIER EFFECT",
       "PELTIER'S CROSS"
     ]
   },
@@ -39328,9 +39244,7 @@
     "variants": [
       "PELTIER'S CROSS\nPel`tier's\" cross. (Elec.)\n\nDefn: A cross formed of two strips of different metals, to illustrate\nthe Peltier effect."
     ],
-    "references": [
-      "PELTIER'S CROSS"
-    ]
+    "references": []
   },
   {
     "spellings": "PELTIFORM",
@@ -39354,9 +39268,7 @@
     "variants": [
       "PELTON WHEEL\nPel\"ton wheel. (Mech.)\n\nDefn: A form of impulse turbine or water wheel, consisting of a row\nof double cup-shaped buckets arranged round the rim of a wheel and\nactuated by one or more jets of water playing into the cups at high\nvelocity."
     ],
-    "references": [
-      "PELTON WHEEL"
-    ]
+    "references": []
   },
   {
     "spellings": "PELTRY",
@@ -39465,9 +39377,7 @@
     "variants": [
       "PEMBROKE TABLE\nPem\"broke ta`ble. [From Pembroke, a town and shire in Wales.]\n\nDefn: A style of four-legged table in vogue in England, chiefly in\nthe later Georgian period.\n\nThe characteristic which gives a table the name of Pembroke consists\nin the drop leaves, which are held up, when the table is open, by\nbrackets which turn under the top.\nF. C. Morse."
     ],
-    "references": [
-      "PEMBROKE TABLE"
-    ]
+    "references": []
   },
   {
     "spellings": "PEMMICAN",
@@ -40002,18 +39912,14 @@
     "variants": [
       "PENANG LAWYER\nPe*nang\" law\"yer. [Prob. fr. Malay pinang liar.]\n\nDefn: A kind of walking stick made from the stem of an East Asiatic\npalm (Licuala acutifida)."
     ],
-    "references": [
-      "PENANG LAWYER"
-    ]
+    "references": []
   },
   {
     "spellings": "PENANG NUT",
     "variants": [
       "PENANG NUT\nPe*nang\" nut`. Etym: [From the native name.] (Bot.)\n\nDefn: The betel nut. Balfour (Cyc. of India)."
     ],
-    "references": [
-      "PENANG NUT"
-    ]
+    "references": []
   },
   {
     "spellings": "PENANNULAR",
@@ -40883,9 +40789,7 @@
     "variants": [
       "PENINSULA STATE\nPen*in\"su*la State.\n\nDefn: Florida; -- a nickname."
     ],
-    "references": [
-      "PENINSULA STATE"
-    ]
+    "references": []
   },
   {
     "spellings": "PENINSULATE",
@@ -43395,9 +43299,7 @@
     "variants": [
       "PEOPLE'S BANK\nPeo\"ple's bank.\n\nDefn: A form of coöperative bank, such as those of Germany; -- a term\nloosely used for various forms of coöperative financial institutions."
     ],
-    "references": [
-      "PEOPLE'S BANK"
-    ]
+    "references": []
   },
   {
     "spellings": "PEOPLE'S PARTY",
@@ -43405,7 +43307,6 @@
       "PEOPLE'S PARTY\nPeople's party. (U. S. Politics)\n\nDefn: A party formed in 1891, advocating in an increase of the\ncurrency, public ownership and operation of railroads, telegraphs,\netc., an income tax, limitation in ownership of land, etc."
     ],
     "references": [
-      "PEOPLE'S PARTY",
       "POPULARES",
       "POPULISM",
       "POPULIST"
@@ -43547,8 +43448,7 @@
       "PEPPER BOX\nPep\"per box`, n.\n\nDefn: A buttress on the left-hand wall of a fives court as the game\nis played at Eton College, England."
     ],
     "references": [
-      "PEPPER",
-      "PEPPER BOX"
+      "PEPPER"
     ]
   },
   {
@@ -43572,9 +43472,7 @@
     "variants": [
       "PEPPER DULSE\nPep\"per dulse`. (Bot.)\n\nDefn: A variety of edible seaweed (Laurencia pinnatifida)\ndistinguished for its pungency. [Scot.] Lindley."
     ],
-    "references": [
-      "PEPPER DULSE"
-    ]
+    "references": []
   },
   {
     "spellings": "PEPPERER",
@@ -45578,8 +45476,7 @@
       "PER DIEM\nPer di\"em. [L.]\n\nDefn: By the day; substantively (chiefly U. S.), an allowance or\namount of so much by the day."
     ],
     "references": [
-      "PER",
-      "PER DIEM"
+      "PER"
     ]
   },
   {
@@ -48436,9 +48333,7 @@
     "variants": [
       "PERIGORD PIE\nPer\"i*gord pie`. Etym: [From Périgord, a former province of France.]\n\nDefn: A pie made of truffles, much esteemed by epicures."
     ],
-    "references": [
-      "PERIGORD PIE"
-    ]
+    "references": []
   },
   {
     "spellings": "PERIGRAPH",
@@ -51117,9 +51012,7 @@
     "variants": [
       "PERNICKETY PERNICKETTY\n{ Per*nick\"et*y Per*nick\"et*ty }, a.\n\nDefn: Finical or fussy; full of petty details. [Colloq.]"
     ],
-    "references": [
-      "PERNICKETY PERNICKETTY"
-    ]
+    "references": []
   },
   {
     "spellings": "PERNIO",
@@ -51157,8 +51050,7 @@
       "PERNOT FURNACE\nPer\"not fur\"nace. Etym: [So called from Charles Pernot, its\ninventor.]\n\nDefn: A reverberatory furnace with a circular revolving hearth, --\nused in making steel."
     ],
     "references": [
-      "KRUPP PROCESS",
-      "PERNOT FURNACE"
+      "KRUPP PROCESS"
     ]
   },
   {
@@ -51167,7 +51059,6 @@
       "PERNYI MOTH\nPer\"ny*i moth\". (Zoöl.)\n\nDefn: A silk-producing moth (Attacus Pernyi) which feeds upon the\noak. It has been introduced into Europe and America from China."
     ],
     "references": [
-      "PERNYI MOTH",
       "SILKWORM"
     ]
   },
@@ -51444,9 +51335,7 @@
     "variants": [
       "PERPEND STONE\nPer\"pend stone`.\n\nDefn: See Perpender."
     ],
-    "references": [
-      "PERPEND STONE"
-    ]
+    "references": []
   },
   {
     "spellings": "PERPENSION",
@@ -51470,8 +51359,7 @@
       "PERPENT STONE\nPer\"pent stone`.\n\nDefn: See Perpender."
     ],
     "references": [
-      "PERPENDER",
-      "PERPENT STONE"
+      "PERPENDER"
     ]
   },
   {
@@ -51620,8 +51508,7 @@
     "references": [
       "CALENDAR",
       "JEWISH CALENDAR",
-      "PERPETUAL",
-      "PERPETUAL CALENDAR"
+      "PERPETUAL"
     ]
   },
   {
@@ -57923,9 +57810,7 @@
     "variants": [
       "PETIT MAL\nPe*tit\" mal\". [F., lit., little sickness.] (Med.)\n\nDefn: The mildest form of epilepsy, with momentary faintness or\nunconsciousness, but without convulsions; -- opposed to grand mal."
     ],
-    "references": [
-      "PETIT MAL"
-    ]
+    "references": []
   },
   {
     "spellings": "PETITOR",
@@ -58721,9 +58606,7 @@
     "variants": [
       "PETWORTH MARBLE\nPet\"worth mar\"ble.\n\nDefn: A kind of shell marble occurring in the Wealden clay at\nPetworth, in Sussex, England; -- called also Sussex marble."
     ],
-    "references": [
-      "PETWORTH MARBLE"
-    ]
+    "references": []
   },
   {
     "spellings": "PETZITE",
@@ -58866,7 +58749,6 @@
       "PEYER'S GLANDS\nPey\"er's glands`. Etym: [So called from J.K.Peyer, who described them\nin 1677.] (Anat.)\n\nDefn: Pathches of lymphoid nodules, in the walls of the small\nintestiness; agminated glands; -- called also Peyer's patches. In\ntyphoid fever they become the seat of ulcers which are regarded as\nthe characteristic organic lesion of that disease."
     ],
     "references": [
-      "PEYER'S GLANDS",
       "TYPHOID"
     ]
   },
@@ -59530,9 +59412,7 @@
     "variants": [
       "PHANTOM CIRCUIT\nPhantom circuit. (Elec.)\n\nDefn: The equivalent of an additional circuit or wire, in reality not\nexisting, obtained by certain arrangements of real circuits, as in\nsome multiplex telegraph systems."
     ],
-    "references": [
-      "PHANTOM CIRCUIT"
-    ]
+    "references": []
   },
   {
     "spellings": "PHARAOH",
@@ -60013,27 +59893,21 @@
     "variants": [
       "PHASE ANGLE\nPhase angle. (Elec.)\n\nDefn: The angle expressing phase relation."
     ],
-    "references": [
-      "PHASE ANGLE"
-    ]
+    "references": []
   },
   {
     "spellings": "PHASE CONVERTER",
     "variants": [
       "PHASE CONVERTER\nPhase converter. (Elec.)\n\nDefn: A machine for converting an alternating current into an\nalternating current of a different number of phases and the same\nfrequency."
     ],
-    "references": [
-      "PHASE CONVERTER"
-    ]
+    "references": []
   },
   {
     "spellings": "PHASE DISPLACEMENT",
     "variants": [
       "PHASE DISPLACEMENT\nPhase displacement. (Elec.)\n\nDefn: A charge of phase whereby an alternating current attains its\nmaximum later or earlier. An inductance would cause a lag, a capacity\nwould cause an advance, in phase."
     ],
-    "references": [
-      "PHASE DISPLACEMENT"
-    ]
+    "references": []
   },
   {
     "spellings": "PHASEL",
@@ -60056,9 +59930,7 @@
     "variants": [
       "PHASE METER; PHASEMETER\nPhase meter, or Phase\"me`ter, n. (Elec.)\n\nDefn: A device for measuring the difference in phase of two\nalternating currents of electromotive forces."
     ],
-    "references": [
-      "PHASE METER; PHASEMETER"
-    ]
+    "references": []
   },
   {
     "spellings": "PHASEOLUS",
@@ -60087,27 +59959,21 @@
     "variants": [
       "PHASE RULE\nPhase rule. (Phys. Chem.)\n\nDefn: A generalization with regard to systems of chemical\nequilibrium, discovered by Prof. J. Willard Gibbs. It may be stated\nthus: The degree of variableness (number of degrees of freedom) of a\nsystem is equal to the number of components minus the number of\nphases, plus two. Thus, if the components be salt and water, and the\nphases salt, ice, saturated solution, and vapor, the system is\ninvariant, that is, there is only one set of conditions under which\nthese four phases can exist in equilibrium. If only three phases be\nconsidered, the system is univariant, that is, the fixing of one\ncondition, as temperature, determines the others."
     ],
-    "references": [
-      "PHASE RULE"
-    ]
+    "references": []
   },
   {
     "spellings": "PHASE SPLITTER",
     "variants": [
       "PHASE SPLITTER\nPhase splitter. (Elec.)\n\nDefn: A device by which a single-phase current is split into two or\nmore currents differing in phase. It is used in starting single-phase\ninduction motors."
     ],
-    "references": [
-      "PHASE SPLITTER"
-    ]
+    "references": []
   },
   {
     "spellings": "PHASE SPLITTING",
     "variants": [
       "PHASE SPLITTING\nPhase splitting. (Elec.)\n\nDefn: The dephasing of the two parts of a single alternating current\nin two dissimilar branches of a given circuit."
     ],
-    "references": [
-      "PHASE SPLITTING"
-    ]
+    "references": []
   },
   {
     "spellings": "PHASING",
@@ -60124,18 +59990,14 @@
     "variants": [
       "PHASING CURRENT\nPhasing current.\n\nDefn: The momentary current between two alternating-current\ngenerators when juxtaposed in parallel and not agreeing exactly in\nphase or period."
     ],
-    "references": [
-      "PHASING CURRENT"
-    ]
+    "references": []
   },
   {
     "spellings": "PHASING TRANSFORMER",
     "variants": [
       "PHASING TRANSFORMER\nPhasing transformer.\n\nDefn: Any of several transformers (there must be at least two) for\nchanging phase."
     ],
-    "references": [
-      "PHASING TRANSFORMER"
-    ]
+    "references": []
   },
   {
     "spellings": "PHASIS",
@@ -60499,8 +60361,7 @@
     "references": [
       "INDICATOR",
       "NOSOPHEN",
-      "PHENOL",
-      "PHENOLPHTHALEIN; PHENOL PHTHALEIN"
+      "PHENOL"
     ]
   },
   {
@@ -62979,9 +62840,7 @@
     "variants": [
       "PHOSPHORUS STEEL\nPhosphorus steel.\n\nDefn: A steel in which the amount of phosphorus exceeds that of\ncarbon."
     ],
-    "references": [
-      "PHOSPHORUS STEEL"
-    ]
+    "references": []
   },
   {
     "spellings": "PHOSPHORYL",
@@ -63021,8 +62880,7 @@
       "PHOTIC REGION\nPhotic region. (Phytogeography)\n\nDefn: The uppermost zone of the sea, which receives the most light."
     ],
     "references": [
-      "APHOTIC REGION",
-      "PHOTIC REGION"
+      "APHOTIC REGION"
     ]
   },
   {
@@ -63198,9 +63056,7 @@
     "variants": [
       "PHOTO-ELECTRIC CELL\nPhoto-electric cell.\n\nDefn: A cell (as one of two electrodes embedded in selenium) which by\nexposure to light generates an electric current."
     ],
-    "references": [
-      "PHOTO-ELECTRIC CELL"
-    ]
+    "references": []
   },
   {
     "spellings": "PHOTO-ELECTRICITY",
@@ -64626,9 +64482,7 @@
     "variants": [
       "PHRYGIAN CAP\nPhryg\"i*an cap`.\n\nDefn: A close-fitting cap represented in Greek art as worn by\nOrientals, assumed to have been conical in shape. It has been adopted\nin modern art as the so-called liberty cap, or cap of liberty."
     ],
-    "references": [
-      "PHRYGIAN CAP"
-    ]
+    "references": []
   },
   {
     "spellings": "PHTHALATE",
@@ -66765,8 +66619,7 @@
       "LEPTOMENINGITIS",
       "MATER",
       "MENINGES",
-      "PIAL",
-      "PIA MATER"
+      "PIAL"
     ]
   },
   {
@@ -67228,7 +67081,6 @@
       "PICHURIM BEAN\nPich\"u*rim bean`. (Bot.)\n\nDefn: The seed of a Brazilian lauraceous tree (Nectandra Puchury) of\na taste and smell between those of nutmeg and of sassafras, --\nsometimes used medicinally. Called also sassafras nut."
     ],
     "references": [
-      "PICHURIM BEAN",
       "SASSAFRAS"
     ]
   },
@@ -67755,9 +67607,7 @@
       "PI CLOTH\nPi\"ña cloth`.\n\nDefn: A fine material for ladies' shawls, scarfs, handkerchiefs,\netc., made from the fiber of the pineapple leaf, and perhaps from\nother fibrous tropical leaves. It is delicate, soft, and transparent,\nwith a slight tinge of pale yellow.",
       "PI CLOTH\nPi`ña cloth. [See Piña.]\n\nDefn: A fine fabric for scarfs, handkerchiefs, embroidery, etc.,\nwoven from the fiber obtained from the leaf of the sterile pineapple\nplant. It is delicate, soft, and transparent, with a tinge of pale\nyellow."
     ],
-    "references": [
-      "PI CLOTH"
-    ]
+    "references": []
   },
   {
     "spellings": "PICNIC",
@@ -70104,9 +69954,7 @@
     "variants": [
       "PIETRA DURA\nPi*e\"tra du\"ra. Etym: [It., hard stone.] (Fine Arts)\n\nDefn: Hard and fine stones in general, such as are used for inlay and\nthe like, as distinguished from the softer stones used in building;\nthus, a Florentine mosaic is a familiar instance of work in pietra\ndura, though the ground may be soft marble."
     ],
-    "references": [
-      "PIETRA DURA"
-    ]
+    "references": []
   },
   {
     "spellings": "PIETY",
@@ -71829,7 +71677,6 @@
       "HONITON LACE",
       "LACE",
       "PILLOW",
-      "PILLOW LACE",
       "YAK"
     ]
   },
@@ -71986,8 +71833,7 @@
       "PILOT BALLOON\nPilot balloon.\n\nDefn: A small, unmanned balloon sent up to indicate the direction of\nair currents."
     ],
     "references": [
-      "PILOT",
-      "PILOT BALLOON"
+      "PILOT"
     ]
   },
   {
@@ -71995,9 +71841,7 @@
     "variants": [
       "PILOT FLAG\nPilot flag.\n\nDefn: The flag hoisted at the fore by a vessel desiring a pilot, in\nthe United States the union jack, in Great Britain the British union\njack with a white border."
     ],
-    "references": [
-      "PILOT FLAG"
-    ]
+    "references": []
   },
   {
     "spellings": "PILOTISM; PILOTRY",
@@ -72011,27 +71855,21 @@
     "variants": [
       "PILOT LAMP; PILOT LIGHT\nPilot lamp or light . (Elec.)\n\nDefn: A small incandescent telltale lamp on a dynamo or battery\ncircuit to show approximately by its brightness the voltage of the\ncurrent."
     ],
-    "references": [
-      "PILOT LAMP; PILOT LIGHT"
-    ]
+    "references": []
   },
   {
     "spellings": "PILOT VALVE",
     "variants": [
       "PILOT VALVE\nPilot valve. (Hydraulics)\n\nDefn: A small hand-operated valve to admit liquid to operate a valve\ndifficult to turn by hand."
     ],
-    "references": [
-      "PILOT VALVE"
-    ]
+    "references": []
   },
   {
     "spellings": "PILOT WHEEL",
     "variants": [
       "PILOT WHEEL\nPilot wheel. (Mach.)\n\nDefn: A wheel, usually with radial handles projecting from the rim,\nfor traversing the saddle of a machine tool, esp. an automatic\nmachine tool, by hand."
     ],
-    "references": [
-      "PILOT WHEEL"
-    ]
+    "references": []
   },
   {
     "spellings": "PILOUR",
@@ -72509,18 +72347,14 @@
     "variants": [
       "PINACATE BUG\nPin`a*ca\"te bug. [Orig. uncert.]\n\nDefn: Any of several clumsy, wingless beetles of the genus Eleodes,\nfound in the Pacific States."
     ],
-    "references": [
-      "PINACATE BUG"
-    ]
+    "references": []
   },
   {
     "spellings": "PINA CLOTH; PINYA CLOTH",
     "variants": [
       "PINA CLOTH; PINYA CLOTH\nPi\"ña cloth`.\n\nDefn: A fine material for ladies' shawls, scarfs, handkerchiefs,\netc., made from the fiber of the pineapple leaf, and perhaps from\nother fibrous tropical leaves. It is delicate, soft, and transparent,\nwith a slight tinge of pale yellow."
     ],
-    "references": [
-      "PINA CLOTH; PINYA CLOTH"
-    ]
+    "references": []
   },
   {
     "spellings": "PINACOID",
@@ -73075,9 +72909,7 @@
     "variants": [
       "PINE-TREE STATE\nPine-tree State.\n\nDefn: Maine; -- a nickname alluding to the pine tree in its coat of\narms."
     ],
-    "references": [
-      "PINE-TREE STATE"
-    ]
+    "references": []
   },
   {
     "spellings": "PINETUM",
@@ -73478,8 +73310,7 @@
       "PINK STERN\nPink\" stern`. Etym: [See 1st Pink.] (Naut.)\n\nDefn: See Chebacco, and 1st Pink."
     ],
     "references": [
-      "PINK",
-      "PINK STERN"
+      "PINK"
     ]
   },
   {
@@ -73902,9 +73733,7 @@
     "variants": [
       "PINTSCH GAS\nPintsch gas. [After Richard Pintsch, German inventor.]\n\nDefn: A kind of oil gas extensively used for lighting railroad cars,\nwhich carry it in compressed form."
     ],
-    "references": [
-      "PINTSCH GAS"
-    ]
+    "references": []
   },
   {
     "spellings": "PINULE",
@@ -74019,9 +73848,7 @@
     "variants": [
       "PIONEERS' DAY\nPi`o*neers'\" Day.\n\nDefn: In Utah, a legal holiday, July 24, commemorated the arrival, in\n1847, of Brigham Young and his followers at the present site of Salt\nLake City."
     ],
-    "references": [
-      "PIONEERS' DAY"
-    ]
+    "references": []
   },
   {
     "spellings": "PIONER",
@@ -74163,8 +73990,7 @@
       "PIPAL TREE\nPi\"pal tree`.\n\nDefn: Same as Peepul tree."
     ],
     "references": [
-      "PEEPUL TREE",
-      "PIPAL TREE"
+      "PEEPUL TREE"
     ]
   },
   {
@@ -74463,7 +74289,6 @@
     ],
     "references": [
       "FAT",
-      "PIPE CLAY",
       "PIPECLAY",
       "TOBACCO"
     ]
@@ -74502,18 +74327,14 @@
     "variants": [
       "PIPELAYER; PIPE LAYER\nPipe\"lay`er, n., or Pipe\" lay`er.\n\n1. One who lays conducting pipes in the ground, as for water, gas,\netc.\n\n2. (Polit. Cant)\n\nDefn: A politician who works in secret; -- in this sense, usually\nwritten as one word. [U.S.]"
     ],
-    "references": [
-      "PIPELAYER; PIPE LAYER"
-    ]
+    "references": []
   },
   {
     "spellings": "PIPELAYING; PIPE LAYING",
     "variants": [
       "PIPELAYING; PIPE LAYING\nPipe\"lay`ing, n., or Pipe\" lay`ing.\n\n1. The laying of conducting pipes underground, as for water, gas,\netc.\n\n2. (Polit. Cant)\n\nDefn: The act or method of making combinations for personal advantage\nsecretly or slyly; -- in this sense, usually written as one word.\n[U.S.]"
     ],
-    "references": [
-      "PIPELAYING; PIPE LAYING"
-    ]
+    "references": []
   },
   {
     "spellings": "PIPE LINE",
@@ -74521,7 +74342,6 @@
       "PIPE LINE\nPipe line.\n\nDefn: A line of pipe with pumping machinery and apparatus for\nconveying liquids, esp. petroleum, between distant points."
     ],
     "references": [
-      "PIPE LINE",
       "PIPE-LINE"
     ]
   },
@@ -74765,8 +74585,7 @@
       "PIPPUL TREE\nPip\"pul tree`.\n\nDefn: Same as Peepul tree."
     ],
     "references": [
-      "PEEPUL TREE",
-      "PIPPUL TREE"
+      "PEEPUL TREE"
     ]
   },
   {
@@ -75329,9 +75148,7 @@
     "variants": [
       "PISTACHIO GREEN\nPistachio green.\n\nDefn: A light yellowish green color resembling that of the pistachio\nnut."
     ],
-    "references": [
-      "PISTACHIO GREEN"
-    ]
+    "references": []
   },
   {
     "spellings": "PISTACIA",
@@ -75652,9 +75469,7 @@
     "variants": [
       "PISTON RING\nPis\"ton ring. (Mach.)\n\nDefn: A spring packing ring, or any of several such rings, for a\npiston."
     ],
-    "references": [
-      "PISTON RING"
-    ]
+    "references": []
   },
   {
     "spellings": "PIT",
@@ -76442,7 +76257,6 @@
       "PITOT'S TUBE\nPi*tot's\" tube`. (Hydraul.)\n\nDefn: A bent tube used to determine the velocity of running water, by\nplacing the curved end under water, and observing the height to which\nthe fluid rises in the tube; a kind of current meter."
     ],
     "references": [
-      "PITOT'S TUBE",
       "RHYSIMETER"
     ]
   },
@@ -81290,9 +81104,7 @@
     "variants": [
       "PLANER TREE\nPlan\"er tree`. Etym: [From J.S.Planer, a German botanist.] (Bot.)\n\nDefn: A small-leaved North American tree (Planera aquatica) related\nto the elm, but having a wingless, nutlike fruit."
     ],
-    "references": [
-      "PLANER TREE"
-    ]
+    "references": []
   },
   {
     "spellings": "PLANET",
@@ -81418,8 +81230,7 @@
       "PLANE TABLE\nPlane\" ta`ble.\n\nDefn: See under Plane, a."
     ],
     "references": [
-      "PLANE",
-      "PLANE TABLE"
+      "PLANE"
     ]
   },
   {
@@ -81481,7 +81292,6 @@
     ],
     "references": [
       "BUTTONWOOD",
-      "PLANE TREE",
       "PLANTAIN",
       "PLATAN",
       "PLATANUS",
@@ -83799,9 +83609,7 @@
     "variants": [
       "PLASMON; PLASMON BUTTER\nPlas\"mon, n. [Cf. Plasma.]\n\nDefn: A flourlike food preparation made from skim milk, and\nconsisting essentially of the unaltered proteid of milk. It is also\nused in making biscuits and crackers, for mixing with cocoa, etc. A\nmixture of this with butter, water, and salt is called Plasmon\nbutter, and resembles clotted cream in appearance."
     ],
-    "references": [
-      "PLASMON; PLASMON BUTTER"
-    ]
+    "references": []
   },
   {
     "spellings": "PLASSON",
@@ -89185,9 +88993,7 @@
     "variants": [
       "PLIMSOLL'S MARK\nPlim\"soll's mark`. (Naut.)\n\nDefn: A mark conspicuously painted on the port side of all British\nsea-going merchant vessels, to indicate the limit of submergence\nallowed by law; -- so called from Samuel Plimsoll, by whose efforts\nthe act of Parliament to prevent overloading was procured."
     ],
-    "references": [
-      "PLIMSOLL'S MARK"
-    ]
+    "references": []
   },
   {
     "spellings": "PLINTH",
@@ -90118,9 +89924,7 @@
     "variants": [
       "PLUCKER TUBE\nPlück\"er tube. [So named after Julius Plücker, a German physicist.]\n(Physics)\n (a) A vacuum tube, used in spectrum analysis, in which the part\nthrough which the discharge takes place is a capillary tube, thus\nproducing intense incandescence of the contained gases.\n (b) Crookes tube."
     ],
-    "references": [
-      "PLUCKER TUBE"
-    ]
+    "references": []
   },
   {
     "spellings": "PLUCKILY",
@@ -90216,9 +90020,7 @@
     "variants": [
       "PLUG BOARD\nPlug board. (Elec.)\n\nDefn: A switchboard in which connections are made by means of plugs."
     ],
-    "references": [
-      "PLUG BOARD"
-    ]
+    "references": []
   },
   {
     "spellings": "PLUGGER",
@@ -90504,8 +90306,7 @@
       "PLUMBER BLOCK\nPlumb\"er block`.\n\nDefn: A pillow block."
     ],
     "references": [
-      "PILLOW",
-      "PLUMBER BLOCK"
+      "PILLOW"
     ]
   },
   {
@@ -91953,8 +91754,7 @@
       "PLYMOUTH BRETHREN\nPlym\"outh Breth\"ren.\n\nDefn: The members of a religious sect which first appeared at\nPlymouth, England, about 1830. They protest against sectarianism, and\nreject all official ministry or clergy. Also called Brethren,\nChristian Brethren, Plymouthists, etc. The Darbyites are a division\nof the Brethren."
     ],
     "references": [
-      "DARBYITE",
-      "PLYMOUTH BRETHREN"
+      "DARBYITE"
     ]
   },
   {
@@ -92555,9 +92355,7 @@
     "variants": [
       "POCKET VETO\nPocket veto.\n\nDefn: The retention by the President of the United States of a bill\nunsigned so that it does not become a law, in virtue of the following\nconstitutional provision (Const. Art. I., sec. 7, cl. 2): \"If any\nbill shall not be returned by the President within ten days (Sundays\nexcepted) after it shall have been presented to him, the same shall\nbe a law, in like manner as if he had signed it, unless the Congress\nby their adjournment prevent its return, in which case it shall not\nbe a law.\" Also, an analogous retention of a bill by a State\ngovernor."
     ],
-    "references": [
-      "POCKET VETO"
-    ]
+    "references": []
   },
   {
     "spellings": "POCK-FRETTEN",
@@ -93904,9 +93702,7 @@
     "variants": [
       "POETS' CORNER\nPo\"ets' Cor\"ner.\n\nDefn: An angle in the south transept of Westminster Abbey, London; --\nso called because it contains the tombs of Chaucer, Spenser, Dryden,\nBen Jonson, Gray, Tennyson, Browning, and other English poets, and\nmemorials to many buried elsewhere."
     ],
-    "references": [
-      "POETS' CORNER"
-    ]
+    "references": []
   },
   {
     "spellings": "POETSHIP",
@@ -95116,18 +94912,14 @@
     "variants": [
       "POINT ALPHABET\nPoint alphabet.\n\nDefn: An alphabet for the blind with a system of raised points\ncorresponding to letters."
     ],
-    "references": [
-      "POINT ALPHABET"
-    ]
+    "references": []
   },
   {
     "spellings": "POINT APPLIQUE",
     "variants": [
       "POINT APPLIQUE\nPoint appliqué.\n\nDefn: Lace having a needle-made design applied to a net ground, this\nground often being machine-made."
     ],
-    "references": [
-      "POINT APPLIQUE"
-    ]
+    "references": []
   },
   {
     "spellings": "POINT-BLANK",
@@ -95147,8 +94939,7 @@
       "POINT D'APPUI\nPoint` d'ap`pui\". Etym: [F.] (Mil.)\n\nDefn: See under Appui."
     ],
     "references": [
-      "APPUI",
-      "POINT D'APPUI"
+      "APPUI"
     ]
   },
   {
@@ -95524,7 +95315,6 @@
       "POINT SWITCH\nPoint switch. (Railroads)\n\nDefn: A switch made up of a rail from each track, both rails being\ntapered far back and connected to throw alongside the through rail of\neither track."
     ],
     "references": [
-      "POINT SWITCH",
       "SPLIT SWITCH"
     ]
   },
@@ -95735,18 +95525,14 @@
     "variants": [
       "POISON BUSH\nPoison bush. In Australia:\n (a) Any fabaceous shrub of the genus Gastrolobium, the herbage of\nwhich is poisonous to stock; also, any species of several related\ngenera, as Oxylobium, Gompholobium, etc.\n (b) The plant Myoporum deserti, often distinguished as Ellangowan\npoison bush or dogwood poison bush.\n (c) The ulmaceous plant Trema cannabina, which, though not\npoisonous, is injurious to stock because of its large amount of\nfiber."
     ],
-    "references": [
-      "POISON BUSH"
-    ]
+    "references": []
   },
   {
     "spellings": "POISON CUP",
     "variants": [
       "POISON CUP\nPoison cup.\n\n1. A cup containing poison.\n\n2.  A cup that was supposed to break on having poison put into it."
     ],
-    "references": [
-      "POISON CUP"
-    ]
+    "references": []
   },
   {
     "spellings": "POISONER",
@@ -96049,9 +95835,7 @@
     "variants": [
       "POKER DICE\nPoker dice.\n\nDefn: A game played with five dice in which the count is usually\nmade, in order, by pairs, two pairs, three of a kind, full houses,\nfour of a kind, and five of a kind (the highest throw), similar to\npoker; also, the dice used in this game, esp. when marked with the\nace, king, queen, jack, ten, and nine instead of the usual digits."
     ],
-    "references": [
-      "POKER DICE"
-    ]
+    "references": []
   },
   {
     "spellings": "POKERISH",
@@ -96884,9 +96668,7 @@
     "variants": [
       "POLICE POWER\nPolice power. (Law)\n\nDefn: The inherent power of a government to regulate its police\naffairs. The term police power is not definitely fixed in meaning. In\nthe earlier cases in the United States it was used as including the\nwhole power of internal government, or the powers of government\ninherent in every sovereignty to the extent of its dominions (11\nPeters (U. S.) 102). The later cases have excepted from its domain\nthe development and administration of private law. Modern political\nscience defines the power as a branch of internal administration in\nthe exercise of which the executive should move within the lines of\ngeneral principles prescribed by the constitution or the legislature,\nand in the exercise of which the most local governmental\norganizations should participate as far as possible (Burgess). Under\nthis limitation the police power, as affecting persons, is the power\nof the state to protect the public against the abuse of individual\nliberty, that is, to restrain the individual in the exercise of his\nrights when such exercise becomes a danger to the community. The\ntendency of judicial and popular usage is towards this narrower\ndefinition."
     ],
-    "references": [
-      "POLICE POWER"
-    ]
+    "references": []
   },
   {
     "spellings": "POLICIAL",
@@ -100857,7 +100639,6 @@
     ],
     "references": [
       "BREADROOT",
-      "POMME BLANCHE",
       "PRAIRIE"
     ]
   },
@@ -101025,9 +100806,7 @@
     "variants": [
       "POMPEIAN RED\nPompeian red. (Art)\n\nDefn: A brownish red approaching maroon, supposed to be imitated from\nthe color of the wall panels of houses in Pompeii, which were\ndecorated during the last age of the Republic."
     ],
-    "references": [
-      "POMPEIAN RED"
-    ]
+    "references": []
   },
   {
     "spellings": "POMPELMOUS",
@@ -101904,18 +101683,14 @@
     "variants": [
       "POONAH PAINTING\nPoo\"nah paint`ing. [From Poona, in Bombay Province, India.]\n\nDefn: A style of painting, popular in England in the 19th century, in\nwhich a thick opaque color is applied without background and with\nscarcely any shading, to thin paper, producing flowers, birds, etc.,\nin imitation of Oriental work. Hence: Poonah brush, paper, painter,\netc."
     ],
-    "references": [
-      "POONAH PAINTING"
-    ]
+    "references": []
   },
   {
     "spellings": "POONGA OIL",
     "variants": [
       "POONGA OIL\nPoon\"ga oil`.\n\nDefn: A kind of oil used in India for lamps, and for boiling with\ndammar for pitching vessels. It is pressed from the seeds of a\nleguminous tree (Pongamia glabra)."
     ],
-    "references": [
-      "POONGA OIL"
-    ]
+    "references": []
   },
   {
     "spellings": "POOP",
@@ -103965,9 +103740,7 @@
     "variants": [
       "POPE'S HEAD\nPope's head.\n\nDefn: A long-handled brush for dusting ceilings, etc., also for\nwashing windows. [Cant]"
     ],
-    "references": [
-      "POPE'S HEAD"
-    ]
+    "references": []
   },
   {
     "spellings": "POPET",
@@ -105787,9 +105560,7 @@
     "variants": [
       "PORTAGE GROUP\nPor\"tage group`. Etym: [So called from the township of Portage in New\nYork.] (Geol.)\n\nDefn: A subdivision of the Chemung period in American geology. See\nChart of Geology."
     ],
-    "references": [
-      "PORTAGE GROUP"
-    ]
+    "references": []
   },
   {
     "spellings": "PORTAGUE",
@@ -106857,8 +106628,7 @@
       "PORTLAND CEMENT\nPort\"land ce*ment\".\n\nDefn: A cement having the color of the Portland stone of England,\nmade by calcining an artificial mixture of carbonate of lime and\nclay, or sometimes certain natural limestones or chalky clays. It\ncontains a large proportion of clay, and hardens under water."
     ],
     "references": [
-      "KIBOSH",
-      "PORTLAND CEMENT"
+      "KIBOSH"
     ]
   },
   {
@@ -106867,8 +106637,7 @@
       "PORTLAND STONE\nPort\"land stone\".\n\nDefn: A yellowish-white calcareous freestone from the Isle of\nPortland in England, much used in building."
     ],
     "references": [
-      "PORTLAND CEMENT",
-      "PORTLAND STONE"
+      "PORTLAND CEMENT"
     ]
   },
   {
@@ -106877,7 +106646,6 @@
       "PORTLAND VASE\nPort\"land vase`.\n\nDefn: A celebrated cinerary urn or vase found in the tomb of the\nEmperor Alexander Severus. It is owned by the Duke of Portland, and\nkept in the British Museum."
     ],
     "references": [
-      "PORTLAND VASE",
       "VASE"
     ]
   },
@@ -108323,7 +108091,6 @@
     ],
     "references": [
       "POSSE",
-      "POSSE COMITATUS",
       "POWER"
     ]
   },
@@ -110320,9 +110087,7 @@
     "variants": [
       "POST NOTE\nPost\" note`. (Com.)\n\nDefn: A note issued by a bank, payable at some future specified time,\nas distinguished from a note payable on demand. Burrill."
     ],
-    "references": [
-      "POST NOTE"
-    ]
+    "references": []
   },
   {
     "spellings": "POSTNUPTIAL",
@@ -110340,8 +110105,7 @@
       "POST-OBIT; POST-OBIT BOND\nPost-o\"bit, n., or Post-o\"bit bond`. [Pref. post- + obit.] (Law)\n\nDefn: A bond in which the obligor, in consideration of having\nreceived a certain sum of money, binds himself to pay a larger sum,\non unusual interest, on the death of some specified individual from\nwhom he has expectations.  Bouvier."
     ],
     "references": [
-      "OBIT",
-      "POST-OBIT; POST-OBIT BOND"
+      "OBIT"
     ]
   },
   {
@@ -110376,7 +110140,6 @@
       "POSTHOUSE",
       "POSTMARK",
       "POSTMASTER",
-      "POST OFFICE",
       "REGISTER"
     ]
   },
@@ -111745,9 +111508,7 @@
     "variants": [
       "POT LACE\nPot lace.\n\nDefn: Lace whose pattern includes one or more representations of\nbaskets or bowls from which flowers spring."
     ],
-    "references": [
-      "POT LACE"
-    ]
+    "references": []
   },
   {
     "spellings": "POTLATCH",
@@ -111763,9 +111524,7 @@
     "variants": [
       "POT LEAD\nPot lead.\n\nDefn: Graphite, or black lead, often used on the bottoms of racing\nvessels to diminish friction."
     ],
-    "references": [
-      "POT LEAD"
-    ]
+    "references": []
   },
   {
     "spellings": "POTLID",
@@ -111829,9 +111588,7 @@
     "variants": [
       "POTSDAM GROUP\nPots\"dam group` (. (Geol.)\n\nDefn: A subdivision of the Primordial or Cambrian period in American\ngeology; -- so named from the sandstone of Potsdam, New York. See\nChart of Geology."
     ],
-    "references": [
-      "POTSDAM GROUP"
-    ]
+    "references": []
   },
   {
     "spellings": "POTSHARD; POTSHARE",
@@ -111858,9 +111615,7 @@
     "variants": [
       "POT SHOT\nPot shot.\n\nDefn: Lit., a shot fired simply to fill the pot; hence, a shot fired\nat an animal or person when at rest or within easy range, or fired\nsimply to kill, without reference to the rules of sport; a shot\nneedling no special skill."
     ],
-    "references": [
-      "POT SHOT"
-    ]
+    "references": []
   },
   {
     "spellings": "POTSTONE",
@@ -112072,7 +111827,6 @@
       "POTT'S DISEASE\nPott's\" dis*ease\". (Med.)\n\nDefn: Caries of the vertebræ, frequently resulting in curvature of\nthe spine and paralysis of the lower extremities; -- so named from\nPercival Pott, an English surgeon. Pott's fracture, a fracture of the\nlower end of the fibula, with displacement of the tibia. Dunglison."
     ],
     "references": [
-      "POTT'S DISEASE",
       "RACHIALGIA"
     ]
   },
@@ -112174,9 +111928,7 @@
     "variants": [
       "POUCHET BOX\nPou\"chet box`.\n\nDefn: See Pouncet box."
     ],
-    "references": [
-      "POUCHET BOX"
-    ]
+    "references": []
   },
   {
     "spellings": "POUCH-MOUTHED",
@@ -112397,8 +112149,7 @@
     ],
     "references": [
       "ANON",
-      "POUCHET BOX",
-      "POUNCET BOX"
+      "POUCHET BOX"
     ]
   },
   {
@@ -112627,8 +112378,7 @@
       "POUPART'S LIGAMENT\nPou*part's\" lig\"a*ment. (Anat.)\n\nDefn: A ligament, of fascia, extending, in most mammals, from the\nventral side of the ilium to near the symphysis of the pubic bones."
     ],
     "references": [
-      "INTERCOLUMNAR",
-      "POUPART'S LIGAMENT"
+      "INTERCOLUMNAR"
     ]
   },
   {
@@ -112866,9 +112616,7 @@
     "variants": [
       "POU STO\nPou sto (poo sto; pou sto). [Gr. poy^ stw^ where I may stand; -- from\nthe reputed saying of Archimedes, \"Give me where I may stand and I\nwill move the whole world with my steelyard.\"]\n\nDefn: A place to stand upon; a locus standi; hence, a foundation or\nbasis for operations."
     ],
-    "references": [
-      "POU STO"
-    ]
+    "references": []
   },
   {
     "spellings": "POUT",
@@ -115398,9 +115146,7 @@
     "variants": [
       "POY NETTE\nPoy nette\", n. Etym: [Cf. Point.]\n\nDefn: A bodkin. [Obs.]"
     ],
-    "references": [
-      "POY NETTE"
-    ]
+    "references": []
   },
   {
     "spellings": "POYNTEL",
@@ -116924,9 +116670,7 @@
     "variants": [
       "PRAIRIE STATE\nPrai\"rie State.\n\nDefn: Illinois; -- a nickname."
     ],
-    "references": [
-      "PRAIRIE STATE"
-    ]
+    "references": []
   },
   {
     "spellings": "PRAISABLE",
@@ -121282,9 +121026,7 @@
     "variants": [
       "PREFERENTIAL VOTING\nPreferential voting. (Political Science)\n\nDefn: A system of voting, as at primaries, in which the voters are\nallowed to indicate on their ballots their preference (usually their\nfirst and second choices) between two or more candidates for an\noffice, so that if no candidate receives a majority of first choices\nthe one receiving the greatest number of first and second choices\ntogether in nominated or elected."
     ],
-    "references": [
-      "PREFERENTIAL VOTING"
-    ]
+    "references": []
   },
   {
     "spellings": "PREFERMENT",
@@ -125917,8 +125659,7 @@
     "references": [
       "DISCOUNT",
       "GLOSSIC",
-      "INCREMENT",
-      "PRESENT VALUE; PRESENT WORTH"
+      "INCREMENT"
     ]
   },
   {
@@ -126689,9 +126430,7 @@
     "variants": [
       "PRESS CAKE\nPress cake.\n\nDefn: A cake of compressed substance, as: in gunpowder manufacture,\nthe cake resulting from compressing the meal powder; in the treatment\nof coal tar, the pressed product at various stages of the process;\nor, in beet-sugar manufacture, the vegetable residue after the sugar\njuice has been expressed."
     ],
-    "references": [
-      "PRESS CAKE"
-    ]
+    "references": []
   },
   {
     "spellings": "PRESSER",
@@ -126865,18 +126604,14 @@
     "variants": [
       "PRESS PROOF\nPress proof. (Print.)\n (a) The last proof for correction before sending to press.\n (b) A proof taken on a press, esp. to show impression, margins,\ncolor, etc."
     ],
-    "references": [
-      "PRESS PROOF"
-    ]
+    "references": []
   },
   {
     "spellings": "PRESS REVISE",
     "variants": [
       "PRESS REVISE\nPress revise. (Print.)\n\nDefn: A proof for final revision."
     ],
-    "references": [
-      "PRESS REVISE"
-    ]
+    "references": []
   },
   {
     "spellings": "PRESSURAGE",
@@ -127235,9 +126970,7 @@
     "variants": [
       "PRESSURE WIRES\nPressure wires. (Elec.)\n\nDefn: Wires leading from various points of an electric system to a\ncentral station, where a voltmeter indicates the potential of the\nsystem at those points."
     ],
-    "references": [
-      "PRESSURE WIRES"
-    ]
+    "references": []
   },
   {
     "spellings": "PRESSWORK",
@@ -127254,9 +126987,7 @@
     "variants": [
       "PRESS WORK\nPress\"work`, n.\n\n5.  Usually Press work. The work of a press agent. [Chiefly Theat.\nCant]"
     ],
-    "references": [
-      "PRESS WORK"
-    ]
+    "references": []
   },
   {
     "spellings": "PREST",
@@ -130956,8 +130687,7 @@
       "PRIMA DONNA\nPri\"ma don\"na; pl. E. Prima donnas, It. Prime Donne. Etym: [It., fr.\nprimo, prima, the first + donna lady, mistress. See Prime, a., and\nDonna.]\n\nDefn: The first or chief female singer in an opera."
     ],
     "references": [
-      "DIVA",
-      "PRIMA DONNA"
+      "DIVA"
     ]
   },
   {
@@ -130965,9 +130695,7 @@
     "variants": [
       "PRIMA FACIE\nPri\"ma fa\"ci*e. Etym: [L., from abl. of primus first + abl. of facies\nappearance.]\n\nDefn: At first view; on the first appearance. Prima facie evidence\n(of a fact) (Law), evidence which is sufficient to establish the fact\nunless rebutted. Bouvier."
     ],
-    "references": [
-      "PRIMA FACIE"
-    ]
+    "references": []
   },
   {
     "spellings": "PRIMAGE",
@@ -131811,9 +131539,7 @@
     "variants": [
       "PRIMROSE LEAGUE\nPrim\"rose` League. (Eng. Politics)\n\nDefn: A league of both sexes among the Conservatives, founded in\n1883. So called because primrose was (erroneously, it is said) taken\nto be the favorite flower of the Conservative statesman Benjamin\nDisraeli, Earl of Beaconsfield."
     ],
-    "references": [
-      "PRIMROSE LEAGUE"
-    ]
+    "references": []
   },
   {
     "spellings": "PRIMULA",
@@ -131843,8 +131569,7 @@
     ],
     "references": [
       "CRYSTALLINE",
-      "DODECATEMORY",
-      "PRIMUM MOBILE"
+      "DODECATEMORY"
     ]
   },
   {
@@ -133541,7 +133266,6 @@
       "LOGOGRAPHY",
       "PRINTER",
       "PRINTING",
-      "PRINTING IN",
       "RAISE",
       "STEREOTYPE",
       "STOP",
@@ -133553,9 +133277,7 @@
     "variants": [
       "PRINTING OUT\nPrinting out. (Photog.)\n\nDefn: A method of printing, in which the image is fully brought out\nby the direct actinic action of light without subsequent development\nby means of chemicals."
     ],
-    "references": [
-      "PRINTING OUT"
-    ]
+    "references": []
   },
   {
     "spellings": "PRINTLESS",
@@ -134246,9 +133968,7 @@
     "variants": [
       "PRISM GLASS\nPrism glass.\n\nDefn: Glass with one side smooth and the other side formed into\nsharp-edged ridges so as to reflect the light that passes through,\nused at windows to throw the light into the interior."
     ],
-    "references": [
-      "PRISM GLASS"
-    ]
+    "references": []
   },
   {
     "spellings": "PRISMOID",
@@ -139271,18 +138991,14 @@
     "variants": [
       "PROCESS PLATE\nProc\"ess plate.\n (a) A plate prepared by a mechanical process, esp. a photomechanical\nprocess.\n (b) A very slow photographic plate, giving good contrasts between\nhigh lights and shadows, used esp. for making lantern slides."
     ],
-    "references": [
-      "PROCESS PLATE"
-    ]
+    "references": []
   },
   {
     "spellings": "PROCES VERBAL",
     "variants": [
       "PROCES VERBAL\nPro`cès\" ver`bal\". Etym: [ F.] (French Law)\n\nDefn: An authentic minute of an official act, or statement of facts."
     ],
-    "references": [
-      "PROCES VERBAL"
-    ]
+    "references": []
   },
   {
     "spellings": "PROCHEIN",
@@ -140816,9 +140532,7 @@
     "variants": [
       "PRODUCE RACE\nProd\"uce race. (Horse Racing)\n\nDefn: A race to be run by the produce of horses named or described at\nthe time of entry."
     ],
-    "references": [
-      "PRODUCE RACE"
-    ]
+    "references": []
   },
   {
     "spellings": "PRODUCER'S GOODS",
@@ -140826,8 +140540,7 @@
       "PRODUCER'S GOODS\nPro*duc\"er's goods. (Polit. Econ.)\n\nDefn: Goods that satisfy wants only indirectly as factors in the\nproduction of other goods, such as tools and raw material; -- called\nalso instrumental goods, auxiliary goods, intermediate goods, or\ngoods of the second and higher orders, and disting. from consumers'\ngoods."
     ],
     "references": [
-      "CONSUMER'S GOODS",
-      "PRODUCER'S GOODS"
+      "CONSUMER'S GOODS"
     ]
   },
   {
@@ -140835,9 +140548,7 @@
     "variants": [
       "PRODUCER'S SURPLUS; PRODUCER'S RENT\nProducer's surplus. (Polit. Econ.)\n\nDefn: Any profit above the normal rate of interest and wages accruing\nto a producer on account of some monopoly (temporary or permanent) of\nthe means or materials of production; -- called also Producer's rent."
     ],
-    "references": [
-      "PRODUCER'S SURPLUS; PRODUCER'S RENT"
-    ]
+    "references": []
   },
   {
     "spellings": "PRODUCIBILITY",
@@ -143081,7 +142792,6 @@
     ],
     "references": [
       "BULL MOOSE",
-      "PROGRESSIVE PARTY",
       "TORY"
     ]
   },
@@ -149947,7 +149657,6 @@
       "MUTUAL",
       "POOL",
       "PRO",
-      "PRO RATA",
       "PRORATE"
     ]
   },
@@ -152267,9 +151976,7 @@
     "variants": [
       "PRO THYALOSOMA\nPro* thy`a*lo*so\"ma, n.; pl. Prothyalosomata. Etym: [NL., fr. Gr.\n(Biol.)\n\nDefn: The investing portion, or spherical envelope, surrounding the\neccentric germinal spot of the germinal vesicle."
     ],
-    "references": [
-      "PRO THYALOSOMA"
-    ]
+    "references": []
   },
   {
     "spellings": "PROTHYALOSOME",
@@ -153614,8 +153321,7 @@
       "PROVENCE ROSE\nProv\"ence rose`. Etym: [Provence the place + rose.]\n(a) The cabbage rose (Rosa centifolia).\n(b) A name of many kinds of roses which are hybrids of Rosa\ncentifolia and R. Gallica."
     ],
     "references": [
-      "MOSS",
-      "PROVENCE ROSE"
+      "MOSS"
     ]
   },
   {
@@ -158337,9 +158043,7 @@
     "variants": [
       "PUBLICITY PAMPHLET\nPublicity pamphlet.\n\nDefn: A pamphlet which, in some States of the United States having\nthe initiative or referendum, is mailed to the voters to inform them\nas to the nature of a measure submitted by the initiative or\nreferendum. The pamphlet contains a copy of the proposed law and\narguments for and against it by those favoring and opposing it,\nrespectively."
     ],
-    "references": [
-      "PUBLICITY PAMPHLET"
-    ]
+    "references": []
   },
   {
     "spellings": "PUBLICLY",
@@ -158428,7 +158132,6 @@
       "DISTRICT",
       "FREE",
       "PRESENT",
-      "PUBLIC SCHOOL",
       "RECTOR",
       "REMOVE",
       "SCHOOL"
@@ -158439,9 +158142,7 @@
     "variants": [
       "PUBLIC-SERVICE CORPORATION; QUASI-PUBLIC CORPORATION\nPublic-service corporation or sometimes Quasi-public corporation.\n\nDefn: A corporation, such as a railroad company, lighting company,\nwater company, etc., organized or chartered to follow a public\ncalling or to render services more or less essential to the general\npublic convenience or safety."
     ],
-    "references": [
-      "PUBLIC-SERVICE CORPORATION; QUASI-PUBLIC CORPORATION"
-    ]
+    "references": []
   },
   {
     "spellings": "PUBLIC-SPIRITED",
@@ -158786,9 +158487,7 @@
     "variants": [
       "PUDDING FISH; PUDDING WIFE\nPud\"ding fish, Pudding wife. [Prob. corrupted fr. the Sp. name in\nCuba, pudiano verde.] (Zoöl.)\n\nDefn: A large, handsomely colored, blue and bronze, labroid fish\n(Iridio, syn. Platyglossus, radiatus) of Florida, Bermuda, and the\nWest Indies. Called also pudiano, doncella, and, at Bermuda,\nbluefish."
     ],
-    "references": [
-      "PUDDING FISH; PUDDING WIFE"
-    ]
+    "references": []
   },
   {
     "spellings": "PUDDING-HEADED",
@@ -159436,7 +159135,6 @@
     ],
     "references": [
       "KING CHARLES SPANIEL",
-      "PUG NOSE",
       "RETROUSSE"
     ]
   },
@@ -159926,8 +159624,7 @@
       "PULLMAN CAR\nPull\"man car`. Etym: [Named after Mr. Pullman, who introduced them.]\n\nDefn: A kind of sleeping car; also, a palace car; -- often shortened\nto Pullman."
     ],
     "references": [
-      "CAR",
-      "PULLMAN CAR"
+      "CAR"
     ]
   },
   {
@@ -160837,9 +160534,7 @@
     "variants": [
       "PUMICE STONE\nPum\"ice stone`.\n\nDefn: Same as Pumice."
     ],
-    "references": [
-      "PUMICE STONE"
-    ]
+    "references": []
   },
   {
     "spellings": "PUMICIFORM",
@@ -162736,9 +162431,7 @@
     "variants": [
       "PURBECK BEDS\nPur\"beck beds`. Etym: [So called from the Isle of Purbeck in\nEngland.] (Geol.)\n\nDefn: The strata of the Purbeck stone, or Purbeck limestone,\nbelonging to the Oölitic group. See the Chart of Geology."
     ],
-    "references": [
-      "PURBECK BEDS"
-    ]
+    "references": []
   },
   {
     "spellings": "PURBECK STONE",
@@ -162746,8 +162439,7 @@
       "PURBECK STONE\nPur\"beck stone`. (Geol.)\n\nDefn: A limestone from the Isle of Purbeck in England."
     ],
     "references": [
-      "PURBECK BEDS",
-      "PURBECK STONE"
+      "PURBECK BEDS"
     ]
   },
   {
@@ -163809,9 +163501,7 @@
     "variants": [
       "PURKINJE'S CELLS\nPur\"kin*je's cells`. Etym: [From J. E. Purkinje, their discoverer.]\n(Anat.)\n\nDefn: Large ganglion cells forming a layer near the surface of the\ncerebellum."
     ],
-    "references": [
-      "PURKINJE'S CELLS"
-    ]
+    "references": []
   },
   {
     "spellings": "PURL",
@@ -166029,9 +165719,7 @@
     "variants": [
       "PUSH BUTTON\nPush button. (Elec.)\n\nDefn: A simple device, resembling a button in form, so arranged that\npushing it closes an electric circuit, as of an electric bell."
     ],
-    "references": [
-      "PUSH BUTTON"
-    ]
+    "references": []
   },
   {
     "spellings": "PUSHER",
@@ -167901,7 +167589,6 @@
     ],
     "references": [
       "PUTT",
-      "PUTTING GREEN",
       "STYMIE; STIMY"
     ]
   },

--- a/output/wordDisplayData#Q-R.json
+++ b/output/wordDisplayData#Q-R.json
@@ -135,9 +135,7 @@
     "variants": [
       "QUACK GRASS\nQuack\" grass`. (Bot.)\n\nDefn: See Quitch grass."
     ],
-    "references": [
-      "QUACK GRASS"
-    ]
+    "references": []
   },
   {
     "spellings": "QUACKISH",
@@ -6074,8 +6072,7 @@
       "QUARTER ROUND\nQuar\"ter round`. (Arch.)\n\nDefn: An ovolo."
     ],
     "references": [
-      "FUSAROLE",
-      "QUARTER ROUND"
+      "FUSAROLE"
     ]
   },
   {
@@ -6358,8 +6355,7 @@
       "QUASI CORPORATION\nQua\"si cor`po*ra\"tion.\n\nDefn: A corporation consisting of a person or body of persons\ninvested with some of the qualities of an artificial person, though\nnot expressly incorporated, esp. the official of certain municipal\ndivisions such as counties, schools districts, and the towns of some\nStates of the United States, certain church officials, as a\nchurchwarden, etc."
     ],
     "references": [
-      "QUASI",
-      "QUASI CORPORATION"
+      "QUASI"
     ]
   },
   {
@@ -6736,9 +6732,7 @@
     "variants": [
       "QUEBEC GROUP\nQue*bec\" group`. (Geol.)\n\nDefn: The middle of the three groups into which the rocks of the\nCanadian period have been divided in the American Lower Silurian\nsystem. See the Chart of Geology."
     ],
-    "references": [
-      "QUEBEC GROUP"
-    ]
+    "references": []
   },
   {
     "spellings": "QUEBRACHO",
@@ -6994,9 +6988,7 @@
     "variants": [
       "QUEEN OLIVE\nQueen olive. [Cf. Sp. aceituna de la Reina olive of the Queen.]\n(Olive Trade)\n\nDefn: Properly, a kind of superior olive grown in the region of\nSeville, Spain. It is large size and oblong shape with a small but\nlong pit; it is cured when green, keeps well, and has a delicate\nflavor. Loosely, any olive of similar character."
     ],
-    "references": [
-      "QUEEN OLIVE"
-    ]
+    "references": []
   },
   {
     "spellings": "QUEEN-POST",
@@ -7022,18 +7014,14 @@
     "variants": [
       "QUEENSLAND NUT\nQueens\"land nut`. (Bot.)\n\nDefn: The nut of an Australian tree (Macadamia ternifolia). It is\nabout an inch in diameter, and contains a single round edible seed,\nor sometimes two hemispherical seeds. So called from Queensland in\nAustralia."
     ],
-    "references": [
-      "QUEENSLAND NUT"
-    ]
+    "references": []
   },
   {
     "spellings": "QUEEN TRUSS",
     "variants": [
       "QUEEN TRUSS\nQueen\" truss. (Arch.)\n\nDefn: A truss framed with queen-posts; a queen-post truss."
     ],
-    "references": [
-      "QUEEN TRUSS"
-    ]
+    "references": []
   },
   {
     "spellings": "QUEER",
@@ -7245,9 +7233,7 @@
     "variants": [
       "QUENOUILLE TRAINING\nQue*nouille train\"ing. Etym: [F. quenouille distaff.] (Hort.)\n\nDefn: A method of training trees or shrubs in the shape of a cone or\ndistaff by tying down the branches and pruning."
     ],
-    "references": [
-      "QUENOUILLE TRAINING"
-    ]
+    "references": []
   },
   {
     "spellings": "QUERCITANNIC",
@@ -8391,7 +8377,6 @@
     ],
     "references": [
       "QUICKBEAM",
-      "QUICKEN TREE",
       "WICKEN TREE"
     ]
   },
@@ -9199,7 +9184,6 @@
       "QUILLAIA BARK\nQuil*la\"ia bark`. (Bot.)\n\nDefn: The bark of a rosaceous tree (Quillaja Saponaria), native of\nChili. The bark is finely laminated, and very heavy with alkaline\nsubstances, and is used commonly by the Chilians instead of soap.\nAlso called soap bark."
     ],
     "references": [
-      "QUILLAIA BARK",
       "SOAP"
     ]
   },
@@ -9847,9 +9831,7 @@
     "variants": [
       "QUINQUE FOLIOLATE\nQuin`que fo\"li*o*late, a. (Bot.)\n\nDefn: Having five leaflets. Gray."
     ],
-    "references": [
-      "QUINQUE FOLIOLATE"
-    ]
+    "references": []
   },
   {
     "spellings": "QUINQUELITERAL",
@@ -10416,7 +10398,6 @@
       "QUICKENS",
       "QUICKEN TREE",
       "QUITCH",
-      "QUITCH GRASS",
       "SQUITCH GRASS",
       "TWITCH GRASS",
       "WITHVINE"
@@ -10720,9 +10701,7 @@
     "variants": [
       "QUI VIVE\nQui` vive\". Etym: [F., fr. qui who + vive, pres. subj. of vivre to\nlive.]\n\nDefn: The challenge of a French sentinel, or patrol; -- used like the\nEnglish challenge: \"Who comes there\" To be on the qui vive, to be on\nguard; to be watchful and alert, like a sentinel."
     ],
-    "references": [
-      "QUI VIVE"
-    ]
+    "references": []
   },
   {
     "spellings": "QUIXOTIC",
@@ -11160,9 +11139,7 @@
     "variants": [
       "QUO WARRANTO\nQuo\" war*ran\"to. Etym: [So called from the Law L. words quo warranto\n(by what authority), in the original Latin form of the writ. See\nWhich, and Warrant.] (Law)\n\nDefn: A writ brought before a proper tribunal, to inquire by what\nwarrant a person or a corporation acts, or exercises certain powers.\nBlackstone.\n\nNote: An information in the nature of a quo warranto is now common as\na substitute for the writ. Wharton."
     ],
-    "references": [
-      "QUO WARRANTO"
-    ]
+    "references": []
   },
   {
     "spellings": "QURAN",
@@ -13412,9 +13389,7 @@
     "variants": [
       "RACE SUICIDE\nRace suicide.\n\nDefn: The voluntary failure of the members of a race or people to\nhave a number of children sufficient to keep the birth rate equal to\nthe death rate."
     ],
-    "references": [
-      "RACE SUICIDE"
-    ]
+    "references": []
   },
   {
     "spellings": "RACH; RACHE",
@@ -13933,7 +13908,6 @@
       "RADIAL ENGINE\nRadial engine. (Mach.)\n\nDefn: An engine, usually an internal-combustion engine of a certain\ntype (the radial type) having several cylinders arranged radially\nlike the spokes of a complete wheel. The semiradial engine has\nradiating cylinders on only one side of the crank shaft."
     ],
     "references": [
-      "RADIAL ENGINE",
       "RADIANT ENGINE",
       "SEMIRADIAL ENGINE"
     ]
@@ -14038,9 +14012,7 @@
     "variants": [
       "RADIANT ENGINE\nRadiant engine. (Mach.)\n\nDefn: A semiradial engine. See Radial engine, above."
     ],
-    "references": [
-      "RADIANT ENGINE"
-    ]
+    "references": []
   },
   {
     "spellings": "RADIANTLY",
@@ -14952,7 +14924,6 @@
       "COORDINATE",
       "HYPERBOLIC; HYPERBOLICAL",
       "LITUUS",
-      "RADIUS VECTOR",
       "VECTOR"
     ]
   },
@@ -15034,9 +15005,7 @@
     "variants": [
       "RAFFIA PALM\nRaf\"fi*a palm.\n (a) A pinnate-leaved palm (Raphia ruffia) native of Madagascar, and\nof considerable economic importance on account of the strong fiber\n(raffia) obtained from its leafstalks.\n (b) The jupati palm."
     ],
-    "references": [
-      "RAFFIA PALM"
-    ]
+    "references": []
   },
   {
     "spellings": "RAFFINOSE",
@@ -15507,7 +15476,6 @@
     ],
     "references": [
       "RAGMAN",
-      "RAGMAN'S ROLL",
       "RIGMAROLE"
     ]
   },
@@ -17411,9 +17379,7 @@
     "variants": [
       "RAKU WARE\nRa\"ku ware`.\n\nDefn: A kind of earthenware made in Japan, resembling Satsuma ware,\nbut having a paler color."
     ],
-    "references": [
-      "RAKU WARE"
-    ]
+    "references": []
   },
   {
     "spellings": "RALE",
@@ -18546,9 +18512,7 @@
     "variants": [
       "RANDALL GRASS\nRan\"dall grass`. (Bot.)\n\nDefn: The meadow fescue (Festuca elatior). See under Grass."
     ],
-    "references": [
-      "RANDALL GRASS"
-    ]
+    "references": []
   },
   {
     "spellings": "RANDAN",
@@ -19603,8 +19567,7 @@
       "RANZ DES VACHES\nRanz\" des` vaches\". Etym: [F., the ranks or rows of cows, the name\nbeing given from the fact that the cattle, when answering the musical\ncall of their keeper, move towards him in a row, preceded by those\nwearing bells.]\n\nDefn: The name for numerous simple, but very irregular, melodies of\nthe Swiss mountaineers, blown on a long tube called the Alpine horn,\nand sometimes sung."
     ],
     "references": [
-      "ALPENHORN; ALPHORN",
-      "RANZ DES VACHES"
+      "ALPENHORN; ALPHORN"
     ]
   },
   {
@@ -20036,9 +19999,7 @@
     "variants": [
       "RAPID-FIRE MOUNT\nRapid-fire mount. (Ordnance)\n\nDefn: A mount permitting easy and quick elevation or depression and\ntraining of the gun, and fitting with a device for taking up the\nrecoil."
     ],
-    "references": [
-      "RAPID-FIRE MOUNT"
-    ]
+    "references": []
   },
   {
     "spellings": "RAPIDITY",
@@ -23819,7 +23780,6 @@
     "references": [
       "DARNEL",
       "GRASS",
-      "RAY GRASS",
       "RIE",
       "RYE"
     ]
@@ -26360,8 +26320,7 @@
       "REACTANCE COIL\nReactance coil (Elec.)\n\nDefn: A choking coil."
     ],
     "references": [
-      "CHOKING COIL",
-      "REACTANCE COIL"
+      "CHOKING COIL"
     ]
   },
   {
@@ -30863,9 +30822,7 @@
     "variants": [
       "RECEIVER'S CERTIFICATE\nRe*ceiv\"er's cer*tif\"i*cate.\n\nDefn: An acknowledgement of indebtedness made by a receiver under\norder of court to obtain funds for the preservation of the assets\nheld by him, as for operating a railroad. Receivers' certificates are\nordinarily a first lien on the assets, prior to that of bonds or\nother securities."
     ],
-    "references": [
-      "RECEIVER'S CERTIFICATE"
-    ]
+    "references": []
   },
   {
     "spellings": "RECEIVERSHIP",
@@ -36173,7 +36130,6 @@
     "references": [
       "ANCHORED",
       "RED",
-      "RED CROSS",
       "ROUGECROIX",
       "SAINT"
     ]
@@ -36422,9 +36378,7 @@
     "variants": [
       "RED DOG FLOUR; RED-DOG FLOUR\nRed dog, or Red`-dog\" flour.\n\nDefn: The lowest grade of flour in milling. It is dark and of little\nexpansive power, is secured largely from the germ or embryo and\nadjacent parts, and contains a relatively high percentage of protein.\nIt is chiefly useful as feed for farm animals."
     ],
-    "references": [
-      "RED DOG FLOUR; RED-DOG FLOUR"
-    ]
+    "references": []
   },
   {
     "spellings": "REDDOUR",
@@ -37003,9 +36957,7 @@
     "variants": [
       "RED-LIGHT DISTRICT\nRed-light district.\n\nDefn: A district or neighborhood in which disorderly resorts are\nfrequent; -- so called in allusion to the red light kept in front of\nmany such resorts at night. [Colloq. or Cant]"
     ],
-    "references": [
-      "RED-LIGHT DISTRICT"
-    ]
+    "references": []
   },
   {
     "spellings": "REDLY",
@@ -38593,9 +38545,7 @@
     "variants": [
       "REENFORCED CONCRETE\nReënforced concrete.\n\nDefn: Concrete having within its mass a system of strengthening iron\nor steel supports. = Ferro-concrete."
     ],
-    "references": [
-      "REENFORCED CONCRETE"
-    ]
+    "references": []
   },
   {
     "spellings": "REENFORCEMENT",
@@ -42492,9 +42442,7 @@
     "variants": [
       "REGENT DIAMOND\nRe\"gent di\"a*mond.\n\nDefn: A famous diamond of fine quality, which weighs about 137 carats\nand is among the state jewels of France. It is so called from the\nDuke of Orleans, Regent of France, to whom it was sold in 1717 by\nPitt the English Governor of Madras (whence also called the Pitt\ndiamond), who bought it of an Indian merchant in 1701."
     ],
-    "references": [
-      "REGENT DIAMOND"
-    ]
+    "references": []
   },
   {
     "spellings": "REGENTESS",
@@ -45308,18 +45256,14 @@
     "variants": [
       "REIS EFFENDI\nReis` Ef*fen\"di (rs` f*fn\"d). Etym: [See 2d Reis, and Effendi.]\n\nDefn: A title formerly given to one of the chief Turkish officers of\nstate. He was chancellor of the empire, etc."
     ],
-    "references": [
-      "REIS EFFENDI"
-    ]
+    "references": []
   },
   {
     "spellings": "REISSNER'S MEMBRANE",
     "variants": [
       "REISSNER'S MEMBRANE\nReiss\"ner's mem\"brane (rs\"nrz mm\"brn). Etym: [Named from E. Reissner,\nA German anatomist.] (Anat.)\n\nDefn: The thin membrane which separates the canal of the cochlea from\nthe vestibular scala in the internal ear."
     ],
-    "references": [
-      "REISSNER'S MEMBRANE"
-    ]
+    "references": []
   },
   {
     "spellings": "REISSUABLE",
@@ -47378,18 +47322,14 @@
     "variants": [
       "RELAY CYLINDER\nRelay cylinder.\n\nDefn: In a variable expansion central-valve engine, a small auxiliary\nengine for automatically adjusting the steam distribution to the load\non the main engine.\n[Webster 1913 Suppl.]"
     ],
-    "references": [
-      "RELAY CYLINDER"
-    ]
+    "references": []
   },
   {
     "spellings": "RELAY GOVERNOR",
     "variants": [
       "RELAY GOVERNOR\nRelay governor.\n\nDefn: A speed regulator, as a water-wheel governor, embodying the\nrelay principle.\n[Webster 1913 Suppl.]"
     ],
-    "references": [
-      "RELAY GOVERNOR"
-    ]
+    "references": []
   },
   {
     "spellings": "RELBUN",
@@ -49988,7 +49928,6 @@
       "RACY",
       "REGARD",
       "REMARK",
-      "REMARQUE; REMARK; REMARQUE PROOF",
       "RETORT",
       "SAGACIOUS",
       "SARCASM",
@@ -59606,8 +59545,7 @@
       "RESERVE CITY\nReserve city. (Banking)\n\nDefn: In the national banking system of the United States, any of\ncertain cities in which the national banks are required (U. S. Rev.\nStat. sec. 5191) to keep a larger reserve (25 per cent) than the\nminimum (15 per cent) required of all other banks. The banks in\ncertain of the reserve cities (specifically called central reserve\ncities) are required to keep their reserve on hand in cash; banks in\nother reserve cities may keep half of their reserve as deposits in\nthese banks (U. S. Rev. Stat. sec. 5195)."
     ],
     "references": [
-      "COUNTRY BANK",
-      "RESERVE CITY"
+      "COUNTRY BANK"
     ]
   },
   {
@@ -60299,7 +60237,6 @@
       "RE SIGN\nRe sign\", n.\n\nDefn: Resignation. [Obs.] Beau & Fl."
     ],
     "references": [
-      "RE SIGN",
       "SIGNATURE",
       "SIGNIFICANT",
       "SPARK"
@@ -60917,9 +60854,7 @@
     "variants": [
       "RESISTANCE FRAME\nRe*sist\"ance frame`. (Elec.)\n\nDefn: A rheostat consisting of an open frame on which are stretched\nspirals of wire. Being freely exposed to the air, they radiate heat\nrapidly."
     ],
-    "references": [
-      "RESISTANCE FRAME"
-    ]
+    "references": []
   },
   {
     "spellings": "RESISTANT",
@@ -63394,9 +63329,7 @@
     "variants": [
       "REST CURE\nRest cure. (Med.)\n\nDefn: Treatment of severe nervous disorder, as neurasthenia, by rest\nand isolation with systematic feeding and the use of massage and\nelectricity."
     ],
-    "references": [
-      "REST CURE"
-    ]
+    "references": []
   },
   {
     "spellings": "RESTEM",
@@ -70085,7 +70018,6 @@
       "REWEL BONE\nRew\"el bone`. Etym: [Perh. from F. rouelle, dim. of roue a wheel, L.\nrota.]\n\nDefn: An obsolete phrase of disputed meaning, -- perhaps, smooth or\npolished bone.\nHis saddle was of rewel boon. Chaucer."
     ],
     "references": [
-      "REWEL BONE",
       "ROWEL BONE",
       "RUELL BONE"
     ]
@@ -71795,9 +71727,7 @@
     "variants": [
       "RHOMB SPAR\nRhomb\" spar`. (Min.)\n\nDefn: A variety of dolomite."
     ],
-    "references": [
-      "RHOMB SPAR"
-    ]
+    "references": []
   },
   {
     "spellings": "RHOMBUS",
@@ -74397,7 +74327,6 @@
       "RIGA FIR\nRi\"ga fir` Etym: [So called from Riga, a city in Russia.] (Bot.)\n\nDefn: A species of pine (Pinus sylvestris), and its wood, which\naffords a valuable timber; -- called also Scotch pine, and red or\nyellow deal. It grows in all parts of Europe, in the Caucasus, and in\nSiberia."
     ],
     "references": [
-      "RIGA FIR",
       "SCOTCH"
     ]
   },
@@ -76013,7 +75942,6 @@
       "MYSIS",
       "MYSTICETE",
       "POLAR",
-      "RIGHT WHALE",
       "SCRAG",
       "WHALE",
       "WHALEBONE"
@@ -76531,9 +76459,7 @@
     "variants": [
       "RIMAU DAHAN\nRi\"mau da\"han. Etym: [From the native Oriental name.] (Zoöl.)\n\nDefn: The clouded tiger cat (Felis marmorata) of Southern Asia and\nthe East Indies."
     ],
-    "references": [
-      "RIMAU DAHAN"
-    ]
+    "references": []
   },
   {
     "spellings": "RIMBASE",
@@ -77054,9 +76980,7 @@
     "variants": [
       "RING ARMATURE\nRing armature. (Elec.)\n\nDefn: An armature for a dynamo or motor having the conductors wound\non a ring."
     ],
-    "references": [
-      "RING ARMATURE"
-    ]
+    "references": []
   },
   {
     "spellings": "RINGBILL",
@@ -77338,8 +77262,7 @@
       "RING WINDING\nRing winding. (Elec.)\n\nDefn: Armature winding in which the wire is wound round the outer and\ninner surfaces alternately of an annular or cylindrical core."
     ],
     "references": [
-      "DRUM WINDING",
-      "RING WINDING"
+      "DRUM WINDING"
     ]
   },
   {
@@ -77576,7 +77499,6 @@
       "RIP CORD\nRip cord. (Aëronautics)\n\nDefn: A cord by which the gas bag of a balloon may be ripped open for\na limited distance to release the gas quickly and so cause immediate\ndescent."
     ],
     "references": [
-      "RIP CORD",
       "RIPPING CORD",
       "RIPPING PANEL"
     ]
@@ -77773,18 +77695,14 @@
     "variants": [
       "RIPPER ACT; RIPPER BILL\nRip\"per act or bill.\n\nDefn: An act or a bill conferring upon a chief executive, as a\ngovernor or mayor, large powers of appointment and removal of heads\nof departments or other subordinate officials. [Polit. Cant, U. S.]"
     ],
-    "references": [
-      "RIPPER ACT; RIPPER BILL"
-    ]
+    "references": []
   },
   {
     "spellings": "RIPPING CORD",
     "variants": [
       "RIPPING CORD\nRip\"ping cord. (Aëronautics)\n\nDefn: = Rip cord."
     ],
-    "references": [
-      "RIPPING CORD"
-    ]
+    "references": []
   },
   {
     "spellings": "RIPPING PANEL",
@@ -77792,7 +77710,6 @@
       "RIPPING PANEL\nRipping panel. (Aëronautics)\n\nDefn: A long patch, on a balloon, to be ripped off, by the rip cord,\nat landing, in order to allow the immediate escape of gas and instant\ndeflation of the bag."
     ],
     "references": [
-      "RIPPING PANEL",
       "RIPPING STRIP"
     ]
   },
@@ -77801,9 +77718,7 @@
     "variants": [
       "RIPPING STRIP\nRipping strip.\n\nDefn: = Ripping panel."
     ],
-    "references": [
-      "RIPPING STRIP"
-    ]
+    "references": []
   },
   {
     "spellings": "RIPPLE",
@@ -79991,8 +79906,7 @@
       "ROARING FORTIES\nRoar\"ing for\"ties. (Naut.)\n\nDefn: The middle latitudes of the southern hemisphere. So called from\nthe boisterous and prevailing westerly winds, which are especially\nstrong in the South Indian Ocean up to 50º S."
     ],
     "references": [
-      "ROAR",
-      "ROARING FORTIES"
+      "ROAR"
     ]
   },
   {
@@ -80466,8 +80380,7 @@
       "HOB",
       "HOBGOBLIN",
       "KOBOLD",
-      "PUCK",
-      "ROBIN GOODFELLOW"
+      "PUCK"
     ]
   },
   {
@@ -80637,7 +80550,6 @@
       "ROCHE ALUM\nRoche\" al`um. (Chem.)\n\nDefn: A kind of alum occuring in small fragments; -- so called from\nRocca, in Syria, whence alum is said to have been obtained; -- also\ncalled rock alum."
     ],
     "references": [
-      "ROCHE ALUM",
       "ROCK"
     ]
   },
@@ -80663,9 +80575,7 @@
     "variants": [
       "ROCHE MOUTONNEE\nRoche\" mou`ton`née\". Etym: [F., sheep-shaped rock.] (Geol.)\n\nDefn: See Sheepback."
     ],
-    "references": [
-      "ROCHE MOUTONNEE"
-    ]
+    "references": []
   },
   {
     "spellings": "ROCHET",
@@ -80683,9 +80593,7 @@
     "variants": [
       "ROCHING CASK\nRoch\"ing cask`. Etym: [Probably from F. roche a rock.]\n\nDefn: A tank in which alum is crystallized from a solution."
     ],
-    "references": [
-      "ROCHING CASK"
-    ]
+    "references": []
   },
   {
     "spellings": "ROCK",
@@ -81298,7 +81206,6 @@
       "LIFTING",
       "ROCKER",
       "ROCKING",
-      "ROCK SHAFT",
       "WAY SHAFT",
       "WIPER"
     ]
@@ -81308,9 +81215,7 @@
     "variants": [
       "ROCK STAFF\nRock\" staff`. Etym: [Cf. Rock, v. i.]\n\nDefn: An oscillating bar in a machine, as the lever of the bellows of\na forge."
     ],
-    "references": [
-      "ROCK STAFF"
-    ]
+    "references": []
   },
   {
     "spellings": "ROCKSUCKER",
@@ -81952,9 +81857,7 @@
     "variants": [
       "ROE, RICHARD\nRoe, Richard. (Law)\n\nDefn: A fictious name for a party, real or fictious, to an act or\nproceeding. Other names were formerly similarly used, as John-a-\nNokes, John o', or of the, Nokes, or Noakes, John-a-Stiles, etc."
     ],
-    "references": [
-      "ROE, RICHARD"
-    ]
+    "references": []
   },
   {
     "spellings": "ROESTONE",
@@ -82547,18 +82450,14 @@
     "variants": [
       "ROLLER BEARING\nRoll\"er bear\"ing. (Mach.)\n\nDefn: A bearing containing friction rollers."
     ],
-    "references": [
-      "ROLLER BEARING"
-    ]
+    "references": []
   },
   {
     "spellings": "ROLLER COASTER",
     "variants": [
       "ROLLER COASTER\nRoller coaster.\n\nDefn: An amusement railroad in which cars coast by gravity over a\nlong winding track, with steep pitches and ascents."
     ],
-    "references": [
-      "ROLLER COASTER"
-    ]
+    "references": []
   },
   {
     "spellings": "ROLLEY",
@@ -83177,8 +83076,7 @@
       "CALENDS",
       "FASTI",
       "FEBRUARY",
-      "JULY",
-      "ROMAN CALENDAR"
+      "JULY"
     ]
   },
   {
@@ -83459,8 +83357,7 @@
       "ROME PENNY; ROME SCOT\nRome\" pen`ny, or; Rome\" scot`.\n\nDefn: See Peter pence, under Peter."
     ],
     "references": [
-      "PETER",
-      "ROME PENNY; ROME SCOT"
+      "PETER"
     ]
   },
   {
@@ -83719,9 +83616,7 @@
     "variants": [
       "RONTGEN RAY\nRöntgen ray. (Physics)\n\nDefn: Any of the rays produced when cathode rays strike upon surface\nof a solid (as the wall of the vacuum tube). Röntgen rays are noted\nfor their penetration of many opaque substances, as wood and flesh,\ntheir action on photographic plates, and their fluorescent effects.\nThey were called X rays by their discoverer, W. K. Röntgen. They also\nionize gases, but cannot be reflected, or polarized, or deflected by\na magnetic field. They are regarded as nonperiodic, transverse pulses\nin the ether. They are used in examining opaque objects, as for\nlocating fractures or bullets in the human body."
     ],
-    "references": [
-      "RONTGEN RAY"
-    ]
+    "references": []
   },
   {
     "spellings": "ROOD",
@@ -84620,9 +84515,7 @@
     "variants": [
       "ROOSA OIL\nRoo\"sa oil`.\n\nDefn: The East Indian name for grass oil. See under Grass."
     ],
-    "references": [
-      "ROOSA OIL"
-    ]
+    "references": []
   },
   {
     "spellings": "ROOST",
@@ -86087,9 +85980,7 @@
     "variants": [
       "ROQUEFORT CHEESE; ROQUEFORT\nRoque`fort\" cheese, or Roque`fort\", n.\n\nDefn: A highly flavored blue-molded cheese, made at Roquefort,\ndepartment of Aveyron, France. It is made from milk of ewes,\nsometimes with cow's milk added, and is cured in caves. Improperly, a\ncheese made in imitation of it."
     ],
-    "references": [
-      "ROQUEFORT CHEESE; ROQUEFORT"
-    ]
+    "references": []
   },
   {
     "spellings": "ROQUELAURE",
@@ -86678,9 +86569,7 @@
     "variants": [
       "ROSENMULLER'S ORGAN; ROSENMUELLER'S ORGAN\nRo\"sen*mül`ler's or\"gan.\n\nDefn: [So named from its first describer, J. C. Rosenmüller, a German\nanatomist.] (Anat.) The parovarium."
     ],
-    "references": [
-      "ROSENMULLER'S ORGAN; ROSENMUELLER'S ORGAN"
-    ]
+    "references": []
   },
   {
     "spellings": "ROSEO-",
@@ -86773,7 +86662,6 @@
       "ROSETTA STONE\nRo*set\"ta stone`.\n\nDefn: A stone found at Rosetta, in Egypt, bearing a trilingual\ninscription, by aid of which, with other inscriptions, a key was\nobtained to the hieroglyphics of ancient Egypt. Brande & C."
     ],
     "references": [
-      "ROSETTA STONE",
       "TRILINGUAL"
     ]
   },
@@ -86782,9 +86670,7 @@
     "variants": [
       "ROSETTA WOOD\nRo*set\"ta wood`.\n\nDefn: An east Indian wood of a reddish orange color, handsomely\nveined with darker marks. It is occasionally used for cabinetwork.\nUre."
     ],
-    "references": [
-      "ROSETTA WOOD"
-    ]
+    "references": []
   },
   {
     "spellings": "ROSETTE",
@@ -86809,7 +86695,6 @@
     ],
     "references": [
       "JULEP",
-      "ROSE WATER",
       "ROSE-WATER",
       "TANSY"
     ]
@@ -86978,9 +86863,7 @@
       "ROSSEL CURRENT\nRos\"sel cur`rent. [From Rossel Island, in the Louisiade Archipelago.]\n(Oceanography)\n\nDefn: A portion of the southern equatorial current flowing westward\nfrom the Fiji Islands to New Guinea.",
       "ROSSEL CURRENT\nRos\"sel cur`rent. [From Rossel Island, in the Louisiade Archipelago.]\n(Oceanography)\n\nDefn: A portion of the southern equatorial current flowing westward\nfrom the Fiji Islands to New Guinea.\n[Webster 1913 Suppl.]"
     ],
-    "references": [
-      "ROSSEL CURRENT"
-    ]
+    "references": []
   },
   {
     "spellings": "ROSSELLY",
@@ -87884,9 +87767,7 @@
     "variants": [
       "ROUGE DRAGON\nRouge\" drag`on, n. Etym: [F., literally, red dragon.] (Her.)\n\nDefn: One of the four pursuivants of the English college of arms."
     ],
-    "references": [
-      "ROUGE DRAGON"
-    ]
+    "references": []
   },
   {
     "spellings": "ROUGH",
@@ -89924,9 +89805,7 @@
     "variants": [
       "ROUT CAKE\nRout\" cake`.\n\nDefn: A kind of rich sweet cake made for routs, or evening parties.\n\nTwenty-four little rout cakes that were lying neglected in a plate.\nThackeray."
     ],
-    "references": [
-      "ROUT CAKE"
-    ]
+    "references": []
   },
   {
     "spellings": "ROUTE",
@@ -90377,7 +90256,6 @@
       "QUICKEN TREE",
       "ROAN",
       "ROWAN",
-      "ROWAN TREE",
       "SERVICE; SERVICE",
       "SORB",
       "SORBIC",
@@ -90479,9 +90357,7 @@
     "variants": [
       "ROWEL BONE\nRow\"el bone`.\n\nDefn: See rewel bone. [Obs.]"
     ],
-    "references": [
-      "ROWEL BONE"
-    ]
+    "references": []
   },
   {
     "spellings": "ROWEN",
@@ -90851,9 +90727,7 @@
     "variants": [
       "ROYAL SPADE\nRoyal spade. (Auction Bridge)\n\nDefn: A spade when spades are trumps under the condition that every\ntrick over six taken by the successful bidder has a score value of 9;\n-- usually in pl."
     ],
-    "references": [
-      "ROYAL SPADE"
-    ]
+    "references": []
   },
   {
     "spellings": "ROYALTY",
@@ -90916,8 +90790,7 @@
       "ROYSTON CROW\nRoys\"ton crow`. Etym: [So called from Royston, a town in England.]\n(Zoöl.)\n\nDefn: See Hooded crow, under Hooded."
     ],
     "references": [
-      "HOODED",
-      "ROYSTON CROW"
+      "HOODED"
     ]
   },
   {
@@ -91469,9 +91342,7 @@
     "variants": [
       "RU BIBLE\nRu\" bi*ble, n.\n\nDefn: A ribble. [Obs.] Chaucer."
     ],
-    "references": [
-      "RU BIBLE"
-    ]
+    "references": []
   },
   {
     "spellings": "RUBICAN",
@@ -92468,9 +92339,7 @@
     "variants": [
       "RUELL BONE\nRu\"ell bone`.\n\nDefn: See rewel bone. [Obs.]"
     ],
-    "references": [
-      "RUELL BONE"
-    ]
+    "references": []
   },
   {
     "spellings": "RUELLE",
@@ -92909,8 +92778,7 @@
     ],
     "references": [
       "COIL",
-      "INDUCTION",
-      "RUHMKORFF'S COIL"
+      "INDUCTION"
     ]
   },
   {
@@ -95038,9 +94906,7 @@
     "variants": [
       "RUNNING LOAD\nRun\"ning load. (Aëronautics)\n (a) The air pressure supported by each longitudinal foot segment of\na wing.\n (b) Commonly, the whole weight of aëroplane and load divided by the\nspan, or length from tip to tip."
     ],
-    "references": [
-      "RUNNING LOAD"
-    ]
+    "references": []
   },
   {
     "spellings": "RUNNINGLY",
@@ -95120,8 +94986,7 @@
       "RUPERT'S DROP\nRu\"pert's drop`.\n\nDefn: A kind of glass drop with a long tail, made by dropping melted\nglass into water. It is remarkable for bursting into fragments when\nthe surface is scratched or the tail broken; -- so called from Prince\nRupert, nephew of Charles I., by whom they were first brought to\nEngland. Called also Rupert's ball, and glass tear."
     ],
     "references": [
-      "GLASS",
-      "RUPERT'S DROP"
+      "GLASS"
     ]
   },
   {
@@ -95998,8 +95863,7 @@
       "RUSSIAN CHURCH\nRus\"sian Church.\n\nDefn: The established church of the Russian empire. It forms a\nportion, by far the largest, of the Eastern Church and is governed by\nthe Holy Synod. The czar is the head of the church, but he has never\nclaimed the right of deciding questions of theology and dogma."
     ],
     "references": [
-      "EASTERN CHURCH",
-      "RUSSIAN CHURCH"
+      "EASTERN CHURCH"
     ]
   },
   {

--- a/output/wordDisplayData#S.json
+++ b/output/wordDisplayData#S.json
@@ -1439,9 +1439,7 @@
     "variants": [
       "SABRINA WORK\nSa*bri\"na work`.\n\nDefn: A variety of appliqué work for quilts, table covers, etc.\nCaulfeild & S. (Dict. of Needlework)."
     ],
-    "references": [
-      "SABRINA WORK"
-    ]
+    "references": []
   },
   {
     "spellings": "SABULOSE",
@@ -3791,9 +3789,7 @@
     "variants": [
       "SAFETY BICYCLE\nSafety bicycle.\n\nDefn: A bicycle with equal or nearly equal wheels, usually 28 inches\ndiameter, driven by pedals connected to the rear (driving) wheel by a\nmultiplying gear."
     ],
-    "references": [
-      "SAFETY BICYCLE"
-    ]
+    "references": []
   },
   {
     "spellings": "SAFETY CHAIN",
@@ -3801,7 +3797,6 @@
       "SAFETY CHAIN\nSafety chain.\n (a) (Railroads) A normally slack chain for preventing excessive\nmovement between a truck and a car body in sluing.\n (b) An auxiliary watch chain, secured to the clothes, usually out of\nsight, to prevent stealing of the watch.\n (c) A chain of sheet metal links with an elongated hole through each\nbroad end, made up by doubling the first link on itself, slipping the\nnext link through and doubling, and so on."
     ],
     "references": [
-      "SAFETY CHAIN",
       "SIDE"
     ]
   },
@@ -4115,9 +4110,7 @@
     "variants": [
       "SAGEBRUSH STATE\nSagebrush State.\n\nDefn: Nevada; -- a nickname."
     ],
-    "references": [
-      "SAGEBRUSH STATE"
-    ]
+    "references": []
   },
   {
     "spellings": "SAGELY",
@@ -8285,8 +8278,7 @@
       "SALINA PERIOD\nSa*li\"na pe\"ri*od. Etym: [So called from Salina, a town in New York.]\n(Geol.)\n\nDefn: The period in which the American Upper Silurian system,\ncontaining the brine-producing rocks of central New York, was formed.\nSee the Chart of Geology."
     ],
     "references": [
-      "SALIFEROUS",
-      "SALINA PERIOD"
+      "SALIFEROUS"
     ]
   },
   {
@@ -8648,9 +8640,7 @@
     "variants": [
       "SALLY LUNN\nSal\"ly Lunn\". Etym: [From a woman, Sally Lunn, who is said to have\nfirst made the cakes, and sold them in the streets of Bath, Eng.]\n\nDefn: A tea cake slighty sweetened, and raised with yeast, baked in\nthe form of biscuits or in a thin loaf, and eaten hot with butter."
     ],
-    "references": [
-      "SALLY LUNN"
-    ]
+    "references": []
   },
   {
     "spellings": "SALLYMAN",
@@ -9852,8 +9842,7 @@
     ],
     "references": [
       "ECZEMA",
-      "RHEUM",
-      "SALT RHEUM"
+      "RHEUM"
     ]
   },
   {
@@ -14695,7 +14684,6 @@
       "SANCE-BELL; SANCTE BELL\nSance\"-bell\", Sanc\"te bell\", n.\n\nDefn: See Sanctus bell, under Sanctus."
     ],
     "references": [
-      "SANCE-BELL; SANCTE BELL",
       "SANCTUS"
     ]
   },
@@ -14714,8 +14702,7 @@
       "SANCHO PEDRO\nSancho pedro. [Sp. Pedro Peter.] (Card Playing)\n\nDefn: A variety of auction pitch in which the nine (sancho) and five\n(pedro) of trumps are added as counting cards at their pip value, and\nthe ten of trumps counts game."
     ],
     "references": [
-      "SANCHO",
-      "SANCHO PEDRO"
+      "SANCHO"
     ]
   },
   {
@@ -16161,9 +16148,7 @@
     "variants": [
       "SAN JOSE SCALE\nSan Jo*sé\" scale.\n\nDefn: A very destructive scale insect (Aspidiotus perniciosus) that\ninfests the apple, pear, and other fruit trees. So called because\nfirst introduced into the United States at San José, California."
     ],
-    "references": [
-      "SAN JOSE SCALE"
-    ]
+    "references": []
   },
   {
     "spellings": "SANK",
@@ -16590,7 +16575,6 @@
     ],
     "references": [
       "BRAZILIN",
-      "SAPAN WOOD",
       "SAPPAN WOOD"
     ]
   },
@@ -16932,8 +16916,7 @@
       "SAPPAN WOOD\nSap*pan\" wood\".\n\nDefn: Sapan wood."
     ],
     "references": [
-      "SAPAN WOOD",
-      "SAPPAN WOOD"
+      "SAPAN WOOD"
     ]
   },
   {
@@ -17973,7 +17956,6 @@
       "SARUM USE\nSa\"rum use`. (Ch. of Eng.)\n\nDefn: A liturgy, or use, put forth about 1087 by St. Osmund, bishop\nof Sarum, based on Anglo-Saxon and Norman customs."
     ],
     "references": [
-      "SARUM USE",
       "YORK USE"
     ]
   },
@@ -18122,8 +18104,7 @@
     ],
     "references": [
       "ERYTHROPHLEINE",
-      "MANCONA BARK",
-      "SASSY BARK"
+      "MANCONA BARK"
     ]
   },
   {
@@ -18555,9 +18536,7 @@
     "variants": [
       "SATIN WEAVE\nSat\"in weave.\n\nDefn: A style of weaving producing smooth-faced fabric in which the\nwarp interlaces with the filling at points distributed over the\nsurface."
     ],
-    "references": [
-      "SATIN WEAVE"
-    ]
+    "references": []
   },
   {
     "spellings": "SATINWOOD",
@@ -18997,8 +18976,7 @@
       "SATSUMA WARE\nSat\"su*ma ware\" ( or ). (Fine Arts)\n\nDefn: A kind of ornamental hard-glazed pottery made at Satsuma in\nKiushu, one of the Japanese islands."
     ],
     "references": [
-      "RAKU WARE",
-      "SATSUMA WARE"
+      "RAKU WARE"
     ]
   },
   {
@@ -19280,7 +19258,6 @@
       "SAUBA ANT\nSau\"ba ant`. (Zoöl.)\n\nDefn: A South American ant (Ecodoma cephalotes) remarkable for having\ntwo large kinds of workers besides the ordinary ones, and for the\nimmense size of its formicaries. The sauba ant cuts off leaves of\nplants and carries them into its subterranean nests, and thus often\ndoes great damage by defoliating trees and cultivated plants."
     ],
     "references": [
-      "SAUBA ANT",
       "UMBRELLA"
     ]
   },
@@ -20733,7 +20710,6 @@
       "SAWARRA NUT\nSa*war\"ra nut`.\n\nDefn: See Souari nut."
     ],
     "references": [
-      "SAWARRA NUT",
       "SOUARI NUT"
     ]
   },
@@ -20886,8 +20862,7 @@
       "SAW PALMETTO\nSaw\" pal*met\"to.\n\nDefn: See under Palmetto."
     ],
     "references": [
-      "PALMETTO",
-      "SAW PALMETTO"
+      "PALMETTO"
     ]
   },
   {
@@ -21201,8 +21176,7 @@
       "SAXONY YARN\nSaxony yarn.\n\nDefn: A fine grade of woolen yarn twisted somewhat harder and\nsmoother than zephyr yarn."
     ],
     "references": [
-      "SAXONY",
-      "SAXONY YARN"
+      "SAXONY"
     ]
   },
   {
@@ -21819,9 +21793,7 @@
     "variants": [
       "SCABBARD PLANE\nScab\"bard plane`.\n\nDefn: See Scaleboard plane, under Scaleboard."
     ],
-    "references": [
-      "SCABBARD PLANE"
-    ]
+    "references": []
   },
   {
     "spellings": "SCABBED",
@@ -23006,9 +22978,7 @@
     "variants": [
       "SCANDALUM MAGNATUM\nScan\"da*lum mag*na\"tum`. Etym: [L., scandal of magnates.] (Law)\n\nDefn: A defamatory speech or writing published to the injury of a\nperson of dignity; -- usually abbreviated scan. mag."
     ],
-    "references": [
-      "SCANDALUM MAGNATUM"
-    ]
+    "references": []
   },
   {
     "spellings": "SCANDENT",
@@ -25042,8 +25012,7 @@
     ],
     "references": [
       "GREEN",
-      "PARROT",
-      "SCHEELE'S GREEN"
+      "PARROT"
     ]
   },
   {
@@ -25742,9 +25711,7 @@
     "variants": [
       "SCHOHARIE GRIT\nScho*har\"ie grit`. (Geol.)\n\nDefn: The formation belonging to the middle of the three subdivisions\nof the Corniferous period in the American Devonian system; -- so\ncalled from Schoharie, in New York, where it occurs. See the Chart of\nGeology."
     ],
-    "references": [
-      "SCHOHARIE GRIT"
-    ]
+    "references": []
   },
   {
     "spellings": "SCHOLAR",
@@ -26460,7 +26427,6 @@
       "SCHWANN'S SHEATH\nSchwann's\" sheath`. Etym: [So called from Theodor Schwann, a German\nanatomist of the 19th century.] (Anat.)\n\nDefn: The neurilemma."
     ],
     "references": [
-      "SCHWANN'S SHEATH",
       "SHEATH"
     ]
   },
@@ -26469,9 +26435,7 @@
     "variants": [
       "SCHWANN'S WHITE SUBSTANCE\nSchwann's white\" sub\"stance. (Anat.)\n\nDefn: The substance of the medullary sheath."
     ],
-    "references": [
-      "SCHWANN'S WHITE SUBSTANCE"
-    ]
+    "references": []
   },
   {
     "spellings": "SCHWANPAN",
@@ -27661,9 +27625,7 @@
     "variants": [
       "SCIRE FACIAS\nSci`re fa\"ci*as. Etym: [L., do you cause to know.] (Law)\n\nDefn: A judicial writ, founded upon some record, and requiring the\nparty proceeded against to show cause why the party bringing it\nshould not have advantage of such record, or (as in the case of scire\nfacias to repeal letters patent) why the record should not be\nannulled or vacated. Wharton. Bouvier."
     ],
-    "references": [
-      "SCIRE FACIAS"
-    ]
+    "references": []
   },
   {
     "spellings": "SCIRRHOID",
@@ -28736,9 +28698,7 @@
     "variants": [
       "SCOPS OWL\nScops\" owl`. Etym: [NL. scops, fr. Gr. (Zoöl.)\n\nDefn: Any one of numerous species of small owls of the genus Scops\nhaving ear tufts like those of the horned owls, especially the\nEuropean scops owl (Scops giu), and the American screech owl. (S.\nAsio)."
     ],
-    "references": [
-      "SCOPS OWL"
-    ]
+    "references": []
   },
   {
     "spellings": "SCOPTIC; SCOPTICAL",
@@ -29744,9 +29704,7 @@
     "variants": [
       "SCOTCH RITE\nScotch rite. (Freemasonry)\n\nDefn: The ceremonial observed by one of the Masonic systems, called\nin full the Ancient and Accepted Scotch Rite; also, the system\nitself, which confers thirty-three degrees, of which the first three\nare nearly identical with those of the York rite."
     ],
-    "references": [
-      "SCOTCH RITE"
-    ]
+    "references": []
   },
   {
     "spellings": "SCOTCH TERRIER",
@@ -29754,7 +29712,6 @@
       "SCOTCH TERRIER\nScotch terrier. (Zoöl.)\n\nDefn: One of a breed of small terriers with long, rough hair."
     ],
     "references": [
-      "SCOTCH TERRIER",
       "SCOTTISH TERRIER"
     ]
   },
@@ -29972,9 +29929,7 @@
     "variants": [
       "SCOTTISH TERRIER\nScot\"tish ter\"ri*er. (Zoöl.)\n\nDefn: Same as Scotch terrier."
     ],
-    "references": [
-      "SCOTTISH TERRIER"
-    ]
+    "references": []
   },
   {
     "spellings": "SCOUNDREL",
@@ -30182,9 +30137,7 @@
     "variants": [
       "SCRABBED EGGS\nScrab\"bed eggs`. Etym: [CF. Scramble.]\n\nDefn: A Lenten dish, composed of eggs boiled hard, chopped, and\nseasoned with butter, salt, and pepper. Halliwell."
     ],
-    "references": [
-      "SCRABBED EGGS"
-    ]
+    "references": []
   },
   {
     "spellings": "SCRABBLE",
@@ -30318,9 +30271,7 @@
     "variants": [
       "SCRAMBLED EGGS\nScram\"bled eggs.\n\nDefn: Eggs of which the whites and yolks are stirred together while\ncooking, or eggs beaten slightly, often with a little milk, and\nstirred while cooking."
     ],
-    "references": [
-      "SCRAMBLED EGGS"
-    ]
+    "references": []
   },
   {
     "spellings": "SCRAMBLER",
@@ -30624,7 +30575,6 @@
     ],
     "references": [
       "PRICKING-UP",
-      "SCRATCH COAT",
       "SCRATCHWORK",
       "THREE-COAT"
     ]
@@ -30658,9 +30608,7 @@
     "variants": [
       "SCRATCH PLAYER; SCRATCH RUNNER\nScratch player, runner, etc.\n\nDefn: One that starts from the scratch; hence, one of first-rate\nability."
     ],
-    "references": [
-      "SCRATCH PLAYER; SCRATCH RUNNER"
-    ]
+    "references": []
   },
   {
     "spellings": "SCRATCHWEED",
@@ -31669,9 +31617,7 @@
     "variants": [
       "SCRODDLED WARE\nScrod\"dled ware`.\n\nDefn: Mottled pottery made from scraps of differently colored clays."
     ],
-    "references": [
-      "SCRODDLED WARE"
-    ]
+    "references": []
   },
   {
     "spellings": "SCROFULA",
@@ -32078,9 +32024,7 @@
     "variants": [
       "SCRUTIN DE LISTE\nScru`tin\" de liste\" (skrus`taN\" de lest). [F., voting by list.]\n\nDefn: Voting for a group of candidates for the same kind of office on\none ticket or ballot, containing a list of them; -- the method, used\nin France, as from June, 1885, to Feb., 1889, in elections for the\nChamber of Deputies, each elector voting for the candidates for the\nwhole department in which he lived, as disting. from scrutin\nd'arrondissement (da`rôN`des`mäN\"), or voting by each elector for the\ncandidate or candidates for his own arrondissement only."
     ],
-    "references": [
-      "SCRUTIN DE LISTE"
-    ]
+    "references": []
   },
   {
     "spellings": "SCRUTINEER",
@@ -32915,8 +32859,7 @@
       "SCUTCH GRASS\nScutch\" grass`. (Bot.)\n\nDefn: A kind of pasture grass (Cynodon Dactylon). See Bermuda grass:\nalso Illustration in Appendix."
     ],
     "references": [
-      "BERMUDA GRASS",
-      "SCUTCH GRASS"
+      "BERMUDA GRASS"
     ]
   },
   {
@@ -34505,8 +34448,7 @@
       "SEA ACORN\nSea\" a\"corn. (Zoöl.)\n\nDefn: An acorn barnacle (Balanus)."
     ],
     "references": [
-      "SEA",
-      "SEA ACORN"
+      "SEA"
     ]
   },
   {
@@ -34516,7 +34458,6 @@
     ],
     "references": [
       "ADDER",
-      "SEA ADDER",
       "TANGLEFISH"
     ]
   },
@@ -34528,8 +34469,7 @@
     "references": [
       "DRAG",
       "DRIFT",
-      "FLOATING",
-      "SEA ANCHOR"
+      "FLOATING"
     ]
   },
   {
@@ -34544,7 +34484,6 @@
       "ANEMONE",
       "ANIMAL",
       "DISK",
-      "SEA ANEMONE",
       "SEA FLOWER",
       "ZOOPHYTE; ZOOEPHYTE"
     ]
@@ -34555,7 +34494,6 @@
       "SEA APE\nSea\" ape`. (Zoöl.)\n(a) The thrasher shark.\n(b) The sea otter."
     ],
     "references": [
-      "SEA APE",
       "THRASHER; THRESHER"
     ]
   },
@@ -34566,8 +34504,7 @@
     ],
     "references": [
       "APPLE",
-      "DEAD",
-      "SEA APPLE"
+      "DEAD"
     ]
   },
   {
@@ -34575,9 +34512,7 @@
     "variants": [
       "SEA ARROW\nSea\" ar\"row. (Zoöl.)\n\nDefn: A squid of the genus Ommastrephes. See Squid."
     ],
-    "references": [
-      "SEA ARROW"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA BANK",
@@ -34585,8 +34520,7 @@
       "SEA BANK\nSea\" bank`.\n\n1. The seashore. Shak.\n\n2. A bank or mole to defend against the sea."
     ],
     "references": [
-      "AGISTMENT",
-      "SEA BANK"
+      "AGISTMENT"
     ]
   },
   {
@@ -34601,9 +34535,7 @@
     "variants": [
       "SEA BARROW\nSea\" bar\"row. (Zoöl.)\n\nDefn: A sea purse."
     ],
-    "references": [
-      "SEA BARROW"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA BASS",
@@ -34616,7 +34548,6 @@
       "BLACKFISH",
       "BLUEFISH",
       "PERCH",
-      "SEA BASS",
       "SEA PERCH",
       "SEA SALMON",
       "SEA TROUT",
@@ -34630,8 +34561,7 @@
       "SEA BAT\nSea\" bat`. (Zoöl.)\n\nDefn: See Batfish (a)."
     ],
     "references": [
-      "BELIEVE",
-      "SEA BAT"
+      "BELIEVE"
     ]
   },
   {
@@ -34649,8 +34579,7 @@
       "SEA BEAN\nSea\" bean. (Bot.)\n\nDefn: Same as Florida bean."
     ],
     "references": [
-      "BEAN",
-      "SEA BEAN"
+      "BEAN"
     ]
   },
   {
@@ -34661,7 +34590,6 @@
     "references": [
       "BEAR",
       "FUR",
-      "SEA BEAR",
       "SEAL",
       "URSINE"
     ]
@@ -34678,9 +34606,7 @@
     "variants": [
       "SEA BEAST\nSea\" beast`. (Zoöl.)\n\nDefn: Any large marine mammal, as a seal, walrus, or cetacean."
     ],
-    "references": [
-      "SEA BEAST"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA BIRD",
@@ -34713,7 +34639,6 @@
       "PUFFIN",
       "ROTCHE",
       "SEA",
-      "SEA BIRD",
       "SULA",
       "TOMNODDY",
       "TUBE-NOSED",
@@ -34725,9 +34650,7 @@
     "variants": [
       "SEA BLITE\nSea\" blite`. (Bot.)\n\nDefn: A plant (Suæda maritima) of the Goosefoot family, growing in\nsalt marches."
     ],
-    "references": [
-      "SEA BLITE"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA-BLUBBER",
@@ -34790,8 +34713,7 @@
       "SEA BOW\nSea\" bow`.\n\nDefn: See Marine rainbow, under Rainbow."
     ],
     "references": [
-      "RAINBOW",
-      "SEA BOW"
+      "RAINBOW"
     ]
   },
   {
@@ -34799,18 +34721,14 @@
     "variants": [
       "SEA BOY\nSea\" boy`.\n\nDefn: A boy employed on shipboard."
     ],
-    "references": [
-      "SEA BOY"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA BREACH",
     "variants": [
       "SEA BREACH\nSea\" breach`.\n\nDefn: A breaking or overflow of a bank or a dike by the sea.\nL'Estrange."
     ],
-    "references": [
-      "SEA BREACH"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA BREAM",
@@ -34823,7 +34741,6 @@
       "GUNNER",
       "HENFISH",
       "OLD",
-      "SEA BREAM",
       "SPAROID"
     ]
   },
@@ -34832,18 +34749,14 @@
     "variants": [
       "SEA BRIEF\nSea\" brief`.\n\nDefn: Same as Sea letter."
     ],
-    "references": [
-      "SEA BRIEF"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA BUG",
     "variants": [
       "SEA BUG\nSea\" bug`. (Zoöl.)\n\nDefn: A chiton."
     ],
-    "references": [
-      "SEA BUG"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA-BUILT",
@@ -34857,9 +34770,7 @@
     "variants": [
       "SEA BUTTERFLY\nSea\" but\"ter*fly`. (Zoöl.)\n\nDefn: A pteropod."
     ],
-    "references": [
-      "SEA BUTTERFLY"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA CABBAGE",
@@ -34869,7 +34780,6 @@
     "references": [
       "CABBAGE",
       "KALE",
-      "SEA CABBAGE",
       "SEA COLEWORT"
     ]
   },
@@ -34879,7 +34789,6 @@
       "SEA CALF\nSea\" calf`. (Zoöl.)\n\nDefn: The common seal."
     ],
     "references": [
-      "SEA CALF",
       "SEAL"
     ]
   },
@@ -34888,9 +34797,7 @@
     "variants": [
       "SEA CANARY\nSea\" ca*na\"ry. Etym: [So called from a whistling sound which it\nmakes.] (Zoöl.)\n\nDefn: The beluga, or white whale."
     ],
-    "references": [
-      "SEA CANARY"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA CAPTAIN",
@@ -34898,8 +34805,7 @@
       "SEA CAPTAIN\nSea\" cap\"tain.\n\nDefn: The captain of a vessel that sails upon the sea."
     ],
     "references": [
-      "BLUFF",
-      "SEA CAPTAIN"
+      "BLUFF"
     ]
   },
   {
@@ -34907,9 +34813,7 @@
     "variants": [
       "SEA CARD\nSea\" card`.\n\nDefn: Mariner's card, or compass."
     ],
-    "references": [
-      "SEA CARD"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA CATFISH; SEA CAT",
@@ -34919,7 +34823,6 @@
     "references": [
       "CAT",
       "CATFISH",
-      "SEA CATFISH; SEA CAT",
       "SEAL",
       "WOLF"
     ]
@@ -34929,9 +34832,7 @@
     "variants": [
       "SEA CHART\nSea\" chart`.\n\nDefn: A chart or map on which the lines of the shore, islands,\nshoals, harbors, etc., are delineated."
     ],
-    "references": [
-      "SEA CHART"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA CHICKWEED",
@@ -34939,7 +34840,6 @@
       "SEA CHICKWEED\nSea\" chick\"weed`. (Bot.)\n\nDefn: A fleshy plant (Arenaria peploides) growing in large tufts in\nthe sands of the northern Atlantic seacoast; -- called also sea\nsandwort, and sea purslane."
     ],
     "references": [
-      "SEA CHICKWEED",
       "SEA SANDWORT"
     ]
   },
@@ -34951,7 +34851,6 @@
     "references": [
       "CLAM",
       "HEN",
-      "SEA CLAM",
       "SKIMMER"
     ]
   },
@@ -34960,9 +34859,7 @@
     "variants": [
       "SEA COAL\nSea\" coal`.\n\nDefn: Coal brought by sea; -- a name by which mineral coal was\nformerly designated in the south of England, in distinction from\ncharcoal, which was brought by land. Sea-coal facing (Founding),\nfacing consisting of pulverized bituminous coal."
     ],
-    "references": [
-      "SEA COAL"
-    ]
+    "references": []
   },
   {
     "spellings": "SEACOAST",
@@ -35004,9 +34901,7 @@
     "variants": [
       "SEA COB\nSea\" cob`. (Zoöl.)\n\nDefn: The black-backed gull."
     ],
-    "references": [
-      "SEA COB"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA COCK",
@@ -35014,8 +34909,7 @@
       "SEA COCK\nSea\" cock`.\n\n1. In a steamship, a cock or valve close to the vessel's side, for\nclosing a pipe which communicates with the sea.\n\n2. (Zoöl.)\n(a) The black-bellied plover.\n(b) A gurnard, as the European red gurnard (Trigla pini)."
     ],
     "references": [
-      "COCKLE",
-      "SEA COCK"
+      "COCKLE"
     ]
   },
   {
@@ -35023,54 +34917,42 @@
     "variants": [
       "SEA COCOA\nSea\" co\"coa. (Bot.)\n\nDefn: A magnificent palm (Lodoicea Sechellarum) found only in the\nSeychelles Islands. The fruit is an immense two-lobed nut. It was\nfound floating in the Indian Ocean before the tree was known, and\ncalled sea cocoanut, and double cocoanut."
     ],
-    "references": [
-      "SEA COCOA"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA COLANDER",
     "variants": [
       "SEA COLANDER\nSea\" col\"an*der. (Bot.)\n\nDefn: A large blackfish seaweed (Agarum Turneri), the frond of which\nis punctured with many little holes."
     ],
-    "references": [
-      "SEA COLANDER"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA COLEWORT",
     "variants": [
       "SEA COLEWORT\nSea\" cole\"wort`. (Bot.)\n\nDefn: Sea cabbage."
     ],
-    "references": [
-      "SEA COLEWORT"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA COMPASS",
     "variants": [
       "SEA COMPASS\nSea\" com\"pass.\n\nDefn: The mariner's compass. See under Compass."
     ],
-    "references": [
-      "SEA COMPASS"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA COOT",
     "variants": [
       "SEA COOT\nSea\" coot`. (Zoöl.)\n\nDefn: A scoter duck."
     ],
-    "references": [
-      "SEA COOT"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA CORN",
     "variants": [
       "SEA CORN\nSea\" corn`. (Zoöl.)\n\nDefn: A yellow cylindrical mass of egg capsule of certain species of\nwhelks (Buccinum), which resembles an ear of maize."
     ],
-    "references": [
-      "SEA CORN"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA COW",
@@ -35080,7 +34962,6 @@
     "references": [
       "MANATEE",
       "RYTINA",
-      "SEA COW",
       "ZEEKOE"
     ]
   },
@@ -35090,8 +34971,7 @@
       "SEA CRAWFISH; SEA CRAYFISH\nSea\" craw\"fish`. Sea\" cray\"fish`. (Zoöl.)\n\nDefn: Any crustacean of the genus Palinurus and allied genera, as the\nEuropean spiny lobster (P. vulgaris), which is much used as an\narticle of food. See Lobster."
     ],
     "references": [
-      "ROCK",
-      "SEA CRAWFISH; SEA CRAYFISH"
+      "ROCK"
     ]
   },
   {
@@ -35100,8 +34980,7 @@
       "SEA CROW\nSea\" crow`. (Zoöl.)\n(a) The chough. [Ireland]\n(b) The cormorant.\n(c) The blackheaded pewit, and other gulls.\n(d) The skua.\n(e) The razorbill. [Orkney Islands]\n(f) The coot."
     ],
     "references": [
-      "LAUGHING",
-      "SEA CROW"
+      "LAUGHING"
     ]
   },
   {
@@ -35111,7 +34990,6 @@
     ],
     "references": [
       "HOLOTHURIAN",
-      "SEA CUCUMBER",
       "TREPANG"
     ]
   },
@@ -35120,18 +34998,14 @@
     "variants": [
       "SEA DACE\nSea\" dace`. (Zoöl.)\n\nDefn: The European sea perch."
     ],
-    "references": [
-      "SEA DACE"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA DAFFODIL",
     "variants": [
       "SEA DAFFODIL\nSea\" daf\"fo*dil. (Bot.)\n\nDefn: A European amarylidaceous plant (Pancratium maritimum)."
     ],
-    "references": [
-      "SEA DAFFODIL"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA DEVIL",
@@ -35144,8 +35018,7 @@
       "HORNED",
       "MANTA",
       "OX",
-      "RAY",
-      "SEA DEVIL"
+      "RAY"
     ]
   },
   {
@@ -35154,7 +35027,6 @@
       "SEA DOG\nSea\" dog`.\n\n1. (Zoöl.)\n\nDefn: The dogfish.\n(b) The common seal.\n\n2. An old sailor; a salt. [Colloq.]"
     ],
     "references": [
-      "SEA DOG",
       "SEA HORSE",
       "SEAL"
     ]
@@ -35164,9 +35036,7 @@
     "variants": [
       "SEA DOTTEREL\nSea\" dot\"ter*el. (Zoöl.)\n\nDefn: The turnstone."
     ],
-    "references": [
-      "SEA DOTTEREL"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA DOVE",
@@ -35177,8 +35047,7 @@
       "DOVE",
       "DOVEKIE",
       "KING",
-      "ROTCHE",
-      "SEA DOVE"
+      "ROTCHE"
     ]
   },
   {
@@ -35186,18 +35055,14 @@
     "variants": [
       "SEA DRAGON\nSea\" drag\"on. (Zoöl.)\n(a) A dragonet, or sculpin.\n(b) The pegasus."
     ],
-    "references": [
-      "SEA DRAGON"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA DRAKE",
     "variants": [
       "SEA DRAKE\nSea\" drake`. (Zoöl.)\n\nDefn: The pewit gull."
     ],
-    "references": [
-      "SEA DRAKE"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA DUCK",
@@ -35210,7 +35075,6 @@
       "EIDER",
       "LABRADOR",
       "SCOTER",
-      "SEA DUCK",
       "STEAMER",
       "SURF",
       "VELVET"
@@ -35226,7 +35090,6 @@
       "ERN; ERNE",
       "OSSIFRAGE",
       "PYGARG; PYGARGUS",
-      "SEA EAGLE",
       "VULTURINE"
     ]
   },
@@ -35248,8 +35111,7 @@
     "references": [
       "BOTTLE",
       "CONGER",
-      "ELVER",
-      "SEA EEL"
+      "ELVER"
     ]
   },
   {
@@ -35257,9 +35119,7 @@
     "variants": [
       "SEA EGG\nSea\" egg`. (Zoöl.)\n\nDefn: A sea urchin."
     ],
-    "references": [
-      "SEA EGG"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA ELEPHANT",
@@ -35267,7 +35127,6 @@
       "SEA ELEPHANT\nSea\" el\"e*phant. (Zoöl.)\n\nDefn: A very large seal (Macrorhinus proboscideus) of the Antarctic\nseas, much hunted for its oil. It sometimes attains a length of\nthirty feet, and is remarkable for the prolongation of the nose of\nthe adult male into an erectile elastic proboscis, about a foot in\nlength. Another species of smaller size (M. angustirostris) occurs on\nthe coast of Lower California, but is now nearly extinct."
     ],
     "references": [
-      "SEA ELEPHANT",
       "SEAL",
       "SEA WOLF"
     ]
@@ -35279,7 +35138,6 @@
     ],
     "references": [
       "GORGONIA",
-      "SEA FAN",
       "TANGLE"
     ]
   },
@@ -35309,8 +35167,7 @@
       "SEA FEATHER\nSea\" feath\"er. (Zoöl.)\n\nDefn: Any gorgonian which branches in a plumelike form."
     ],
     "references": [
-      "CORAL",
-      "SEA FEATHER"
+      "CORAL"
     ]
   },
   {
@@ -35318,18 +35175,14 @@
     "variants": [
       "SEA FENNEL\nSea\" fen\"nel. (Bot.)\n\nDefn: Samphire."
     ],
-    "references": [
-      "SEA FENNEL"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA FERN",
     "variants": [
       "SEA FERN\nSea\" fern\". (Zoöl.)\n\nDefn: Any gorgonian which branches like a fern."
     ],
-    "references": [
-      "SEA FERN"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA FIGHT",
@@ -35338,7 +35191,6 @@
     ],
     "references": [
       "NAUMACHY",
-      "SEA FIGHT",
       "VIKING"
     ]
   },
@@ -35347,9 +35199,7 @@
     "variants": [
       "SEA FIR\nSea\" fir`. (Zoöl.)\n\nDefn: A sertularian hydroid, especially Sertularia abietina, which\nbranches like a miniature fir tree."
     ],
-    "references": [
-      "SEA FIR"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA FLOWER",
@@ -35357,8 +35207,7 @@
       "SEA FLOWER\nSea\" flow\"er. (Zoöl.)\n\nDefn: A sea anemone, or any related anthozoan."
     ],
     "references": [
-      "DRESS",
-      "SEA FLOWER"
+      "DRESS"
     ]
   },
   {
@@ -35368,7 +35217,6 @@
     ],
     "references": [
       "MEERSCHAUM",
-      "SEA FOAM",
       "SEA FROTH"
     ]
   },
@@ -35381,8 +35229,7 @@
       "GANNET",
       "GUANO",
       "RANK",
-      "SEA BIRD",
-      "SEA FOWL"
+      "SEA BIRD"
     ]
   },
   {
@@ -35393,7 +35240,6 @@
     "references": [
       "FOX",
       "FOXFISH",
-      "SEA FOX",
       "THRASHER; THRESHER"
     ]
   },
@@ -35403,8 +35249,7 @@
       "SEA FROTH\nSea\" froth`.\n\nDefn: See Sea foam, 2."
     ],
     "references": [
-      "SEA FOAM",
-      "SEA FROTH"
+      "SEA FOAM"
     ]
   },
   {
@@ -35420,8 +35265,7 @@
       "SEA GAUGE\nSea\" gauge`.\n\nDefn: See under Gauge, n."
     ],
     "references": [
-      "GAUGE",
-      "SEA GAUGE"
+      "GAUGE"
     ]
   },
   {
@@ -35430,8 +35274,7 @@
       "SEA GHERKIN; SEA GIRKIN\nSea\" gher`kin, or; Sea\" gir\"kin. (Zoöl.)\n\nDefn: Any small holothurian resembling in form a gherkin."
     ],
     "references": [
-      "GHERKIN",
-      "SEA GHERKIN; SEA GIRKIN"
+      "GHERKIN"
     ]
   },
   {
@@ -35439,9 +35282,7 @@
     "variants": [
       "SEA GINGER\nSea\" gin\"ger. (Zoöl.)\n\nDefn: A hydroid coral of the genus Millepora, especially M.\nalcicornis, of the West Indies and Florida. So called because it\nstings the tongue like ginger. See Illust. under Millepore."
     ],
-    "references": [
-      "SEA GINGER"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA GIRDLES",
@@ -35449,7 +35290,6 @@
       "SEA GIRDLES\nSea\" gir\"dles. (Bot.)\n\nDefn: A kind of kelp (Laminaria digitata) with palmately cleft\nfronds; -- called also sea wand, seaware, and tangle."
     ],
     "references": [
-      "SEA GIRDLES",
       "SEAWAND",
       "SEAWARE"
     ]
@@ -35470,7 +35310,6 @@
     ],
     "references": [
       "PROTEUS",
-      "SEA GOD",
       "SEA GODDESS"
     ]
   },
@@ -35479,9 +35318,7 @@
     "variants": [
       "SEA GODDESS\nSea\" god\"dess.\n\nDefn: A goddess supposed to live in or reign over the sea, or some\npart of the sea."
     ],
-    "references": [
-      "SEA GODDESS"
-    ]
+    "references": []
   },
   {
     "spellings": "SEAGOING",
@@ -35502,8 +35339,7 @@
     ],
     "references": [
       "GOOSE",
-      "PHALAROPE",
-      "SEA GOOSE"
+      "PHALAROPE"
     ]
   },
   {
@@ -35511,9 +35347,7 @@
     "variants": [
       "SEA GOWN\nSea\" gown`.\n\nDefn: A gown or frock with short sleeves, formerly worn by mariners.\nShak."
     ],
-    "references": [
-      "SEA GOWN"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA GRAPE",
@@ -35523,8 +35357,7 @@
     "references": [
       "GULF",
       "KINO",
-      "POLYGONACEOUS",
-      "SEA GRAPE"
+      "POLYGONACEOUS"
     ]
   },
   {
@@ -35532,9 +35365,7 @@
     "variants": [
       "SEA GRASS\nSea\" grass`. (Bot.)\n\nDefn: Eelgrass."
     ],
-    "references": [
-      "SEA GRASS"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA GREEN",
@@ -35544,8 +35375,7 @@
     "references": [
       "GLAUCUS",
       "LUMPFISH",
-      "ROLLER",
-      "SEA GREEN"
+      "ROLLER"
     ]
   },
   {
@@ -35567,9 +35397,7 @@
     "variants": [
       "SEA GUDGEON\nSea\" gud\"geon. (Zoöl.)\n\nDefn: The European black goby (Gobius niger)."
     ],
-    "references": [
-      "SEA GUDGEON"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA GULL",
@@ -35577,8 +35405,7 @@
       "SEA GULL\nSea\" gull`. (Zoöl.)\n\nDefn: Any gull living on the seacoast."
     ],
     "references": [
-      "LARY",
-      "SEA GULL"
+      "LARY"
     ]
   },
   {
@@ -35595,8 +35422,7 @@
     ],
     "references": [
       "APLYSIA",
-      "HARE",
-      "SEA HARE"
+      "HARE"
     ]
   },
   {
@@ -35604,18 +35430,14 @@
     "variants": [
       "SEA HAWK\nSea\" hawk`. (Zoöl.)\n\nDefn: A jager gull."
     ],
-    "references": [
-      "SEA HAWK"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA HEATH",
     "variants": [
       "SEA HEATH\nSea\" heath`. (Bot.)\n\nDefn: A low perennial plant (Frankenia lævis) resembling heath,\ngrowing along the seashore in Europe."
     ],
-    "references": [
-      "SEA HEATH"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA HEDGEHOG",
@@ -35624,8 +35446,7 @@
     ],
     "references": [
       "DIODON",
-      "HEDGEHOG",
-      "SEA HEDGEHOG"
+      "HEDGEHOG"
     ]
   },
   {
@@ -35633,18 +35454,14 @@
     "variants": [
       "SEA HEN\nSea\" hen`. (Zoöl.)\n\nDefn: the common guillemot; -- applied also to various other sea\nbirds."
     ],
-    "references": [
-      "SEA HEN"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA HOG",
     "variants": [
       "SEA HOG\nSea\" hog`. (Zoöl.)\n\nDefn: The porpoise."
     ],
-    "references": [
-      "SEA HOG"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA HOLLY",
@@ -35655,7 +35472,6 @@
       "ERINGO",
       "ERYNGIUM",
       "HOLLY",
-      "SEA HOLLY",
       "SEA HOLM",
       "SEA HULVER"
     ]
@@ -35666,9 +35482,7 @@
       "SEA HOLM\nSea\" holm`.\n\nDefn: A small uninhabited island.",
       "SEA HOLM\nSea\" holm`. (Bot.)\n\nDefn: Sea holly."
     ],
-    "references": [
-      "SEA HOLM"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA HORSE",
@@ -35676,8 +35490,7 @@
       "SEA HORSE\nSea\" horse`.\n\n1. A fabulous creature, half horse and half fish, represented in\nclassic mythology as driven by sea dogs or ridden by the Nereids. It\nis also depicted in heraldry. See Hippocampus.\n\n2. (Zoöl.)\n(a) The walrus.\n(b) Any fish of the genus Hippocampus.\n\nNote: In a passage of Dryden's, the word is supposed to refer to the\nhippopotamus."
     ],
     "references": [
-      "HIPPOCAMPUS",
-      "SEA HORSE"
+      "HIPPOCAMPUS"
     ]
   },
   {
@@ -35685,9 +35498,7 @@
     "variants": [
       "SEA HULVER\nSea\" hul\"ver. (Bot.)\n\nDefn: Sea holly."
     ],
-    "references": [
-      "SEA HULVER"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA-ISLAND",
@@ -35703,9 +35514,7 @@
     "variants": [
       "SEA JELLY\nSea\" jel\"ly. (Zoöl.)\n\nDefn: A medusa, or jellyfish."
     ],
-    "references": [
-      "SEA JELLY"
-    ]
+    "references": []
   },
   {
     "spellings": "SEAK",
@@ -35722,8 +35531,7 @@
     "references": [
       "CABBAGE",
       "KALE",
-      "SEA CABBAGE",
-      "SEA KALE"
+      "SEA CABBAGE"
     ]
   },
   {
@@ -35732,7 +35540,6 @@
       "SEA KING\nSea\" king`.\n\nDefn: One of the leaders among the Norsemen who passed their lives in\nroving the seas in search of plunder and adventures; a Norse pirate\nchief. See the Note under Viking."
     ],
     "references": [
-      "SEA KING",
       "VIKING"
     ]
   },
@@ -35910,9 +35717,7 @@
     "variants": [
       "SEA LACES\nSea\" la\"ces. (Bot.)\n\nDefn: A kind of seaweed (Chorda Filum) having blackish cordlike\nfronds, often many feet long."
     ],
-    "references": [
-      "SEA LACES"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA LAMPREY",
@@ -35920,8 +35725,7 @@
       "SEA LAMPREY\nSea\" lam\"prey. (Zoöl.)\n\nDefn: The common lamprey."
     ],
     "references": [
-      "LAMPREY",
-      "SEA LAMPREY"
+      "LAMPREY"
     ]
   },
   {
@@ -35929,9 +35733,7 @@
     "variants": [
       "SEA LANGUAGE\nSea\" lan\"guage.\n\nDefn: The peculiar language or phraseology of seamen; sailor's cant."
     ],
-    "references": [
-      "SEA LANGUAGE"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA LARK",
@@ -35940,7 +35742,6 @@
     ],
     "references": [
       "PIPIT",
-      "SEA LARK",
       "TURNSTONE"
     ]
   },
@@ -35952,8 +35753,7 @@
     "references": [
       "BEHEN; BEHN",
       "LAVENDER",
-      "MARSH",
-      "SEA LAVENDER"
+      "MARSH"
     ]
   },
   {
@@ -35962,8 +35762,7 @@
       "SEA LAWYER\nSea\" law\"yer. (Zoöl.)\n\nDefn: The gray snapper. See under Snapper."
     ],
     "references": [
-      "GRAY",
-      "SEA LAWYER"
+      "GRAY"
     ]
   },
   {
@@ -35980,18 +35779,14 @@
     "variants": [
       "SEA LEGS\nSea\" legs`.\n\nDefn: Legs able to maintain their possessor upright in stormy weather\nat sea, that is, ability stand or walk steadily on deck when a vessel\nis rolling or pitching in a rough sea. [Sailor's Cant] Totten."
     ],
-    "references": [
-      "SEA LEGS"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA LEMON",
     "variants": [
       "SEA LEMON\nSea\" lem\"on. (Zoöl.)\n\nDefn: Any one of several species of nudibranchiate mollusks of the\ngenus Doris and allied genera, having a smooth, thick, convex yellow\nbody."
     ],
-    "references": [
-      "SEA LEMON"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA LEOPARD",
@@ -35999,8 +35794,7 @@
       "SEA LEOPARD\nSea\" leop\"ard. (Zoöl.)\n\nDefn: Any one of several species of spotted seals, especially\nOgmorhinus leptonyx, and Leptonychotes Weddelli, of the Antarctic\nOcean. The North Pacific sea leopard is the harbor seal."
     ],
     "references": [
-      "SEAL",
-      "SEA LEOPARD"
+      "SEAL"
     ]
   },
   {
@@ -36020,7 +35814,6 @@
     ],
     "references": [
       "SEA BRIEF",
-      "SEA LETTER",
       "SEA PASS",
       "SHIP"
     ]
@@ -36033,7 +35826,6 @@
     "references": [
       "ALGA",
       "LETTUCE",
-      "SEA LETTUCE",
       "ULVA"
     ]
   },
@@ -36048,7 +35840,6 @@
       "COORDINATE",
       "ISOBAR",
       "OROMETER",
-      "SEA LEVEL",
       "SIPHON"
     ]
   },
@@ -36064,9 +35855,7 @@
     "variants": [
       "SEA LILY\nSea\" lil\"y. (Zoöl.)\n\nDefn: A crinoid."
     ],
-    "references": [
-      "SEA LILY"
-    ]
+    "references": []
   },
   {
     "spellings": "SEALING WAX",
@@ -36076,7 +35865,6 @@
     "references": [
       "LAC",
       "LACQUER",
-      "SEALING WAX",
       "VERMILION",
       "WAX",
       "WAXBILL",
@@ -36092,7 +35880,6 @@
       "HAIR",
       "MANED",
       "SEAL",
-      "SEA LION",
       "SEA WOLF"
     ]
   },
@@ -36102,7 +35889,6 @@
       "SEA LOACH\nSea\" loach\". (Zoöl.)\n\nDefn: The three-bearded rockling. See Rockling."
     ],
     "references": [
-      "SEA LOACH",
       "WHISTLEFISH"
     ]
   },
@@ -36111,9 +35897,7 @@
     "variants": [
       "SEA LOUSE\nSea\" louse`. (Zoöl.)\n\nDefn: Any one of numerous species of isopod crustaceans of Cymothoa,\nLivoneca, and allied genera, mostly parasites on fishes."
     ],
-    "references": [
-      "SEA LOUSE"
-    ]
+    "references": []
   },
   {
     "spellings": "SEALSKIN",
@@ -36265,18 +36049,14 @@
     "variants": [
       "SEA MANTIS\nSea\" man\"tis. (Zoöl.)\n\nDefn: A squilla."
     ],
-    "references": [
-      "SEA MANTIS"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA MARGE",
     "variants": [
       "SEA MARGE\nSea\" marge`.\n\nDefn: Land which borders on the sea; the seashore. Shak.\nYou are near the sea marge of a land teeming with life. J. Burroughs."
     ],
-    "references": [
-      "SEA MARGE"
-    ]
+    "references": []
   },
   {
     "spellings": "SEAMARK",
@@ -36292,18 +36072,14 @@
     "variants": [
       "SEA MAT\nSea\" mat`. (Zoöl.)\n\nDefn: Any bryozoan of the genus Flustra or allied genera which form\nfrondlike corals."
     ],
-    "references": [
-      "SEA MAT"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA MAW",
     "variants": [
       "SEA MAW\nSea\" maw`. (Zoöl.)\n\nDefn: The sea mew."
     ],
-    "references": [
-      "SEA MAW"
-    ]
+    "references": []
   },
   {
     "spellings": "SEAMED",
@@ -36333,8 +36109,7 @@
       "MEAW",
       "MEW",
       "SEA MAW",
-      "SEA-MELL",
-      "SEA MEW"
+      "SEA-MELL"
     ]
   },
   {
@@ -36342,9 +36117,7 @@
     "variants": [
       "SEA MILE\nSea\" mile`.\n\nDefn: A geographical mile. See Mile."
     ],
-    "references": [
-      "SEA MILE"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA MILKWORT",
@@ -36352,8 +36125,7 @@
       "SEA MILKWORT\nSea\" milk\"wort`. (Bot.)\n\nDefn: A low, fleshy perennial herb (Glaux maritima) found along\nnorthern seashores."
     ],
     "references": [
-      "SALTWORT",
-      "SEA MILKWORT"
+      "SALTWORT"
     ]
   },
   {
@@ -36380,9 +36152,7 @@
     "variants": [
       "SEA MONK\nSea\" monk`. (Zoöl.)\n\nDefn: See Monk seal, under Monk."
     ],
-    "references": [
-      "SEA MONK"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA MONSTER",
@@ -36393,7 +36163,6 @@
       "HIPPODAME",
       "KRAKEN",
       "MONOCEROS",
-      "SEA MONSTER",
       "UPWARD; UPWARDS",
       "VARUNA",
       "WHIRLPOOL"
@@ -36405,7 +36174,6 @@
       "SEA MOSS\nSea\" moss`. (Zoöl.)\n\nDefn: Any branched marine bryozoan resembling moss."
     ],
     "references": [
-      "SEA MOSS",
       "ZOOECIUM"
     ]
   },
@@ -36415,8 +36183,7 @@
       "SEA MOUSE\nSea\" mouse`. (Zoöl.)\n(a) A dorsibranchiate annelid, belonging to Aphrodite and allied\ngenera, having long, slender, hairlike setæ on the sides.\n(b) The dunlin."
     ],
     "references": [
-      "APHRODITE",
-      "SEA MOUSE"
+      "APHRODITE"
     ]
   },
   {
@@ -36463,7 +36230,6 @@
     "references": [
       "COCCOLITH",
       "RHIZOPOD",
-      "SEA MUD",
       "SEA OOZE"
     ]
   },
@@ -36502,8 +36268,7 @@
     "references": [
       "GARFISH",
       "HORNFISH",
-      "NEEDLE",
-      "SEA NEEDLE"
+      "NEEDLE"
     ]
   },
   {
@@ -36514,8 +36279,7 @@
     "references": [
       "ACALEPHAE",
       "BLUBBER",
-      "NETTLE",
-      "SEA NETTLE"
+      "NETTLE"
     ]
   },
   {
@@ -36533,7 +36297,6 @@
       "SEA ONION\nSea\" on\"ion. (Bot.)\n\nDefn: The officinal squill. See Squill."
     ],
     "references": [
-      "SEA ONION",
       "SQUILL",
       "SQUILLA"
     ]
@@ -36544,8 +36307,7 @@
       "SEA OOZE\nSea\" ooze`.\n\nDefn: Same as Sea mud. Mortimer."
     ],
     "references": [
-      "SEA MUD",
-      "SEA OOZE"
+      "SEA MUD"
     ]
   },
   {
@@ -36553,9 +36315,7 @@
     "variants": [
       "SEA ORANGE\nSea\" or\"ange. (Zoöl.)\n\nDefn: A large American holothurian (Lophothuria Fabricii) having a\nbright orange convex body covered with finely granulated scales. Its\nexpanded tentacles are bright red."
     ],
-    "references": [
-      "SEA ORANGE"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA-ORB",
@@ -36572,8 +36332,7 @@
     "references": [
       "KALAN",
       "OTTER",
-      "SEA APE",
-      "SEA OTTER"
+      "SEA APE"
     ]
   },
   {
@@ -36583,8 +36342,7 @@
     ],
     "references": [
       "LUMPFISH",
-      "OWL",
-      "SEA OWL"
+      "OWL"
     ]
   },
   {
@@ -36592,18 +36350,14 @@
     "variants": [
       "SEA PAD\nSea\" pad`. (Zoöl.)\n\nDefn: The puffin."
     ],
-    "references": [
-      "SEA PAD"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA PARROT",
     "variants": [
       "SEA PARROT\nSea\" par\"rot (se\" par\"rut). (Zoöl.)\n\nDefn: The puffin."
     ],
-    "references": [
-      "SEA PARROT"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA PARTRIDGE",
@@ -36612,8 +36366,7 @@
     ],
     "references": [
       "GILTHEAD",
-      "PARTRIDGE",
-      "SEA PARTRIDGE"
+      "PARTRIDGE"
     ]
   },
   {
@@ -36621,27 +36374,21 @@
     "variants": [
       "SEA PASS\nSea\" pass`.\n\nDefn: A document carried by neutral merchant vessels in time of war,\nto show their nationality; a sea letter or passport. See Passport."
     ],
-    "references": [
-      "SEA PASS"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA PEACH",
     "variants": [
       "SEA PEACH\nSea\" peach`. (Zoöl.)\n\nDefn: A beautiful American ascidian (Cynthia, or Halocynthia,\npyriformis) having the size, form, velvety surface, and color of a\nripe peach."
     ],
-    "references": [
-      "SEA PEACH"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA PEAR",
     "variants": [
       "SEA PEAR\nSea\" pear`. (Zoöl.)\n\nDefn: A pedunculated ascidian of the genus Boltonia."
     ],
-    "references": [
-      "SEA PEAR"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA-PEN",
@@ -36660,7 +36407,6 @@
     ],
     "references": [
       "SEA DACE",
-      "SEA PERCH",
       "SEA WOLF",
       "STONE"
     ]
@@ -36671,8 +36417,7 @@
       "SEA PHEASANT\nSea\" pheas\"ant. (Zoöl.)\n\nDefn: The pintail duck."
     ],
     "references": [
-      "PHEASANT",
-      "SEA PHEASANT"
+      "PHEASANT"
     ]
   },
   {
@@ -36683,7 +36428,6 @@
     ],
     "references": [
       "PIET",
-      "SEA PIE",
       "SEA PIET",
       "SEA PYE",
       "SEA PYOT"
@@ -36702,8 +36446,7 @@
       "SEA PIET\nSea\" pi\"et. (Zoöl.)\n\nDefn: See 1st Sea pie."
     ],
     "references": [
-      "PIET",
-      "SEA PIET"
+      "PIET"
     ]
   },
   {
@@ -36713,7 +36456,6 @@
     ],
     "references": [
       "GUILLEMOT",
-      "SEA PIG",
       "SEA PIGEON",
       "SEA TURTLE"
     ]
@@ -36725,7 +36467,6 @@
     ],
     "references": [
       "GUILLEMOT",
-      "SEA PIGEON",
       "SEA TURTLE"
     ]
   },
@@ -36737,8 +36478,7 @@
     "references": [
       "GARFISH",
       "MERLUCE",
-      "PIKE",
-      "SEA PIKE"
+      "PIKE"
     ]
   },
   {
@@ -36746,9 +36486,7 @@
     "variants": [
       "SEA PINCUSHION\nSea\" pin`cush`ion. (Zoöl.)\n(a) A sea purse.\n(b) A pentagonal starfish."
     ],
-    "references": [
-      "SEA PINCUSHION"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA PINK",
@@ -36757,7 +36495,6 @@
     ],
     "references": [
       "PINK",
-      "SEA PINK",
       "THRIFT"
     ]
   },
@@ -36766,9 +36503,7 @@
     "variants": [
       "SEA PLOVER\nSea\" plov\"er.\n\nDefn: the black-bellied plover."
     ],
-    "references": [
-      "SEA PLOVER"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA POACHER; SEA POKER",
@@ -36777,8 +36512,7 @@
     ],
     "references": [
       "LYRIE",
-      "POACHER",
-      "SEA POACHER; SEA POKER"
+      "POACHER"
     ]
   },
   {
@@ -36786,45 +36520,35 @@
     "variants": [
       "SEA POOL\nSea\" pool`.\n\nDefn: A pool of salt water. Spenser."
     ],
-    "references": [
-      "SEA POOL"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA POPPY",
     "variants": [
       "SEA POPPY\nSea\" pop\"py. (Bot.)\n\nDefn: The horn poppy. See under Horn."
     ],
-    "references": [
-      "SEA POPPY"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA PORCUPINE",
     "variants": [
       "SEA PORCUPINE\nSea\" por\"cu*pine. (Zoöl.)\n\nDefn: Any fish of the genus Diodon, and allied genera, whose body is\ncovered with spines. See Illust. under Diodon."
     ],
-    "references": [
-      "SEA PORCUPINE"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA PORK",
     "variants": [
       "SEA PORK\nSea\" pork`. (Zoöl.)\n\nDefn: An American compound ascidian (Amoræcium stellatum) which forms\nlarge whitish masses resembling salt pork."
     ],
-    "references": [
-      "SEA PORK"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA PORT",
     "variants": [
       "SEA PORT\nSea\" port`, n.\n\nDefn: A port on the seashore, or one accessible for seagoing vessels.\nAlso used adjectively; as, a seaport town."
     ],
-    "references": [
-      "SEA PORT"
-    ]
+    "references": []
   },
   {
     "spellings": "SEAPOY",
@@ -36838,9 +36562,7 @@
     "variants": [
       "SEA PUDDING\nSea\" pud\"ding. (Zoöl.)\n\nDefn: Any large holothurian. [Prov. Eng.]"
     ],
-    "references": [
-      "SEA PUDDING"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA PURSE",
@@ -36850,7 +36572,6 @@
     "references": [
       "SEA BARROW",
       "SEA PINCUSHION",
-      "SEA PURSE",
       "SHARK",
       "SKATE"
     ]
@@ -36862,8 +36583,7 @@
     ],
     "references": [
       "PURSLANE",
-      "SEA CHICKWEED",
-      "SEA PURSLANE"
+      "SEA CHICKWEED"
     ]
   },
   {
@@ -36871,18 +36591,14 @@
     "variants": [
       "SEA PYE\nSea\" pye`. (Zoöl.)\n\nDefn: See 1st Sea pie."
     ],
-    "references": [
-      "SEA PYE"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA PYOT",
     "variants": [
       "SEA PYOT\nSea\" py\"ot. (Zoöl.)\n\nDefn: See 1st Sea pie."
     ],
-    "references": [
-      "SEA PYOT"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA QUAIL",
@@ -36890,8 +36606,7 @@
       "SEA QUAIL\nSea\" quail`. (Zoöl.)\n\nDefn: The turnstone."
     ],
     "references": [
-      "QUAIL",
-      "SEA QUAIL"
+      "QUAIL"
     ]
   },
   {
@@ -36936,9 +36651,7 @@
     "variants": [
       "SEA RAT\nSea\" rat`.\n\n1. A pirate. [R.] Massinger.\n\n2. (Zoöl.)\n\nDefn: The chimæra."
     ],
-    "references": [
-      "SEA RAT"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA RAVEN",
@@ -36948,8 +36661,7 @@
     "references": [
       "CORMORANT",
       "RAVEN",
-      "SCULPIN",
-      "SEA RAVEN"
+      "SCULPIN"
     ]
   },
   {
@@ -37233,18 +36945,14 @@
     "variants": [
       "SEA REED\nSea\" reed`. (Bot.)\n\nDefn: The sea-sand reed. See under Reed."
     ],
-    "references": [
-      "SEA REED"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA RISK",
     "variants": [
       "SEA RISK\nSea\" risk.\n\nDefn: Risk of injury, destruction, or loss by the sea, or while at\nsea."
     ],
-    "references": [
-      "SEA RISK"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA ROBBER",
@@ -37253,7 +36961,6 @@
     ],
     "references": [
       "BUCCANEER",
-      "SEA ROBBER",
       "SEA ROVER"
     ]
   },
@@ -37266,7 +36973,6 @@
       "GRUNTER",
       "GURNARD; GURNET",
       "ROBIN",
-      "SEA ROBIN",
       "WINGFISH"
     ]
   },
@@ -37276,8 +36982,7 @@
       "SEA ROCKET\nSea\" rock\"et.(Bot.)\n\nDefn: See under Rocket."
     ],
     "references": [
-      "ROCKET",
-      "SEA ROCKET"
+      "ROCKET"
     ]
   },
   {
@@ -37287,8 +36992,7 @@
     ],
     "references": [
       "BERTH",
-      "CLEAR",
-      "SEA ROOM"
+      "CLEAR"
     ]
   },
   {
@@ -37297,8 +37001,7 @@
       "SEA ROVER\nSea\" rov\"er.\n\nDefn: One that cruises or roves the sea for plunder; a sea robber; a\npirate; also, a piratical vessel."
     ],
     "references": [
-      "SEA ROBBER",
-      "SEA ROVER"
+      "SEA ROBBER"
     ]
   },
   {
@@ -37315,8 +37018,7 @@
     ],
     "references": [
       "SALMON",
-      "SEA BASS",
-      "SEA SALMON"
+      "SEA BASS"
     ]
   },
   {
@@ -37325,8 +37027,7 @@
       "SEA SALT\nSea\" salt`.\n\nDefn: Common salt, obtained from sea water by evaporation."
     ],
     "references": [
-      "MURIATIC",
-      "SEA SALT"
+      "MURIATIC"
     ]
   },
   {
@@ -37334,27 +37035,21 @@
     "variants": [
       "SEA SANDPIPER\nSea\" sand\"pi`per. (Zoöl.)\n\nDefn: The purple sandpiper."
     ],
-    "references": [
-      "SEA SANDPIPER"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA SANDWORT",
     "variants": [
       "SEA SANDWORT\nSea\" sand\"wort`. (Bot.)\n\nDefn: See Sea chickweed."
     ],
-    "references": [
-      "SEA SANDWORT"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA SAURIAN",
     "variants": [
       "SEA SAURIAN\nSea\" sau\"ri*an, n. (Zoöl.)\n\nDefn: Any marine saurian; esp. (Paleon.) the large extinct species of\nMosasaurus, Icthyosaurus, Plesiosaurus, and related genera."
     ],
-    "references": [
-      "SEA SAURIAN"
-    ]
+    "references": []
   },
   {
     "spellings": "SEASCAPE",
@@ -37368,18 +37063,14 @@
     "variants": [
       "SEA SCORPION\nSea\" scor\"pi*on. (Zoöl.)\n(a) A European sculpin (Cottus scorpius) having the head armed with\nshort spines.\n(b) The scorpene."
     ],
-    "references": [
-      "SEA SCORPION"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA SCURF",
     "variants": [
       "SEA SCURF\nSea\" scurf`. (Zoöl.)\n\nDefn: Any bryozoan which forms rounded or irregular patches of coral\non stones, seaweeds, etc."
     ],
-    "references": [
-      "SEA SCURF"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA SERPENT",
@@ -37388,8 +37079,7 @@
     ],
     "references": [
       "KRAKEN",
-      "MOSASAURIA",
-      "SEA SERPENT"
+      "MOSASAURIA"
     ]
   },
   {
@@ -37484,7 +37174,6 @@
       "SEA SLATER\nSea\" slat\"er. (Zoöl.)\n\nDefn: Any isopod crustacean of the genus Ligia."
     ],
     "references": [
-      "SEA SLATER",
       "SEA WOOD LOUSE"
     ]
   },
@@ -37495,7 +37184,6 @@
     ],
     "references": [
       "HOLOTHURIAN",
-      "SEA SLUG",
       "SLUG",
       "TREPANG"
     ]
@@ -37506,7 +37194,6 @@
       "SEA SNAIL\nSea\" snail`. (Zoöl.)\n(a) A small fish of the genus Liparis, having a ventral sucker. It\nlives among stones and seaweeds.\n(b) Any small creeping marine gastropod, as the species of Littorina,\nNatica, etc."
     ],
     "references": [
-      "SEA SNAIL",
       "SNAIL",
       "SNAILFISH"
     ]
@@ -37519,8 +37206,7 @@
     "references": [
       "HYDROPHID",
       "PROTEROGLYPHA",
-      "SEA SERPENT",
-      "SEA SNAKE"
+      "SEA SERPENT"
     ]
   },
   {
@@ -37529,7 +37215,6 @@
       "SEA SNIPE\nSea\" snipe`. (Zoöl.)\n(a) A sandpiper, as the knot and dunlin.\n(b) The bellows fish."
     ],
     "references": [
-      "SEA SNIPE",
       "SNIPE"
     ]
   },
@@ -37795,18 +37480,14 @@
     "variants": [
       "SEA SPIDER\nSea\" spi\"der. (Zoöl.)\n(a) Any maioid crab; a spider crab. See Maioid, and Spider crab,\nunder Spider.\n(b) Any pycnogonid."
     ],
-    "references": [
-      "SEA SPIDER"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA SQUIRT",
     "variants": [
       "SEA SQUIRT\nSea\" squirt`. (Zoöl.)\n\nDefn: An ascidian. See Illust. under Tunicata."
     ],
-    "references": [
-      "SEA SQUIRT"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA STAR",
@@ -37814,7 +37495,6 @@
       "SEA STAR\nSea\" star`. (Zoöl.)\n\nDefn: A starfish, or brittle star."
     ],
     "references": [
-      "SEA STAR",
       "STARFISH"
     ]
   },
@@ -37824,7 +37504,6 @@
       "SEA SURGEON\nSea\" sur\"geon. (Zoöl.)\n\nDefn: A surgeon fish."
     ],
     "references": [
-      "SEA SURGEON",
       "SURGEON"
     ]
   },
@@ -37836,8 +37515,7 @@
     "references": [
       "CHOUGH",
       "FAIRY",
-      "SCRAY",
-      "SEA SWALLOW"
+      "SCRAY"
     ]
   },
   {
@@ -38090,36 +37768,28 @@
     "variants": [
       "SEA TANG\nSea\" tang`. (Bot.)\n\nDefn: A kind of seaweed; tang; tangle.\nTo their nests of sedge and sea tang. Longfellow."
     ],
-    "references": [
-      "SEA TANG"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA TERM",
     "variants": [
       "SEA TERM\nSea\" term`.\n\nDefn: A term used specifically by seamen; a nautical word or phrase."
     ],
-    "references": [
-      "SEA TERM"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA THIEF",
     "variants": [
       "SEA THIEF\nSea\" thief`.\n\nDefn: A pirate. Drayton."
     ],
-    "references": [
-      "SEA THIEF"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA THONGS",
     "variants": [
       "SEA THONGS\nSea\" thongs`. (Bot.)\n\nDefn: A kind of blackish seaweed (Himanthalia lorea) found on the\nnorthern coasts of the Atlantic. It has a thonglike forking process\nrising from a top-shaped base."
     ],
-    "references": [
-      "SEA THONGS"
-    ]
+    "references": []
   },
   {
     "spellings": "SEATING",
@@ -38137,9 +37807,7 @@
     "variants": [
       "SEA TITLING\nSea\" tit\"ling. (Zoöl.)\n\nDefn: The rock pipit."
     ],
-    "references": [
-      "SEA TITLING"
-    ]
+    "references": []
   },
   {
     "spellings": "SEATLESS",
@@ -38153,9 +37821,7 @@
     "variants": [
       "SEA TOAD\nSea\" toad`. (Zoöl.)\n(a) A sculpin.\n(b) A toadfish.\n(c) The angler."
     ],
-    "references": [
-      "SEA TOAD"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA TROUT",
@@ -38166,7 +37832,6 @@
       "HERLING; HIRLING",
       "ROCK",
       "SALMON",
-      "SEA TROUT",
       "SQUETEAGUE",
       "TROUT"
     ]
@@ -38177,7 +37842,6 @@
       "SEA TRUMPET\nSea\" trum\"pet.\n\n1. (Bot.)\n\nDefn: A great blackish seaweed of the Southern Ocean, having a hollow\nand expanding stem and a pinnate frond, sometimes twenty feet long.\n\n2. (Zoöl.)\n\nDefn: Any large marine univalve shell of the genus Triton. See\nTriton."
     ],
     "references": [
-      "SEA TRUMPET",
       "TRITON",
       "TRUMPET",
       "TRUMPETWEED"
@@ -38188,9 +37852,7 @@
     "variants": [
       "SEA TURN\nSea\" turn`.\n\nDefn: A breeze, gale, or mist from the sea. Ham. Nav. Encyc."
     ],
-    "references": [
-      "SEA TURN"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA TURTLE",
@@ -38202,7 +37864,6 @@
       "HAWKBILL",
       "LEATHERBACK",
       "PADDLE",
-      "SEA TURTLE",
       "TORTOISE",
       "TURTLE"
     ]
@@ -38213,8 +37874,7 @@
       "SEA UNICORN\nSea\" u\"ni*corn. (Zoöl.)\n\nDefn: The narwhal."
     ],
     "references": [
-      "NARWHAL",
-      "SEA UNICORN"
+      "NARWHAL"
     ]
   },
   {
@@ -38250,7 +37910,6 @@
       "SAND",
       "SEA EGG",
       "SEA HEDGEHOG",
-      "SEA URCHIN",
       "SEMITA",
       "SIPHON",
       "SPATANGOIDEA",
@@ -38285,7 +37944,6 @@
       "FACING",
       "FORE",
       "PIERRE-PERDU",
-      "SEA WALL",
       "WATER GANG",
       "WHARFING"
     ]
@@ -38401,9 +38059,7 @@
     "variants": [
       "SEA WHIP\nSea\" whip`. (Zoöl.)\n\nDefn: A gorgonian having a simple stem."
     ],
-    "references": [
-      "SEA WHIP"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA WIDGEON",
@@ -38411,7 +38067,6 @@
       "SEA WIDGEON\nSea\" wid\"geon. (Zoöl.)\n(a) The scaup duck.\n(b) The pintail duck."
     ],
     "references": [
-      "SEA WIDGEON",
       "WIDGEON"
     ]
   },
@@ -38429,27 +38084,21 @@
     "variants": [
       "SEA WILLOW\nSea\" wil\"low. (Zoöl.)\n\nDefn: A gorgonian coral with long flexible branches."
     ],
-    "references": [
-      "SEA WILLOW"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA WING",
     "variants": [
       "SEA WING\nSea\" wing`. (Zoöl.)\n\nDefn: A wing shell (Avicula)."
     ],
-    "references": [
-      "SEA WING"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA WITHWIND",
     "variants": [
       "SEA WITHWIND\nSea\" with\"wind`.\n\nDefn: (Bot.) A kind of bindweed (Convolvulus Soldanella) growing on\nthe seacoast of Europe."
     ],
-    "references": [
-      "SEA WITHWIND"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA WOLF",
@@ -38457,7 +38106,6 @@
       "SEA WOLF\nSea\" wolf`. (Zoöl.)\n(a) The wolf fish.\n(b) The European sea perch.\n(c) The sea elephant.\n(d) A sea lion."
     ],
     "references": [
-      "SEA WOLF",
       "WOLF"
     ]
   },
@@ -38467,7 +38115,6 @@
       "SEA WOODCOCK\nSea\" wood\"cock`. (Zoöl.)\n\nDefn: The bar-tailed godwit."
     ],
     "references": [
-      "SEA WOODCOCK",
       "WOODCOCK"
     ]
   },
@@ -38476,18 +38123,14 @@
     "variants": [
       "SEA WOOD LOUSE\nSea\" wood louse`. (Zoöl.)\n\nDefn: A sea slater."
     ],
-    "references": [
-      "SEA WOOD LOUSE"
-    ]
+    "references": []
   },
   {
     "spellings": "SEA WORMWOOD",
     "variants": [
       "SEA WORMWOOD\nSea\" worm\"wood`. (Bot.)\n\nDefn: A European species of wormwood (Artemisia maritima) growing by\nthe sea."
     ],
-    "references": [
-      "SEA WORMWOOD"
-    ]
+    "references": []
   },
   {
     "spellings": "SEAWORTHINESS",
@@ -38512,7 +38155,6 @@
       "SEA WRACK\nSea\" wrack`. (Bot.)\n\nDefn: See Wrack."
     ],
     "references": [
-      "SEA WRACK",
       "ZOSTERA"
     ]
   },
@@ -40288,9 +39930,7 @@
     "variants": [
       "SECRET SERVICE\nSe\"cret serv\"ice.\n\nDefn: The detective service of a government. In the United States, in\ntime of peace the bureau of secret service is under the treasury\ndepartment, and in time of war it aids the war department in securing\ninformation concerning the movements of the enemy."
     ],
-    "references": [
-      "SECRET SERVICE"
-    ]
+    "references": []
   },
   {
     "spellings": "SECT",
@@ -52729,7 +52369,6 @@
       "SELTERS WATER\nSel\"ters wa\"ter.\n\nDefn: A mineral water from Sellers, in the district of Nassan,\nGermany, containing much free carbonic acid."
     ],
     "references": [
-      "SELTERS WATER",
       "SELTZER WATER"
     ]
   },
@@ -52739,7 +52378,6 @@
       "SELTZER WATER\nSelt\"zer wa\"ter.\n\nDefn: See Selters water."
     ],
     "references": [
-      "SELTZER WATER",
       "SELTZO-GENE"
     ]
   },
@@ -53365,9 +53003,7 @@
     "variants": [
       "SEMI CIRCUMFERENCE\nSem`i cir*cum\"fer*ence, n.\n\nDefn: Half of a circumference."
     ],
-    "references": [
-      "SEMI CIRCUMFERENCE"
-    ]
+    "references": []
   },
   {
     "spellings": "SEMICIRQUE",
@@ -53428,9 +53064,7 @@
     "variants": [
       "SEMI CRUSTACEOUS\nSem`i crus*ta\"ceous, a.\n\nDefn: Half crustaceous; partially crustaceous."
     ],
-    "references": [
-      "SEMI CRUSTACEOUS"
-    ]
+    "references": []
   },
   {
     "spellings": "SEMICRYSTALLINE",
@@ -54194,9 +53828,7 @@
     "variants": [
       "SEMI PUPA\nSem`i pu\"pa, n. (Zoöl.)\n\nDefn: The young of an insect in a stage between the larva and pupa."
     ],
-    "references": [
-      "SEMI PUPA"
-    ]
+    "references": []
   },
   {
     "spellings": "SEMIQUADRATE; SEMIQUARTILE",
@@ -54243,8 +53875,7 @@
     ],
     "references": [
       "RADIAL ENGINE",
-      "RADIANT ENGINE",
-      "SEMIRADIAL ENGINE"
+      "RADIANT ENGINE"
     ]
   },
   {
@@ -58104,9 +57735,7 @@
     "variants": [
       "SENTENCE METHOD\nSen\"tence meth`od. (Education)\n\nDefn: A method of teaching reading by giving first attention to\nphrases and sentences and later analyzing these into their verbal and\nalphabetic components; -- contrasted with alphabet and word methods."
     ],
-    "references": [
-      "SENTENCE METHOD"
-    ]
+    "references": []
   },
   {
     "spellings": "SENTENCER",
@@ -61671,27 +61300,21 @@
     "variants": [
       "SERIES DYNAMO\nSeries dynamo. (Elec.)\n (a) A series-wound dynamo.\n (b) A dynamo running in series with another or others."
     ],
-    "references": [
-      "SERIES DYNAMO"
-    ]
+    "references": []
   },
   {
     "spellings": "SERIES MOTOR",
     "variants": [
       "SERIES MOTOR\nSeries motor. (Elec.)\n (a) A series-wound motor.\n (b) A motor capable of being used in a series circuit."
     ],
-    "references": [
-      "SERIES MOTOR"
-    ]
+    "references": []
   },
   {
     "spellings": "SERIES TURNS",
     "variants": [
       "SERIES TURNS\nSeries turns. (Elec.)\n\nDefn: The turns in a series circuit."
     ],
-    "references": [
-      "SERIES TURNS"
-    ]
+    "references": []
   },
   {
     "spellings": "SERIES WINDING",
@@ -61699,7 +61322,6 @@
       "SERIES WINDING\nSeries winding. (Elec.)\n\nDefn: A winding in which the armature coil and the field-magnet coil\nare in series with the external circuits; -- opposed to shunt\nwinding. --Se\"ries-wound`, a."
     ],
     "references": [
-      "SERIES WINDING",
       "SHUNT WINDING"
     ]
   },
@@ -63776,18 +63398,14 @@
     "variants": [
       "SERVICE CAP; SERVICE HAT\nServ\"ice cap or hat. (Mil.)\n\nDefn: A cap or hat worn by officers or enlisted men when full-dress\nuniform, or dress uniform, is not worn. In the United States army the\nservice cap is round, about 3½ inches high, flat-topped, with  a\nvisor. The service hat is of soft felt of khaki color, with  broad\nbrim and high crown, creased down the middle."
     ],
-    "references": [
-      "SERVICE CAP; SERVICE HAT"
-    ]
+    "references": []
   },
   {
     "spellings": "SERVICE UNIFORM",
     "variants": [
       "SERVICE UNIFORM\nService uniform. (Mil. & Nav.)\n\nDefn: The uniform prescribed in regulations for active or routine\nservice, in distinction from dress, full dress, etc. In the United\nStates army it is of olive-drab woolen or khaki-colored cotton, with\nall metal attachments of dull-finish bronze, with the exceptional of\ninsignia of rank, which are of gold or silver finish."
     ],
-    "references": [
-      "SERVICE UNIFORM"
-    ]
+    "references": []
   },
   {
     "spellings": "SERVIENT",
@@ -65949,9 +65567,7 @@
     "variants": [
       "SET CHISEL\nSet chisel. (Mech.)\n\nDefn: A kind of chisel or punch, variously shaped, with a broad flat\nend, used for stripping off rivet heads, etc."
     ],
-    "references": [
-      "SET CHISEL"
-    ]
+    "references": []
   },
   {
     "spellings": "SETDOWN",
@@ -66352,9 +65968,7 @@
     "variants": [
       "SETTING-UP EXERCISE\nSet`ting-up\" ex\"er*cise.\n\nDefn: Any one of a series of gymnastic exercises used, as in drilling\nrecruits, for the purpose of giving an erect carriage, supple\nmuscles, and an easy control of the limbs."
     ],
-    "references": [
-      "SETTING-UP EXERCISE"
-    ]
+    "references": []
   },
   {
     "spellings": "SETTLE",
@@ -68981,18 +68595,14 @@
     "variants": [
       "SEVRES BLUE\nSè\"vres blue`.\n\nDefn: A very light blue."
     ],
-    "references": [
-      "SEVRES BLUE"
-    ]
+    "references": []
   },
   {
     "spellings": "SEVRES WARE",
     "variants": [
       "SEVRES WARE\nSè\"vres ware`.\n\nDefn: Porcelain manufactured at Sèvres, France, ecpecially in the\nnational factory situated there."
     ],
-    "references": [
-      "SEVRES WARE"
-    ]
+    "references": []
   },
   {
     "spellings": "SEW",
@@ -75004,27 +74614,21 @@
     "variants": [
       "SHASTA DAISY\nShasta daisy.\n\nDefn: A large-flowered garden variety of the oxeye daisy."
     ],
-    "references": [
-      "SHASTA DAISY"
-    ]
+    "references": []
   },
   {
     "spellings": "SHASTA FIR",
     "variants": [
       "SHASTA FIR\nShasta fir.\n\nDefn: A Californian fir (Abies shastensis)."
     ],
-    "references": [
-      "SHASTA FIR"
-    ]
+    "references": []
   },
   {
     "spellings": "SHASTA SAM",
     "variants": [
       "SHASTA SAM\nShasta Sam. (Card Playing)\n\nDefn: A game like California Jack, except that the pack drawn from is\nturned face down."
     ],
-    "references": [
-      "SHASTA SAM"
-    ]
+    "references": []
   },
   {
     "spellings": "SHASTER; SHASTRA",
@@ -76243,8 +75847,7 @@
     ],
     "references": [
       "SHEAR",
-      "SHEARING",
-      "SHEAR STEEL"
+      "SHEARING"
     ]
   },
   {
@@ -76481,7 +76084,6 @@
     ],
     "references": [
       "BUTTER",
-      "SHEA TREE",
       "VEGETABLE"
     ]
   },
@@ -77455,7 +77057,6 @@
     "references": [
       "ANCHOR",
       "CABLE",
-      "SHEET ANCHOR",
       "SHEET CABLE",
       "WAIST"
     ]
@@ -77467,7 +77068,6 @@
     ],
     "references": [
       "CABLE",
-      "SHEET CABLE",
       "SHEET CHAIN"
     ]
   },
@@ -77476,9 +77076,7 @@
     "variants": [
       "SHEET CHAIN\nSheet\" chain\". (Naut.)\n\nDefn: A chain sheet cable."
     ],
-    "references": [
-      "SHEET CHAIN"
-    ]
+    "references": []
   },
   {
     "spellings": "SHEETFUL",
@@ -78857,8 +78455,7 @@
       "SHETLAND PONY\nShet\"land po\"ny.\n\nDefn: One of a small, hardy breed of horses, with long mane and tail,\nwhich originated in the Shetland Islands; a sheltie."
     ],
     "references": [
-      "SHELTIE; SHELTY",
-      "SHETLAND PONY"
+      "SHELTIE; SHELTY"
     ]
   },
   {
@@ -79894,9 +79491,7 @@
     "variants": [
       "SHIN SHU\nShin Shu. [Jap., lit., true sect.]\n\nDefn: The leading and most progressive Buddhist sect of Japan,\nresting its faith rather upon Amida than Gautama Buddha. Rites and\nceremonies are held useless without uprightness."
     ],
-    "references": [
-      "SHIN SHU"
-    ]
+    "references": []
   },
   {
     "spellings": "SHINTIYAN; SHINTYAN",
@@ -80832,9 +80427,7 @@
     "variants": [
       "SHIPPING NOTE\nShip\"ping note. (Com.)\n\nDefn: A document used in shipping goods by sea. In the case of free\ngoods the shipping notes are the receiving note, addressed by the\nshipper to the chief officer of the vessel, requesting him to receive\non board specified goods, and a receipt for the mate to sign, on\nreceiving whose signature it is called the mate's receipt, and is\nsurrendered by the shipper for the bills of lading."
     ],
-    "references": [
-      "SHIPPING NOTE"
-    ]
+    "references": []
   },
   {
     "spellings": "SHIPPO",
@@ -80856,8 +80449,7 @@
       "SHIP RAILWAY\nShip railway.\n (a) An inclined railway running into the water with a cradelike car\non which a vessel may be drawn out on land, as for repairs.\n (b) A railway on which to transport vessels overland between bodies\nof water."
     ],
     "references": [
-      "SHIP",
-      "SHIP RAILWAY"
+      "SHIP"
     ]
   },
   {
@@ -80956,9 +80548,7 @@
     "variants": [
       "SHIRE HORSE\nShire horse.\n\nDefn: One of an English breed of heavy draft horses believed to be\ndescended largely from the horses used in war in the days of heavy\narmor. They are the  largest of the British draft breeds, and have\nlong hair on the back of the cannons and fetlocks. Brown or bay with\nwhite on the face and legs is now the commonest color."
     ],
-    "references": [
-      "SHIRE HORSE"
-    ]
+    "references": []
   },
   {
     "spellings": "SHIRK",
@@ -81097,18 +80687,14 @@
     "variants": [
       "SHIRT WAIST\nShirt waist.\n\nDefn: A belted waist resembling a shirt in plainness of cut and\nstyle, worn by women or children; -- in England called a blouse."
     ],
-    "references": [
-      "SHIRT WAIST"
-    ]
+    "references": []
   },
   {
     "spellings": "SHIRT-WAIST SUIT",
     "variants": [
       "SHIRT-WAIST SUIT\nShirt-waist suit.\n\nDefn: A costume consisting of a plain belted waist and skirt of the\nsame material."
     ],
-    "references": [
-      "SHIRT-WAIST SUIT"
-    ]
+    "references": []
   },
   {
     "spellings": "SHIST; SHISTOSE",
@@ -81123,7 +80709,6 @@
       "SHITTAH; SHITTAH TREE\nShit\"tah, Shit\"tah tree`, n. Etym: [Heb. shittah, pl. shittim.]\n\nDefn: A tree that furnished the precious wood of which the ark,\ntables, altars, boards, etc., of the Jewish tabernacle were made; --\nnow believed to have been the wood of the Acacia Seyal, which is\nhard, fine grained, and yellowish brown in color."
     ],
     "references": [
-      "SHITTAH; SHITTAH TREE",
       "SHITTIM; SHITTIM WOOD"
     ]
   },
@@ -81135,8 +80720,7 @@
     "references": [
       "BAR",
       "SETIM",
-      "SHITTAH; SHITTAH TREE",
-      "SHITTIM; SHITTIM WOOD"
+      "SHITTAH; SHITTAH TREE"
     ]
   },
   {
@@ -81505,9 +81089,7 @@
     "variants": [
       "SHODDY FEVER\nShoddy fever. (Med.)\n\nDefn: A febrile disease characterized by dyspnoa and bronchitis\ncaused by inhaling dust."
     ],
-    "references": [
-      "SHODDY FEVER"
-    ]
+    "references": []
   },
   {
     "spellings": "SHODDYISM",
@@ -83570,8 +83152,7 @@
       "SHORT CIRCUIT\nShort\" cir\"cuit. (Elec.)\n\nDefn: A circuit formed or closed by a conductor of relatively low\nresistance because shorter or of relatively great conductivity."
     ],
     "references": [
-      "LIGHTNING",
-      "SHORT CIRCUIT"
+      "LIGHTNING"
     ]
   },
   {
@@ -84103,9 +83684,7 @@
     "variants": [
       "SHOT SAMPLES\nShot samples. (Metal.)\n\nDefn: Samples taken for assay from  a molten metallic mass pouring a\nportion into water, to granulate it."
     ],
-    "references": [
-      "SHOT SAMPLES"
-    ]
+    "references": []
   },
   {
     "spellings": "SHOTTED",
@@ -87609,18 +87188,14 @@
     "variants": [
       "SHUNT VALVE\nShunt valve. (Mach.)\n\nDefn: A valve permitting a fluid under pressure an easier avenue of\nescape than normally; specif., a valve, actuated by the governor,\nused in one system of marine-engine governing to connect both ends of\nthe low-pressure cylinder as a supplementary control."
     ],
-    "references": [
-      "SHUNT VALVE"
-    ]
+    "references": []
   },
   {
     "spellings": "SHUNT WINDING",
     "variants": [
       "SHUNT WINDING\nShunt winding. (Elec.)\n\nDefn: A winding so arranged as to divide the armature current and\nlead a portion of it around the field-magnet coils; -- opposed to\nseries winding. --Shunt\"-wound` (#), a."
     ],
-    "references": [
-      "SHUNT WINDING"
-    ]
+    "references": []
   },
   {
     "spellings": "SHUT",
@@ -90252,9 +89827,7 @@
     "variants": [
       "SIDE-CHAIN THEORY\nSide\"-chain` the`o*ry. (Physiol. Chem.)\n\nDefn: A theory proposed by Ehrlich as a chemical explanation of\nimmunity phenomena. In brief outline it is as follows: Animal cells\nand bacteria are complex aggregations of molecules, which are\nthemselves complex. Complex molecules react with one another through\ncertain of their side chains, but only when these side chains have a\ndefinite correspondence in structure (this account for the specific\naction of antitoxins)."
     ],
-    "references": [
-      "SIDE-CHAIN THEORY"
-    ]
+    "references": []
   },
   {
     "spellings": "SIDED",
@@ -90294,8 +89867,7 @@
     "references": [
       "FEEDER",
       "LINE",
-      "LYE",
-      "SIDE LINE"
+      "LYE"
     ]
   },
   {
@@ -90513,9 +90085,7 @@
     "variants": [
       "SIDE SLIP\nSide slip.\n\nDefn: See Skid, below."
     ],
-    "references": [
-      "SIDE SLIP"
-    ]
+    "references": []
   },
   {
     "spellings": "SIDE-SLIP",
@@ -90706,8 +90276,7 @@
       "SIEMENS-MARTIN PROCESS\nSie\"mens-Mar`tin proc\"ess.\n\nDefn: See Open-hearth process, etc., under Open."
     ],
     "references": [
-      "OPEN",
-      "SIEMENS-MARTIN PROCESS"
+      "OPEN"
     ]
   },
   {
@@ -90716,8 +90285,7 @@
       "SIEMENS-MARTIN STEEL\nSie\"mens-Mar\"tin steel.\n\nDefn: See Open-hearth steel, under Open."
     ],
     "references": [
-      "OPEN",
-      "SIEMENS-MARTIN STEEL"
+      "OPEN"
     ]
   },
   {
@@ -94846,9 +94414,7 @@
     "variants": [
       "SILVER CERTIFICATE\nSil\"ver cer*tif\"i*cate.\n\nDefn: A certificate issued by a government that there has been\ndeposited with it silver to a specified amount, payable to the bearer\non demand. In the United States and its possessions, it is issued\nagainst the deposit of silver coin, and is not legal tender, but is\nreceivable for customs, taxes, and all public dues."
     ],
-    "references": [
-      "SILVER CERTIFICATE"
-    ]
+    "references": []
   },
   {
     "spellings": "SILVERFIN",
@@ -94976,9 +94542,7 @@
     "variants": [
       "SILVER STATE\nSilver State.\n\nDefn: Nevada; -- a nickname alluding to its silver mines."
     ],
-    "references": [
-      "SILVER STATE"
-    ]
+    "references": []
   },
   {
     "spellings": "SILVERWARE",
@@ -99306,9 +98870,7 @@
     "variants": [
       "SINGLE TAX\nSin\"gle tax`. (Pol. Econ.)\n\nDefn: A tax levied upon land alone, irrespective of improvements, --\nadvocated by certain economists as the sole source of public revenue.\n\nWhatever may be thought of Henry George's single-tax theory as a\nwhole, there can be little question that a relatively higher\nassessment of ground rent, with corresponding relief for those who\nhave made improvements, is a much-needed reform.\nA. T. Hadley."
     ],
-    "references": [
-      "SINGLE TAX"
-    ]
+    "references": []
   },
   {
     "spellings": "SINGLETON",
@@ -100250,9 +99812,7 @@
     "variants": [
       "SIOUX STATE\nSioux State.\n\nDefn: North Dakota; -- a nickname."
     ],
-    "references": [
-      "SIOUX STATE"
-    ]
+    "references": []
   },
   {
     "spellings": "SIP",
@@ -100676,9 +100236,7 @@
     "variants": [
       "SI QUIS\nSi` quis\". Etym: [L., if any one (the first words of the notice in\nLatin).] (Ch. of Eng.)\n\nDefn: A notification by a candidate for orders of his intention to\ninquire whether any impediment may be alleged against him."
     ],
-    "references": [
-      "SI QUIS"
-    ]
+    "references": []
   },
   {
     "spellings": "SIR",
@@ -104540,8 +104098,7 @@
     ],
     "references": [
       "HEMP",
-      "JENIQUEN",
-      "SISAL GRASS; SISAL HEMP"
+      "JENIQUEN"
     ]
   },
   {
@@ -105780,8 +105337,7 @@
       "SITZ BATH\nSitz\" bath`. Etym: [G. sitzbad.]\n\nDefn: A tub in which one bathes in a sitting posture; also, a bath so\ntaken; a hip bath."
     ],
     "references": [
-      "BIDET",
-      "SITZ BATH"
+      "BIDET"
     ]
   },
   {
@@ -107936,8 +107492,7 @@
       "SKID ROAD\nSkid road. (Logging)\n (a) A road along which logs are dragged to the skidway or landing; -\n- called also travois, or travoy, road.\n (b) A road having partly sunken transverse logs (called skids) at\nintervals of about five feet."
     ],
     "references": [
-      "SKIDDER",
-      "SKID ROAD"
+      "SKIDDER"
     ]
   },
   {
@@ -110339,7 +109894,6 @@
     ],
     "references": [
       "CLYDESDALE TERRIER",
-      "SKYE TERRIER",
       "TERRIER"
     ]
   },
@@ -110412,9 +109966,7 @@
     "variants": [
       "SKY PILOT\nSky pilot. (Aëronautics)\n\nDefn: A person licensed as a pilot. [Slang]"
     ],
-    "references": [
-      "SKY PILOT"
-    ]
+    "references": []
   },
   {
     "spellings": "SKYROCKET",
@@ -111184,9 +110736,7 @@
     "variants": [
       "SLASH PINE\nSlash\" pine\". (Bot.)\n\nDefn: A kind of pine tree (Pinus Cubensis) found in Southern Florida\nand the West Indies; -- so called because it grows in \"slashes.\""
     ],
-    "references": [
-      "SLASH PINE"
-    ]
+    "references": []
   },
   {
     "spellings": "SLASHY",
@@ -114611,9 +114161,7 @@
     "variants": [
       "SLIPCOAT CHEESE\nSlip\"coat` cheese\".\n\nDefn: A rich variety of new cheese, resembling butter, but white.\nHalliwell."
     ],
-    "references": [
-      "SLIPCOAT CHEESE"
-    ]
+    "references": []
   },
   {
     "spellings": "SLIPES",
@@ -115451,8 +114999,7 @@
       "SLOT MACHINE\nSlot\" ma*chine\".\n\nDefn: A machine the operation of which is started by dropping a coin\ninto a slot, for delivering small articles of merchandise, showing\none's weight, exhibiting pictures, throwing dice, etc."
     ],
     "references": [
-      "JACK-O'-LANTERN",
-      "SLOT MACHINE"
+      "JACK-O'-LANTERN"
     ]
   },
   {
@@ -116072,9 +115619,7 @@
     "variants": [
       "SLUDGE ACID\nSludge acid.\n\nDefn: Impure dark-colored sulphuric acid that has been used in the\nrefining of petroleum."
     ],
-    "references": [
-      "SLUDGE ACID"
-    ]
+    "references": []
   },
   {
     "spellings": "SLUDGER",
@@ -116199,9 +115744,7 @@
     "variants": [
       "SLUGGING MATCH\nSlug\"ging match.\n (a) A boxing match or prize fight marked rather by heavy hitting\nthan skill. [Cant or Slang]\n (b) A ball game, esp. a baseball game, in which  there is much hard\nhitting of the ball. [Slang, U. S.]"
     ],
-    "references": [
-      "SLUGGING MATCH"
-    ]
+    "references": []
   },
   {
     "spellings": "SLUGGISH",
@@ -120489,8 +120032,7 @@
       "SMEAR DAB\nSmear\" dab\". (Zoöl.)\n\nDefn: The sand fluke (b). [Prov. Eng.]"
     ],
     "references": [
-      "SAND",
-      "SMEAR DAB"
+      "SAND"
     ]
   },
   {
@@ -120799,7 +120341,6 @@
       "SMELLING SALTS\nSmell\"ing salts.\n\nDefn: An aromatic preparation of carbonate of ammonia and, often,\nsome scent, to avoid or relieve faintness, headache, or the like."
     ],
     "references": [
-      "SMELLING SALTS",
       "VINAIGRETTE"
     ]
   },
@@ -121585,8 +121126,7 @@
       "BLOUSE",
       "FROCK",
       "SLOP",
-      "SMOCK",
-      "SMOCK FROCK"
+      "SMOCK"
     ]
   },
   {
@@ -121754,8 +121294,7 @@
       "SMOKE BALL\nSmoke ball.\n\nDefn: Same as Puffball."
     ],
     "references": [
-      "SMOKE",
-      "SMOKE BALL"
+      "SMOKE"
     ]
   },
   {
@@ -121799,8 +121338,7 @@
     ],
     "references": [
       "BALLISTITE",
-      "CORDITE",
-      "SMOKELESS POWDER"
+      "CORDITE"
     ]
   },
   {
@@ -122597,9 +122135,7 @@
     "variants": [
       "SMOTHERED MATE\nSmoth\"ered mate. (Chess)\n\nDefn: Checkmate given when movement of the king is completely\nobstructed by his own men."
     ],
-    "references": [
-      "SMOTHERED MATE"
-    ]
+    "references": []
   },
   {
     "spellings": "SMOTHERINESS",
@@ -123323,8 +122859,7 @@
       "SNAPSHOT; SNAP SHOT\nSnap\"shot`, n.\n\n1. Commonly Snap shot.\n (a) A quick offhand shot, made without deliberately taking aim over\nthe sights.\n (b) (Photog.) Act of taking a snapshot (in sense 2).\n\n2.  An instantaneous photograph made, usually with a hand camera,\nwithout formal posing of, and often without the foreknowledge of, the\nsubject."
     ],
     "references": [
-      "SNAP",
-      "SNAPSHOT; SNAP SHOT"
+      "SNAP"
     ]
   },
   {
@@ -123549,9 +123084,7 @@
     "variants": [
       "SNATCH BLOCK\nSnatch block (Naut.),\n\nDefn: a kind of block with an opening in one side to receive the\nbight of a rope."
     ],
-    "references": [
-      "SNATCH BLOCK"
-    ]
+    "references": []
   },
   {
     "spellings": "SNATCHER",
@@ -123665,9 +123198,7 @@
     "variants": [
       "SNEAK CURRENT\nSneak current. (Elec.)\n\nDefn: A current which, though too feeble to blow the usual fuse or to\ninjure at once telegraph or telephone instruments, will in time burn\nthem out."
     ],
-    "references": [
-      "SNEAK CURRENT"
-    ]
+    "references": []
   },
   {
     "spellings": "SNEAKER",
@@ -123967,9 +123498,7 @@
     "variants": [
       "SNIDER RIFLE; SNIDER\nSni\"der ri\"fle, or Sni\"der, n. (Mil.)\n\nDefn: A breech-loading rifle formerly used in the British service; --\nso called from the inventor."
     ],
-    "references": [
-      "SNIDER RIFLE; SNIDER"
-    ]
+    "references": []
   },
   {
     "spellings": "SNIFF",
@@ -124748,9 +124277,7 @@
     "variants": [
       "SNOW BANNER\nSnow banner.\n\nDefn: A bannerlike stream of snow blown into the air from a mountain\npeak, often having a pinkish color and extending horizontally for\nseveral miles across the sky."
     ],
-    "references": [
-      "SNOW BANNER"
-    ]
+    "references": []
   },
   {
     "spellings": "SNOWBERRY",
@@ -130072,8 +129599,7 @@
       "SOAPBERRY TREE\nSoap\"ber`ry tree`. (Bot.)\n\nDefn: Any tree of the genus Sapindus, esp. Sapindus saponaria, the\nfleshy part of whose fruit is used instead of soap in washing linen;\n-- also called soap tree."
     ],
     "references": [
-      "SOAP",
-      "SOAPBERRY TREE"
+      "SOAP"
     ]
   },
   {
@@ -131678,7 +131204,6 @@
       "MIRABILITE",
       "PROCESS",
       "SODA",
-      "SODIUM SULPHATE",
       "THENARDITE"
     ]
   },
@@ -132722,8 +132247,7 @@
     ],
     "references": [
       "HARVEY PROCESS",
-      "SIDEROGRAPHY",
-      "SOFT STEEL"
+      "SIDEROGRAPHY"
     ]
   },
   {
@@ -133042,7 +132566,6 @@
     ],
     "references": [
       "SOIL",
-      "SOIL PIPE",
       "TRAP"
     ]
   },
@@ -133372,7 +132895,6 @@
       "GANNET",
       "GOOSE",
       "SOLAND",
-      "SOLAN GOOSE",
       "SULA"
     ]
   },
@@ -133552,18 +133074,14 @@
     "variants": [
       "SOLAR MYTH\nSo\"lar myth.\n\nDefn: A myth which essentially consists of allegory based upon ideas\nas to the sun's course, motion, influence, or the like."
     ],
-    "references": [
-      "SOLAR MYTH"
-    ]
+    "references": []
   },
   {
     "spellings": "SOLAR PARALLAX",
     "variants": [
       "SOLAR PARALLAX\nSolar parallax.\n\nDefn: The parallax of the sun, that is, the angle subtended at the\nsun by the semidiameter of the earth. It is 8.\"80, and is the\nfundamental datum."
     ],
-    "references": [
-      "SOLAR PARALLAX"
-    ]
+    "references": []
   },
   {
     "spellings": "SOLARY",
@@ -134779,8 +134297,7 @@
       "SOLE TRADER\nSole trader.\n\nDefn: A feme sole trader."
     ],
     "references": [
-      "FEME",
-      "SOLE TRADER"
+      "FEME"
     ]
   },
   {
@@ -135995,7 +135512,6 @@
     "references": [
       "LADY'S SEAL",
       "SOLOMON",
-      "SOLOMON'S SEAL",
       "WHITEWORT"
     ]
   },
@@ -136017,9 +135533,7 @@
     "variants": [
       "SOLO WHIST\nSolo whist.\n\nDefn: A card game played with the full pack ranking as at whist, each\nplayer declaring for which of seven different points he proposes to\nplay."
     ],
-    "references": [
-      "SOLO WHIST"
-    ]
+    "references": []
   },
   {
     "spellings": "SOLPUGID",
@@ -145748,9 +145262,7 @@
     "variants": [
       "SOONER STATE\nSooner State.\n\nDefn: Oklahoma; -- a nickname."
     ],
-    "references": [
-      "SOONER STATE"
-    ]
+    "references": []
   },
   {
     "spellings": "SOONLY",
@@ -147114,9 +146626,7 @@
     "variants": [
       "SORRENTO WORK\nSor\"ren\"to work`.\n\nDefn: Ornamental work, mostly carved in olivewood, decorated with\ninlay, made at or near Sorrento, Italy. Hence, more rarely, jig-saw\nwork and the like done anywhere."
     ],
-    "references": [
-      "SORRENTO WORK"
-    ]
+    "references": []
   },
   {
     "spellings": "SORRILY",
@@ -148129,9 +147639,7 @@
     "variants": [
       "SOTTO VOCE\nSot`to vo\"ce. Etym: [It.]\n\n1. (Mus.)\n\nDefn: With a restrained voice or moderate force; in an undertone.\n\n2. Spoken low or in an undertone."
     ],
-    "references": [
-      "SOTTO VOCE"
-    ]
+    "references": []
   },
   {
     "spellings": "SOU",
@@ -148174,8 +147682,7 @@
     ],
     "references": [
       "BUTTERNUT",
-      "SAWARRA NUT",
-      "SOUARI NUT"
+      "SAWARRA NUT"
     ]
   },
   {
@@ -149812,9 +149319,7 @@
     "variants": [
       "SOUNDING BALLOON\nSound\"ing bal*loon\".\n\nDefn: An unmanned balloon sent aloft for meteorological or aëronautic\npurposes."
     ],
-    "references": [
-      "SOUNDING BALLOON"
-    ]
+    "references": []
   },
   {
     "spellings": "SOUNDING-BOARD",
@@ -153766,9 +153271,7 @@
     "variants": [
       "SPACE BAR; SPACE KEY\nSpace bar or key. (Mach.)\n\nDefn: A bar or key, in a typewriter or typesetting machine, used for\nspacing between letters."
     ],
-    "references": [
-      "SPACE BAR; SPACE KEY"
-    ]
+    "references": []
   },
   {
     "spellings": "SPACEFUL",
@@ -154141,9 +153644,7 @@
     "variants": [
       "SPALDING KNIFE\nSpald\"ing knife`.\n\nDefn: A spalting knife."
     ],
-    "references": [
-      "SPALDING KNIFE"
-    ]
+    "references": []
   },
   {
     "spellings": "SPALE",
@@ -154195,8 +153696,7 @@
       "SPALTING KNIFE\nSpalt\"ing knife`.\n\nDefn: A knife used in splitting codfish. [Written also spalding\nknife.]"
     ],
     "references": [
-      "SPALDING KNIFE",
-      "SPALTING KNIFE"
+      "SPALDING KNIFE"
     ]
   },
   {
@@ -154600,9 +154100,7 @@
     "variants": [
       "SPANKING BREEZE\nSpanking breeze (Naut.),\n\nDefn: a strong breeze."
     ],
-    "references": [
-      "SPANKING BREEZE"
-    ]
+    "references": []
   },
   {
     "spellings": "SPANLESS",
@@ -155088,9 +154586,7 @@
     "variants": [
       "SPARK COIL\nSpark coil. (Elec.)\n (a) An induction coil, esp. of an internal-combustion engine,\nwireless telegraph apparatus, etc.\n (b) A self-induction coil used to increase the spark in an electric\ngas-lighting apparatus."
     ],
-    "references": [
-      "SPARK COIL"
-    ]
+    "references": []
   },
   {
     "spellings": "SPARKER",
@@ -155112,7 +154608,6 @@
       "SPARK GAP\nSpark gap. (Elec.)\n\nDefn: The space filled with air or other dielectric between high\npotential terminals (as of an electrostatic machine, induction coil,\nor condenser), through which the discharge passes; the air gap of a\njump spark."
     ],
     "references": [
-      "SPARK GAP",
       "SPARK PLUG"
     ]
   },
@@ -155219,9 +154714,7 @@
     "variants": [
       "SPARK PLUG\nSpark plug.\n\nDefn: In internal-combustion engines with electric ignition, a plug,\nscrewed into the cylinder head, having through it an insulated wire\nwhich is connected with the induction coil or magneto circuit on the\noutside, and forms, with another terminal on the base of the plug, a\nspark gap inside the cylinder."
     ],
-    "references": [
-      "SPARK PLUG"
-    ]
+    "references": []
   },
   {
     "spellings": "SPARLING",
@@ -163004,9 +162497,7 @@
     "variants": [
       "SPEED COUNTER\nSpeed counter. (Mach.)\n\nDefn: A device for automatically counting the revolutions or\npulsations of an engine or other machine; -- called also simply\ncounter."
     ],
-    "references": [
-      "SPEED COUNTER"
-    ]
+    "references": []
   },
   {
     "spellings": "SPEEDER",
@@ -164449,7 +163940,6 @@
       "SNUB-NOSED",
       "SPERM",
       "SPERMACETI",
-      "SPERM WHALE",
       "WHALE"
     ]
   },
@@ -165822,9 +165312,7 @@
     "variants": [
       "SPIDER STITCH\nSpi\"der stitch.\n\nDefn: A stitch in lace making used to fill in open spaces with\nthreads resembling a cobweb."
     ],
-    "references": [
-      "SPIDER STITCH"
-    ]
+    "references": []
   },
   {
     "spellings": "SPIDER WEB; SPIDER'S WEB",
@@ -165837,7 +165325,6 @@
       "ARTIFICIALLY",
       "GARDEN",
       "SPIDER",
-      "SPIDER WEB; SPIDER'S WEB",
       "TOIL",
       "WEB",
       "WHEEL"
@@ -165881,8 +165368,7 @@
       "SPIEGEL IRON\nSpie\"gel i`ron. Etym: [G. spiegel mirror + E. iron.] (Metal.)\n\nDefn: A fusible white cast iron containing a large amount of carbon\n(from three and a half to six per cent) and some manganese. When the\nmanganese reaches twenty-five per cent and upwards it has a granular\nstructure, and constitutes the alloy ferro manganese, largely used in\nthe manufacture of Bessemer steel. Called also specular pig iron,\nspiegel, and spiegeleisen."
     ],
     "references": [
-      "SPIEGELEISEN",
-      "SPIEGEL IRON"
+      "SPIEGELEISEN"
     ]
   },
   {
@@ -166137,9 +165623,7 @@
     "variants": [
       "SPILLET FISHING; SPILLIARD FISHING\nSpil\"let fish`ing, Spil\"liard fish`ing,\n\nDefn: A system or method of fishing by means of a number of hooks set\non snoods all on one line; -- in North America, called trawl fishing,\nbultow, or bultow fishing, and long-line fishing."
     ],
-    "references": [
-      "SPILLET FISHING; SPILLIARD FISHING"
-    ]
+    "references": []
   },
   {
     "spellings": "SPILLIKIN",
@@ -166270,9 +165754,7 @@
     "variants": [
       "SPINA BIFIDA\nSpi\"na bif\"i*da. (Med.) Etym: [L., cleft spine.]\n\nDefn: A congenital malformation in which the spinal column is cleft\nat its lower portion, and the membranes of the spinal cord project as\nan elastic swelling from the gap thus formed."
     ],
-    "references": [
-      "SPINA BIFIDA"
-    ]
+    "references": []
   },
   {
     "spellings": "SPINACEOUS",
@@ -168790,9 +168272,7 @@
     "variants": [
       "SPIT BALL\nSpit ball. (Baseball)\n\nDefn: A pitched ball in throwing which the pitcher grips the ball\nbetween two, or three, fingers on one side (which is made slippery,\nas by saliva) and the thumb on the other side, and delivers it so\nthat it slips off the fingers with the least possible friction. When\npitched directly overhand a spit ball darts downward, when pitched\nwith the arm extended sidewise it darts down and out. [Cant] -- Spit\nballer."
     ],
-    "references": [
-      "SPIT BALL"
-    ]
+    "references": []
   },
   {
     "spellings": "SPITBOX",
@@ -168827,9 +168307,7 @@
     "variants": [
       "SPIT CURL\nSpit\" curl`.\n\nDefn: A little lock of hair, plastered in a spiral form on the temple\nor forehead with spittle, or other adhesive substance. [Colloq.]"
     ],
-    "references": [
-      "SPIT CURL"
-    ]
+    "references": []
   },
   {
     "spellings": "SPITE",
@@ -169034,8 +168512,7 @@
     "references": [
       "DOG",
       "LOUP-LOUP",
-      "POMERANIAN",
-      "SPITZ DOG"
+      "POMERANIAN"
     ]
   },
   {
@@ -169925,9 +169402,7 @@
     "variants": [
       "SPLIT DYNAMOMETER\nSplit dynamometer. (Elec.)\n\nDefn: An electric dynamometer having two coils so arranged that one\ncarries the primary current, and the other the secondary current, of\na transformer."
     ],
-    "references": [
-      "SPLIT DYNAMOMETER"
-    ]
+    "references": []
   },
   {
     "spellings": "SPLITFEET",
@@ -169941,54 +169416,42 @@
     "variants": [
       "SPLIT INFINITIVE\nSplit infinitive. (Gram.)\n\nDefn: A simple infinitive with to, having a modifier between the verb\nand the to; as in, to largely decrease. Called also cleft infinitive."
     ],
-    "references": [
-      "SPLIT INFINITIVE"
-    ]
+    "references": []
   },
   {
     "spellings": "SPLIT KEY",
     "variants": [
       "SPLIT KEY\nSplit key. (Mach.)\n\nDefn: A key split at one end like a split pin, for the same purpose."
     ],
-    "references": [
-      "SPLIT KEY"
-    ]
+    "references": []
   },
   {
     "spellings": "SPLIT SHOT; SPLIT STROKE",
     "variants": [
       "SPLIT SHOT; SPLIT STROKE\nSplit shot or stroke .\n\nDefn: In croquet, etc., a shot or stroke in which one drives in\ndifferent directions one's own and the opponent's ball placed in\ncontact."
     ],
-    "references": [
-      "SPLIT SHOT; SPLIT STROKE"
-    ]
+    "references": []
   },
   {
     "spellings": "SPLIT STITCH",
     "variants": [
       "SPLIT STITCH\nSplit stitch.\n\nDefn: A stitch used in stem work to produce a fine line, much used in\nold church embroidery to work the hands and faces of figures."
     ],
-    "references": [
-      "SPLIT STITCH"
-    ]
+    "references": []
   },
   {
     "spellings": "SPLIT STUFF",
     "variants": [
       "SPLIT STUFF\nSplit stuff.\n\nDefn: Timber sawn into lengths and then split."
     ],
-    "references": [
-      "SPLIT STUFF"
-    ]
+    "references": []
   },
   {
     "spellings": "SPLIT SWITCH",
     "variants": [
       "SPLIT SWITCH\nSplit switch. (Railroading)\n\nDefn: = Point switch."
     ],
-    "references": [
-      "SPLIT SWITCH"
-    ]
+    "references": []
   },
   {
     "spellings": "SPLIT-TAIL",
@@ -170021,9 +169484,7 @@
     "variants": [
       "SPLIT WHEEL\nSplit wheel.\n\nDefn: = Split pulley."
     ],
-    "references": [
-      "SPLIT WHEEL"
-    ]
+    "references": []
   },
   {
     "spellings": "SPLOTCH",
@@ -172019,9 +171480,7 @@
     "variants": [
       "SPOT CASH\nSpot cash. (Com.)\n\nDefn: Cash paid or ready for payment at once upon delivery of\nproperty purchased."
     ],
-    "references": [
-      "SPOT CASH"
-    ]
+    "references": []
   },
   {
     "spellings": "SPOTLESS",
@@ -172058,9 +171517,7 @@
     "variants": [
       "SPOT STROKE\nSpot stroke. (Eng. Billiards)\n\nDefn: The pocketing of the red ball in a top corner pocket from off\nits own spot so as to leave the cue ball in position for an easy\nwinning hazard in either top corner pocket."
     ],
-    "references": [
-      "SPOT STROKE"
-    ]
+    "references": []
   },
   {
     "spellings": "SPOTTED",
@@ -172899,9 +172356,7 @@
     "variants": [
       "SPRENGEL PUMP\nSpreng\"el pump`. (Physics)\n\nDefn: A form of air pump in which exhaustion is produced by a stream\nof mercury running down a narrow tube, in the manner of an aspirator;\n-- named from the inventor."
     ],
-    "references": [
-      "SPRENGEL PUMP"
-    ]
+    "references": []
   },
   {
     "spellings": "SPRENT",
@@ -173588,9 +173043,7 @@
     "variants": [
       "SPRING STEEL\nSpring steel.\n\nDefn: A variety of steel, elastic, strong, and tough, rolled for\nsprings, etc."
     ],
-    "references": [
-      "SPRING STEEL"
-    ]
+    "references": []
   },
   {
     "spellings": "SPRINGTAIL",
@@ -173834,7 +173287,6 @@
       "GEARING",
       "PITCH",
       "RAG",
-      "SPROCKET WHEEL",
       "WHELP"
     ]
   },
@@ -175774,9 +175226,7 @@
     "variants": [
       "SQUAW MAN\nSquaw man.\n\nDefn: A white man who has married an Indian squaw; sometimes, one who\nhas gained tribal rights by such a marriage; -- often a term of\ncontempt. [Western U. S.]"
     ],
-    "references": [
-      "SQUAW MAN"
-    ]
+    "references": []
   },
   {
     "spellings": "SQUAWROOT",
@@ -175792,9 +175242,7 @@
     "variants": [
       "SQUAW VINE\nSquaw vine. (Bot.)\n\nDefn: The partridge berry (Mitchella repens)."
     ],
-    "references": [
-      "SQUAW VINE"
-    ]
+    "references": []
   },
   {
     "spellings": "SQUAWWEED",
@@ -175906,9 +175354,7 @@
     "variants": [
       "SQUEEGEE ROLLER\nSqueegee roller.\n\nDefn: A small India-rubber roller with a handle, used esp. in\nprinting and photography as a squeegee."
     ],
-    "references": [
-      "SQUEEGEE ROLLER"
-    ]
+    "references": []
   },
   {
     "spellings": "SQUEEZE",
@@ -176450,9 +175896,7 @@
     "variants": [
       "SQUITCH GRASS\nSquitch\" grass`. (Bot.)\n\nDefn: Quitch grass."
     ],
-    "references": [
-      "SQUITCH GRASS"
-    ]
+    "references": []
   },
   {
     "spellings": "SQUITEE",
@@ -176513,9 +175957,7 @@
     "variants": [
       "STABAT MATER\nSta\"bat Ma\"ter. Etym: [L., the mother was standing.]\n\nDefn: A celebrated Latin hymn, beginning with these words,\ncommemorating the sorrows of the mother of our Lord at the foot of\nthe cross. It is read in the Mass of the Sorrows of the Virgin Mary,\nand is sung by Catholics when making \"the way of the cross\" (Via\nCrucis). See Station, 7 (c)."
     ],
-    "references": [
-      "STABAT MATER"
-    ]
+    "references": []
   },
   {
     "spellings": "STABBER",
@@ -176536,9 +175978,7 @@
     "variants": [
       "STAB CULTURE\nStab culture. (Bacteriol.)\n\nDefn: A culture made by inoculating a solid medium, as gelatin, with\nthe puncture of a needle or wire. The growths are usually of\ncharacteristic form."
     ],
-    "references": [
-      "STAB CULTURE"
-    ]
+    "references": []
   },
   {
     "spellings": "STABILIMENT",
@@ -176711,9 +176151,7 @@
     "variants": [
       "STABLE STAND\nSta\"ble stand`. (O.Eng. Law)\n\nDefn: The position of a man who is found at his standing in the\nforest, with a crossbow or a longbow bent, ready to shoot at a deer,\nor close by a tree with greyhounds in a leash ready to slip; -- one\nof the four presumptions that a man intends stealing the king's deer.\nWharton."
     ],
-    "references": [
-      "STABLE STAND"
-    ]
+    "references": []
   },
   {
     "spellings": "STABLING",
@@ -176878,7 +176316,6 @@
       "STADIA HAIRS; STADIA WIRES\nSta\"di*a hairs or wires . (Surv.)\n\nDefn: In a theodolite, etc., horizontal cross wires or hairs\nequidistant from the central horizontal cross wire."
     ],
     "references": [
-      "STADIA HAIRS; STADIA WIRES",
       "STADIUM",
       "TACHYMETER"
     ]
@@ -177437,7 +176874,6 @@
       "STAGE DIRECTOR\nStage director. (Theat.)\n\nDefn: One who prepares a play for production. He arranges the details\nof the stage settings, the business to be used, all stage effects,\nand instructs the actors, excepting usually the star, in the general\ninterpretation of their parts."
     ],
     "references": [
-      "STAGE DIRECTOR",
       "STAGE MANAGER"
     ]
   },
@@ -177446,9 +176882,7 @@
     "variants": [
       "STAGE FRIGHT\nStage fright.\n\nDefn: Nervousness felt before an audience."
     ],
-    "references": [
-      "STAGE FRIGHT"
-    ]
+    "references": []
   },
   {
     "spellings": "STAGEHOUSE",
@@ -177470,8 +176904,7 @@
       "STAGE MANAGER\nStage manager. (Theat.)\n\nDefn: One in control of the stage during the production of a play. He\ndirects the stage hands, property man, etc., has charge of all\ndetails behind the curtain, except the acting, and has a general\noversight of the actors. Sometimes he is also the stage director."
     ],
     "references": [
-      "BUSINESS",
-      "STAGE MANAGER"
+      "BUSINESS"
     ]
   },
   {
@@ -177578,8 +177011,7 @@
       "STAG-HORN CORAL; STAG-HORN FERN\nStag\"-horn` co\"ral, Stag\"-horn` fern`, etc.\n\nDefn: See under Stag."
     ],
     "references": [
-      "STAG",
-      "STAG-HORN CORAL; STAG-HORN FERN"
+      "STAG"
     ]
   },
   {
@@ -180941,9 +180373,7 @@
     "variants": [
       "STAR DRIFT\nStar drift. (Astron.)\n\nDefn: Similar and probably related motion of the stars of an\nasterism, as distinguished from apparent change of place due to solar\nmotion.-- ## = star streaming --"
     ],
-    "references": [
-      "STAR DRIFT"
-    ]
+    "references": []
   },
   {
     "spellings": "STARE",
@@ -181322,9 +180752,7 @@
     "variants": [
       "STAR STEREOGRAM\nStar stereogram.\n\nDefn: A view of the universe of brighter stars as it would appear to\nan observer transported into space outside or beyond our universe of\nstars."
     ],
-    "references": [
-      "STAR STEREOGRAM"
-    ]
+    "references": []
   },
   {
     "spellings": "STARSTONE",
@@ -187199,9 +186627,7 @@
     "variants": [
       "STATE SOCIALISM\nState socialism.\n\nDefn: A form of socialism, esp. advocated in Germany, which, while\nretaining the right of private property and the institution of the\nfamily and other features of the present form of the state, would\nintervene by various measures intended to give or maintain equality\nof opportunity, as compulsory state insurance, old-age pensions,\netc., answering closely to socialism of the chair."
     ],
-    "references": [
-      "STATE SOCIALISM"
-    ]
+    "references": []
   },
   {
     "spellings": "STATESWOMAN",
@@ -187900,9 +187326,7 @@
     "variants": [
       "STATUS IN QUO; STATUS QUO\nSta\"tus in` quo\", Sta\"tus quo\". Etym: [L., state in which.]\n\nDefn: The state in which anything is already. The phrase is also used\nretrospectively, as when, on a treaty of place, matters return to the\nstatus quo ante bellum, or are left in statu quo ante bellum, i.e.,\nthe state (or, in the state) before the war."
     ],
-    "references": [
-      "STATUS IN QUO; STATUS QUO"
-    ]
+    "references": []
   },
   {
     "spellings": "STATUTABLE",
@@ -189389,7 +188813,6 @@
       "SPRAY",
       "STATIONARY",
       "STEAM",
-      "STEAM ENGINE",
       "STEEPLE",
       "STROKE",
       "STUFFING",
@@ -190050,9 +189473,7 @@
     "variants": [
       "STEELBOW GOODS\nSteel\"bow` goods\". (Scots Law)\n\nDefn: Those goods on a farm, such as corn, cattle, implements\nhusbandry, etc., which may not be carried off by a removing tenant,\nas being the property of the landlord."
     ],
-    "references": [
-      "STEELBOW GOODS"
-    ]
+    "references": []
   },
   {
     "spellings": "STEELER",
@@ -195161,9 +194582,7 @@
     "variants": [
       "STILLSON WRENCH\nStill\"son wrench.\n\nDefn: A pipe wrench having an adjustable L-shaped jaw piece sliding\nin a sleeve that is pivoted to, and loosely embraces, the handle.\nPressure on the handle increases the grip."
     ],
-    "references": [
-      "STILLSON WRENCH"
-    ]
+    "references": []
   },
   {
     "spellings": "STILLSTAND",
@@ -195238,9 +194657,7 @@
     "variants": [
       "STILTON CHEESE; STILTON\nStil\"ton cheese\", or Stil\"ton, n.\n\nDefn: A peculiarly flavored unpressed cheese made from milk with\ncream added; -- so called from the village or parish of Stilton,\nEngland, where it was originally made. It is very rich in fat.\n\nThus, in the outset he was gastronomic; discussed the dinner from the\nsoup to the stilton.\nC. Lever."
     ],
-    "references": [
-      "STILTON CHEESE; STILTON"
-    ]
+    "references": []
   },
   {
     "spellings": "STILTY",
@@ -195624,7 +195041,6 @@
       "SEPHEN",
       "STING",
       "STINGAREE",
-      "STING RAY; STINGRAY",
       "STINGTAIL",
       "TRYGON",
       "WHIPPAREE"
@@ -199533,9 +198949,7 @@
     "variants": [
       "STOP ORDER\nStop order. (Finance)\n\nDefn: An order that aims to limit losses by fixing a figure at which\npurchases shall be sold or sales bought in, as where stock is bought\nat 100 and the broker is directed to sell if the market price drops\nto 98."
     ],
-    "references": [
-      "STOP ORDER"
-    ]
+    "references": []
   },
   {
     "spellings": "STOP-OVER",
@@ -202428,9 +201842,7 @@
     "variants": [
       "STRANGLE HOLD\nStran\"gle hold.\n\nDefn: In wrestling, a hold by which one's opponent is choked. It is\nusually not allowed."
     ],
-    "references": [
-      "STRANGLE HOLD"
-    ]
+    "references": []
   },
   {
     "spellings": "STRANGLER",
@@ -203757,9 +203169,7 @@
     "variants": [
       "STREAM CLOCK\nStream clock. (Physiol.)\n\nDefn: An instrument for ascertaining the velocity of the blood in a\nvessel."
     ],
-    "references": [
-      "STREAM CLOCK"
-    ]
+    "references": []
   },
   {
     "spellings": "STREAMER",
@@ -203789,9 +203199,7 @@
     "variants": [
       "STREAM GOLD\nStream gold. (Mining)\n\nDefn: Gold in alluvial deposits; placer gold."
     ],
-    "references": [
-      "STREAM GOLD"
-    ]
+    "references": []
   },
   {
     "spellings": "STREAMINESS",
@@ -203845,7 +203253,6 @@
       "STREAM LINE\nStream line.\n\nDefn: The path of a constituent particle of a flowing fluid\nundisturbed by eddies or the like."
     ],
     "references": [
-      "STREAM LINE",
       "STREAMLINE"
     ]
   },
@@ -203861,9 +203268,7 @@
     "variants": [
       "STREAM WHEEL\nStream wheel.\n\nDefn: A wheel used for measuring, by its motion when submerged, the\nvelocity of flowing water; a current wheel."
     ],
-    "references": [
-      "STREAM WHEEL"
-    ]
+    "references": []
   },
   {
     "spellings": "STREAMY",
@@ -209086,7 +208491,6 @@
       "STRUCTURAL SHAPE\nStruc\"tur*al shape. (Engin. & Arch.)\n\nDefn: The shape of a member especially adapted to structural\npurposes, esp. in giving the greatest strength with the least\nmaterial. Hence, Colloq.,\n\nDefn: any steel or iron member of such shape, as channel irons, I\nbeams, T beams, etc., or, sometimes, a column, girder, etc., built up\nwith such members."
     ],
     "references": [
-      "STRUCTURAL SHAPE",
       "STRUCTURAL STEEL"
     ]
   },
@@ -209095,9 +208499,7 @@
     "variants": [
       "STRUCTURAL STEEL\nStructural steel.\n (a) Rolled steel in structural shapes.\n (b)  A kind of strong mild steel, suitable for structural shapes."
     ],
-    "references": [
-      "STRUCTURAL STEEL"
-    ]
+    "references": []
   },
   {
     "spellings": "STRUCTURE",
@@ -210386,7 +209788,6 @@
     "references": [
       "JEWEL",
       "LIGHT",
-      "STUDDING SAIL",
       "STUNSAIL",
       "TACK",
       "WATER SAIL",
@@ -216471,9 +215872,7 @@
     "variants": [
       "SUB JUDICE\nSub ju\"di*ce. Etym: [L.]\n\nDefn: Before the judge, or court; not yet decided; under judicial\nconsideration."
     ],
-    "references": [
-      "SUB JUDICE"
-    ]
+    "references": []
   },
   {
     "spellings": "SUBJUGATE",
@@ -218648,8 +218047,7 @@
       "SUBSISTENCE DEPARTMENT\nSub*sist\"ence De*part\"ment. (Mil.)\n\nDefn: A staff department of the United States army charged, under the\nsupervision of the Chief of Staff, with the purchasing and issuing to\nthe army of such supplies as make up the  ration. It also supplies,\nfor authorized sales, certain articles of food and other minor\nstores. It is commanded by any officer of the rank of brigadier\ngeneral, called commissary general, and the department is popularly\ncalled the Commissary Department."
     ],
     "references": [
-      "ARMY ORGANIZATION",
-      "SUBSISTENCE DEPARTMENT"
+      "ARMY ORGANIZATION"
     ]
   },
   {
@@ -225542,9 +224940,7 @@
     "variants": [
       "SUCKER STATE\nSuck\"er State.\n\nDefn: Illinois; -- a nickname."
     ],
-    "references": [
-      "SUCKER STATE"
-    ]
+    "references": []
   },
   {
     "spellings": "SUCKET",
@@ -227966,9 +227362,7 @@
     "variants": [
       "SUGGESTIVE MEDICINE\nSug*gest\"ive med\"i*cine.\n\nDefn: Treatment by commands or positive statements addressed to a\nmore or less hypnotized patient."
     ],
-    "references": [
-      "SUGGESTIVE MEDICINE"
-    ]
+    "references": []
   },
   {
     "spellings": "SUGGESTMENT",
@@ -228063,9 +227457,7 @@
     "variants": [
       "SUI GENERIS\nSu\"i gen\"e*ris. Etym: [L.]\n\nDefn: Of his or its own kind."
     ],
-    "references": [
-      "SUI GENERIS"
-    ]
+    "references": []
   },
   {
     "spellings": "SUILLAGE",
@@ -228877,9 +228269,7 @@
     "variants": [
       "SULEAH FISH\nSu\"le*ah fish`. (Zoöl.)\n\nDefn: A coarse fish of India, used in making a breakfast relish\ncalled burtah."
     ],
-    "references": [
-      "SULEAH FISH"
-    ]
+    "references": []
   },
   {
     "spellings": "SULK",
@@ -230662,9 +230052,7 @@
     "variants": [
       "SUMATRA LEAF\nSu*ma\"tra leaf.\n\nDefn: A thin, elastic, uniformly light-colored tobacco leaf, raised\nin Sumatra and extensively used for cigar wrappers."
     ],
-    "references": [
-      "SUMATRA LEAF"
-    ]
+    "references": []
   },
   {
     "spellings": "SUMATRAN",
@@ -231232,7 +230620,6 @@
       "SUMMUM BONUM\nSum\"mum bo\"num. [L.] (Philos.)\n\nDefn: The supreme or highest good, -- referring to the object of\nhuman life."
     ],
     "references": [
-      "SUMMUM BONUM",
       "TRENCHER"
     ]
   },
@@ -232210,9 +231597,7 @@
     "variants": [
       "SUNFLOWER STATE\nSun\"flow`er State.\n\nDefn: Kansas; a nickname."
     ],
-    "references": [
-      "SUNFLOWER STATE"
-    ]
+    "references": []
   },
   {
     "spellings": "SUNG",
@@ -232678,8 +232063,7 @@
       "SUN STAR\nSun\" star`. (Zoöl.)\n\nDefn: See Sun star, under Sun."
     ],
     "references": [
-      "SUN",
-      "SUN STAR"
+      "SUN"
     ]
   },
   {
@@ -239638,9 +239022,7 @@
     "variants": [
       "SURFACE LOADING\nSur\"face load`ing. (Aëronautics)\n\nDefn: The weight supported per square unit of surface; the quotient\nobtained by dividing the gross weight, in pounds, of a fully loaded\nflying machine, by the total area, in square feet, of its supporting\nsurface."
     ],
-    "references": [
-      "SURFACE LOADING"
-    ]
+    "references": []
   },
   {
     "spellings": "SURFACER",
@@ -239655,8 +239037,7 @@
       "SURFACE TENSION\nSur\"face ten\"sion. (Physics)\n\nDefn: That property, due to molecular forces, which exists in the\nsurface film of all liquids and tends to bring the contained volume\ninto a form having the least superficial area. The thickness of this\nfilm, amounting to less than a thousandth of a millimeter, is\nconsidered to equal the radius of the sphere of molecular action,\nthat is, the greatest distance at which there is cohesion between two\nparticles. Particles lying below this film, being equally acted on\nfrom all sides, are in equilibrium as to forces of cohesion, but\nthose in the film are on the whole attracted inward, and tension\nresults."
     ],
     "references": [
-      "FLOTATION PROCESS",
-      "SURFACE TENSION"
+      "FLOTATION PROCESS"
     ]
   },
   {
@@ -239945,7 +239326,6 @@
     ],
     "references": [
       "PIPA",
-      "SURINAM TOAD",
       "TOAD"
     ]
   },
@@ -241149,9 +240529,7 @@
     "variants": [
       "SURSUM CORDA\nSur\"sum cor\"da. [L. sursum upward + corda hearts.] (Eccl.)\n\nDefn: In the Eucharist, the versicles immediately before the preface,\ninviting the people to join in the service by \"lifting up the heart\"\nto God."
     ],
-    "references": [
-      "SURSUM CORDA"
-    ]
+    "references": []
   },
   {
     "spellings": "SURTAX",
@@ -243740,9 +243118,7 @@
     "variants": [
       "SWAY BAR\nSway bar. (Vehicles)\n (a) A bar attached to the hounds, in the rear of the front axle, so\nas to slide on the reach as the axle is swung in turning the vehicle.\n (b) Either of the two bars used in coupling the front and rear sleds\nof a logging sled; also, the bar used to couple two logging cars."
     ],
-    "references": [
-      "SWAY BAR"
-    ]
+    "references": []
   },
   {
     "spellings": "SWAY-BRACING",
@@ -251559,8 +250935,7 @@
       "SYRPHUS FLY\nSyr\"phus fly`. Etym: [NL. Syrphus, the generic name, fr. Gr. (Zoöl.)\n\nDefn: Any one of numerous species of dipterous flies of the genus\nSyrphus and allied genera. They are usually bright-colored, with\nyellow bands, and hover around plants. The larvæ feed upon plant\nlice, and are, therefore, very beneficial to agriculture."
     ],
     "references": [
-      "SYRPHIAN",
-      "SYRPHUS FLY"
+      "SYRPHIAN"
     ]
   },
   {

--- a/output/wordDisplayData#T.json
+++ b/output/wordDisplayData#T.json
@@ -204,9 +204,7 @@
     "variants": [
       "TABASCO SAUCE\nTa*bas\"co sauce. [So named after Tabasco, a river and state of\nMexico.]\n\nDefn: A kind of very pungent sauce made from red peppers."
     ],
-    "references": [
-      "TABASCO SAUCE"
-    ]
+    "references": []
   },
   {
     "spellings": "TABASHEER",
@@ -765,9 +763,7 @@
     "variants": [
       "TABLEAU VIVANT\nTa`bleau\" vi`vant\"; pl. Tableaux vivants. Etym: [F.]\n\nDefn: Same as Tableau, n., 2."
     ],
-    "references": [
-      "TABLEAU VIVANT"
-    ]
+    "references": []
   },
   {
     "spellings": "TABLEBOOK",
@@ -796,9 +792,7 @@
     "variants": [
       "TABLE D'HOTE\nTa\"ble d'hôte\"; pl. Tables d'hôte. Etym: [F., literally, table of the\nlandlord.]\n\nDefn: A common table for guests at a hotel; an ordinary."
     ],
-    "references": [
-      "TABLE D'HOTE"
-    ]
+    "references": []
   },
   {
     "spellings": "TABLE-LAND",
@@ -906,8 +900,7 @@
       "TABLE WORK\nTable work. (Print.)\n\nDefn: Typesetting of tabular nmatter, or the type matter set in\ntabular form."
     ],
     "references": [
-      "INTEREST",
-      "TABLE WORK"
+      "INTEREST"
     ]
   },
   {
@@ -1968,8 +1961,7 @@
       "TAG DAY\nTag day.\n\nDefn: A day on which contributions to some public or private charity\nor fund are solicited promiscuously on the street, and tags given to\ncontributors to wear as an evidence of their having contributed. Such\nsolicitation is now subject to legal restriction in various places."
     ],
     "references": [
-      "DIET",
-      "TAG DAY"
+      "DIET"
     ]
   },
   {
@@ -2908,9 +2900,7 @@
     "variants": [
       "TAJ MAHAL\nTaj Ma*hal\" (täj ma*häl\"). [Corruption of Per. Mumtaz-i-Mahsal, lit.,\nthe distinguished one of the palace, fr. Ar.]\n\nDefn: A marble mausoleum built at Agra, India, by the Mogul Emperor\nShah Jahan, in memory of his favorite wife. In beauty of design and\nrich decorative detail it is one of the best examples of Saracenic\narchitecture."
     ],
-    "references": [
-      "TAJ MAHAL"
-    ]
+    "references": []
   },
   {
     "spellings": "TAKE",
@@ -6862,8 +6852,7 @@
       "TAMPICO FIBER; TAMPICO FIBRE\nTam*pi\"co fi\"ber or; Tam*pi\"co fi\"bre.\n\nDefn: A tough vegetable fiber used as a substitute for bristles in\nmaking brushes. The piassava and the ixtle are both used under this\nname."
     ],
     "references": [
-      "IXTLE; IXTLI",
-      "TAMPICO FIBER; TAMPICO FIBRE"
+      "IXTLE; IXTLI"
     ]
   },
   {
@@ -7115,9 +7104,7 @@
     "variants": [
       "TANDEM CART\nTan\"dem cart.\n\nDefn: A kind of two-wheeled vehicle with seats back to back, the\nfront one somewhat elevated."
     ],
-    "references": [
-      "TANDEM CART"
-    ]
+    "references": []
   },
   {
     "spellings": "TANDEM ENGINE",
@@ -7125,8 +7112,7 @@
       "TANDEM ENGINE\nTandem engine.\n\nDefn: A steam engine having two or more steam cylinders in line, with\na common piston rod."
     ],
     "references": [
-      "TANDEM",
-      "TANDEM ENGINE"
+      "TANDEM"
     ]
   },
   {
@@ -7134,9 +7120,7 @@
     "variants": [
       "TANDEM SYSTEM\nTandem system. (Elec.)\n\nDefn: = Cascade system."
     ],
-    "references": [
-      "TANDEM SYSTEM"
-    ]
+    "references": []
   },
   {
     "spellings": "TANG",
@@ -7285,7 +7269,6 @@
       "TANGENT SPOKE\nTangent spoke.\n\nDefn: A tension spoke of a bicycle or similar wheel, secured\ntangentially to the hub."
     ],
     "references": [
-      "TANGENT SPOKE",
       "TANGENT WHEEL"
     ]
   },
@@ -7295,7 +7278,6 @@
       "TANGENT WHEEL\nTangent wheel.\n (a) A worm or worm wheel; a tangent screw.\n (b) A wheel with tangent spokes."
     ],
     "references": [
-      "TANGENT WHEEL",
       "WORM"
     ]
   },
@@ -7544,9 +7526,7 @@
     "variants": [
       "TANK SHIP; TANK VESSEL\nTank ship, Tank vessel . (Naut.)\n\nDefn: A vessel fitted with tanks for the carrying of oil or other\nliquid in bulk."
     ],
-    "references": [
-      "TANK SHIP; TANK VESSEL"
-    ]
+    "references": []
   },
   {
     "spellings": "TANLING",
@@ -8181,9 +8161,7 @@
     "variants": [
       "TAPESTRY BEETLE\nTap\"es*try bee\"tle.\n\nDefn: A small black dermestoid beetle (Attagenus piceus) whose larva\nfeeds on tapestry, carpets, silk, fur, flour, and various other\ngoods."
     ],
-    "references": [
-      "TAPESTRY BEETLE"
-    ]
+    "references": []
   },
   {
     "spellings": "TAPET",
@@ -8336,9 +8314,7 @@
     "variants": [
       "TAPOA TAFA\nTa*po\"a ta\"fa. (Zoöl.)\n\nDefn: A small carnivorous marsupial (Phascogale penicillata) having\nlong, soft fur, and a very long tail with a tuft of long hairs at the\nend; -- called also brush-tailed phascogale."
     ],
-    "references": [
-      "TAPOA TAFA"
-    ]
+    "references": []
   },
   {
     "spellings": "TAPPEN",
@@ -8381,9 +8357,7 @@
     "variants": [
       "TAPPET ROD\nTap\"pet rod. (Mech.)\n\nDefn: A rod carrying a tappet or tappets, as one for closing the\nvalves in a Cornish pumping engine."
     ],
-    "references": [
-      "TAPPET ROD"
-    ]
+    "references": []
   },
   {
     "spellings": "TAPPICE; TAPPIS",
@@ -8400,9 +8374,7 @@
     "variants": [
       "TAPPIT HEN\nTap\"pit hen`.\n\n1. A hen having a tuft of feathers on her head. [Scot.] Jamieson.\n\n2. A measuring pot holding one quart (according to some, three\nquarts); -- so called from a knob on the lid, though to resemble a\ncrested hen. [Scot.] Jamieson."
     ],
-    "references": [
-      "TAPPIT HEN"
-    ]
+    "references": []
   },
   {
     "spellings": "TAPPOON",
@@ -9619,7 +9591,6 @@
       "TARTINI'S TONES\nTar*ti\"ni's tones`. Etym: [From Tartini, an Italian violinist, who\ndiscovered them in 1754.]\n\nDefn: See the Note under Tone."
     ],
     "references": [
-      "TARTINI'S TONES",
       "TONE"
     ]
   },
@@ -9935,9 +9906,7 @@
     "variants": [
       "TASK WAGE\nTask wage. (Polit. Econ.)\n\nDefn: A wage paid by the day, or some fixed period, on condition that\na minimum task be performed. When the workman is paid in proportion\nfor excess over the minimum, the wage is one for piece-work."
     ],
-    "references": [
-      "TASK WAGE"
-    ]
+    "references": []
   },
   {
     "spellings": "TASKWORK",
@@ -11829,9 +11798,7 @@
     "variants": [
       "TAX CERTIFICATE\nTax certificate. (Law)\n\nDefn: The certificate issued to the purchaser of land at a tax sale\ncertifying to the sale and the payment of the consideration thereof,\nand entitling the purchaser upon certain conditions and at a certain\ntime thereafter to a deed or instrument of conveyance (called a tax\ndeed) of the land, to be executed by the proper officer."
     ],
-    "references": [
-      "TAX CERTIFICATE"
-    ]
+    "references": []
   },
   {
     "spellings": "TAXEL",
@@ -11980,9 +11947,7 @@
     "variants": [
       "TAYLOR-WHITE PROCESS\nTay\"lor-White\" proc`ess. (Metal.)\n\nDefn: A process (invented about 1899 by Frederick W. Taylor and\nMaunsel B. White) for giving toughness to self-hardening steels. The\nsteel is heated almost to fusion, cooled to a temperature of from\n700º to 850º C. in molten lead, further cooled in oil, reheated to\nbetween 370º and 670º C., and cooled in air."
     ],
-    "references": [
-      "TAYLOR-WHITE PROCESS"
-    ]
+    "references": []
   },
   {
     "spellings": "TAYRA",
@@ -12015,8 +11980,7 @@
       "T CART\nT\" cart`.\n\nDefn: See under T."
     ],
     "references": [
-      "NIGHT",
-      "T CART"
+      "NIGHT"
     ]
   },
   {
@@ -12042,8 +12006,7 @@
       "CONNECTION",
       "CONSEQUENTIALLY",
       "INCONNEXEDLY",
-      "LEAD",
-      "T CONNECTION"
+      "LEAD"
     ]
   },
   {
@@ -13434,7 +13397,6 @@
     ],
     "references": [
       "CANTOR",
-      "TE DEUM",
       "THOU"
     ]
   },
@@ -13554,18 +13516,14 @@
     "variants": [
       "TEEING GROUND\nTeeing ground. (Golf)\n\nDefn: The space from within which the ball must be struck in\nbeginning the play for each hole."
     ],
-    "references": [
-      "TEEING GROUND"
-    ]
+    "references": []
   },
   {
     "spellings": "TEE IRON",
     "variants": [
       "TEE IRON\nTee\" i`ron.\n\nDefn: See T iron, under T."
     ],
-    "references": [
-      "TEE IRON"
-    ]
+    "references": []
   },
   {
     "spellings": "TEEK",
@@ -14672,8 +14630,7 @@
       "TELEGRAPH PLANT\nTelegraph plant.\n\nDefn: An East Indian tick trefoil (Meibomia gyrans), whose lateral\nleaflets jerk up and down like the arms of a semaphore, and also\nrotate on their axes."
     ],
     "references": [
-      "TELEGRAPH",
-      "TELEGRAPH PLANT"
+      "TELEGRAPH"
     ]
   },
   {
@@ -14968,8 +14925,7 @@
       "TELEPHONE EXCHANGE\nTel`e*phone ex*change\".\n\nDefn: A central office in which the wires of telephones may be\nconnected to permit conversation."
     ],
     "references": [
-      "EXCHANGE",
-      "TELEPHONE EXCHANGE"
+      "EXCHANGE"
     ]
   },
   {
@@ -15177,9 +15133,7 @@
     "variants": [
       "TELESCOPE BAG\nTelescope bag.\n\nDefn: An adjustable traveling bag consisting of two cases, the larger\nslipping over the other."
     ],
-    "references": [
-      "TELESCOPE BAG"
-    ]
+    "references": []
   },
   {
     "spellings": "TELESCOPIC; TELESCOPICAL",
@@ -15211,8 +15165,7 @@
     ],
     "references": [
       "QUADRANT",
-      "SEXTANT",
-      "TELESCOPIC SIGHT"
+      "SEXTANT"
     ]
   },
   {
@@ -16598,8 +16551,7 @@
       "TEMPER SCREW\nTem\"per screw.\n\n1. A screw link, to which is attached the rope of a rope-drilling\napparatus, for feeding and slightly turning the drill jar at each\nstroke.\n\n2.  A set screw used for adjusting."
     ],
     "references": [
-      "TEMPER",
-      "TEMPER SCREW"
+      "TEMPER"
     ]
   },
   {
@@ -18461,7 +18413,6 @@
       "TENANT SAW\nTen\"ant saw`.\n\nDefn: See Tenon saw, under Tenon."
     ],
     "references": [
-      "TENANT SAW",
       "TENON"
     ]
   },
@@ -22177,9 +22128,7 @@
     "variants": [
       "TERM DAY\nTerm day.\n\nDefn: A day which is a term (as for payment of rent), or is a day in\na term, as of the sitting of a court; esp., one of a series of\nspecial days, designated by scientists of different nations or\nstations, for making synoptic magnetic, meteorological, or other\nphysical observations."
     ],
-    "references": [
-      "TERM DAY"
-    ]
+    "references": []
   },
   {
     "spellings": "TERMER",
@@ -22537,7 +22486,6 @@
       "TERM INSURANCE\nTerm insurance.\n\nDefn: Insurance for a specified term providing for no payment to the\ninsured except upon losses during the term, and becoming void upon\nits expiration."
     ],
     "references": [
-      "TERM INSURANCE",
       "TERM POLICY"
     ]
   },
@@ -22606,9 +22554,7 @@
     "variants": [
       "TERM POLICY\nTerm policy.\n\nDefn: A policy of term insurance."
     ],
-    "references": [
-      "TERM POLICY"
-    ]
+    "references": []
   },
   {
     "spellings": "TERN",
@@ -22871,9 +22817,7 @@
     "variants": [
       "TERRA INCOGNITA\nTer\"ra in*cog\"ni*ta. [L.]\n\nDefn: An unknown land; unexplored country.\n\nThe enormous tracts lying outside China proper, still almost terræ\nincognitæ.\nA. R. Colquhoun."
     ],
-    "references": [
-      "TERRA INCOGNITA"
-    ]
+    "references": []
   },
   {
     "spellings": "TERRANE",
@@ -23336,7 +23280,6 @@
     ],
     "references": [
       "HIGH",
-      "TERRITORIAL WATERS",
       "THREE-MILE"
     ]
   },
@@ -23722,9 +23665,7 @@
     "variants": [
       "TERTIUM QUID\nTer\"ti*um quid. [L.]\n\nDefn: A third somewhat; something mediating, or regarded as being,\nbetween two diverse or incompatible substances, natures, or\npositions."
     ],
-    "references": [
-      "TERTIUM QUID"
-    ]
+    "references": []
   },
   {
     "spellings": "TERUTERO",
@@ -23738,9 +23679,7 @@
     "variants": [
       "TERZA RIMA\nTer\"za ri\"ma. Etym: [It., a third or triple rhyme.]\n\nDefn: A peculiar and complicated system of versification, borrowed by\nthe early Italian poets from the Troubadours."
     ],
-    "references": [
-      "TERZA RIMA"
-    ]
+    "references": []
   },
   {
     "spellings": "TERZETTO",
@@ -23756,9 +23695,7 @@
     "variants": [
       "TESLA COIL; TESLA TRANSFORMER\nTes\"la coil, Tes\"la trans*form\"er. [After N. Tesla, American\nelectrician.] (Elec.)\n\nDefn: A transformer without iron, for high frequency alternating or\noscillating currents; an oscillation transformer."
     ],
-    "references": [
-      "TESLA COIL; TESLA TRANSFORMER"
-    ]
+    "references": []
   },
   {
     "spellings": "TESSELAR",
@@ -26056,9 +25993,7 @@
     "variants": [
       "TEXAS LEAGUER\nTex\"as Leagu\"er. [From the Texas (baseball) League.] (Baseball)\n\nDefn: A short fly that falls too far out to be handled by an\ninfielder and too close in to be caught by an outfielder. [Cant]"
     ],
-    "references": [
-      "TEXAS LEAGUER"
-    ]
+    "references": []
   },
   {
     "spellings": "TEXT",
@@ -26172,8 +26107,7 @@
       "TEXT HAND\nText hand.\n\nDefn: A large hand in writing; -- so called because it was the\npractice to write the text of a book in a large hand and the notes in\na smaller hand."
     ],
     "references": [
-      "TEXT",
-      "TEXT HAND"
+      "TEXT"
     ]
   },
   {
@@ -50446,8 +50380,7 @@
       "THERMOELECTRIC COUPLE; THERMOELECTRIC PAIR\nTher`mo*e*lec\"tric couple or pair. (Elec.)\n\nDefn: A union of two conductors, as bars or wires of dissimilar\nmetals joined at their extremities, for producing a thermoelectric\ncurrent."
     ],
     "references": [
-      "THERMOCOUPLE",
-      "THERMOELECTRIC COUPLE; THERMOELECTRIC PAIR"
+      "THERMOCOUPLE"
     ]
   },
   {
@@ -55541,9 +55474,7 @@
     "variants": [
       "THIBET CLOTH\nThib\"et cloth`.\n(a) A fabric made of coarse goat's hair; a kind of camlet.\n(b) A kind of fine woolen cloth, used for dresses, cloaks, etc."
     ],
-    "references": [
-      "THIBET CLOTH"
-    ]
+    "references": []
   },
   {
     "spellings": "THIBETIAN",
@@ -56275,7 +56206,6 @@
       "THICK WIND\nThick\" wind`. (Far.)\n\nDefn: A defect of respiration in a horse, that is unassociated with\nnoise in breathing or with the signs of emphysema."
     ],
     "references": [
-      "THICK WIND",
       "THICK-WINDED"
     ]
   },
@@ -59612,7 +59542,6 @@
       "THIRD RAIL\nThird rail. (Electric Railways)\n (a) The third rail used in the third-rail system.\n (b) An electric railway using such a rail. [Colloq.]"
     ],
     "references": [
-      "THIRD RAIL",
       "THIRD-RAIL SYSTEM"
     ]
   },
@@ -59622,8 +59551,7 @@
       "THIRD-RAIL SYSTEM\nThird-rail system. (Electric Railways)\n\nDefn: A system in which a third rail is used for carrying the current\nfor operating the motors, the rail being insulated from the ground\nand the current being taken off by means of contact brushes or other\ndevices."
     ],
     "references": [
-      "THIRD RAIL",
-      "THIRD-RAIL SYSTEM"
+      "THIRD RAIL"
     ]
   },
   {
@@ -63311,8 +63239,7 @@
       "THOMAS PHOSPHATE; THOMAS SLAG\nThom\"as phos\"phate or slag .\n\nDefn: Same as Basic slag, above."
     ],
     "references": [
-      "BASIC SLAG",
-      "THOMAS PHOSPHATE; THOMAS SLAG"
+      "BASIC SLAG"
     ]
   },
   {
@@ -63321,8 +63248,7 @@
       "THOMAS PROCESS\nThom\"as proc\"ess. (Iron Metal.)\n\nDefn: Same as Basic process, above."
     ],
     "references": [
-      "BASIC PROCESS",
-      "THOMAS PROCESS"
+      "BASIC PROCESS"
     ]
   },
   {
@@ -63358,9 +63284,7 @@
     "variants": [
       "THOMSEN'S DISEASE\nThom\"sen's dis*ease\". Etym: [From Thomsen, a physician of Sleswick.]\n(Med.)\n\nDefn: An affection apparently congenital, consisting in tonic\ncontraction and stiffness of the voluntary muscles occurring after a\nperiod of muscular inaction."
     ],
-    "references": [
-      "THOMSEN'S DISEASE"
-    ]
+    "references": []
   },
   {
     "spellings": "THOMSONIAN",
@@ -63393,9 +63317,7 @@
     "variants": [
       "THOMSON PROCESS\nThomson process. [After Elihu Thomson, American inventor.]\n\nDefn: A process of electric welding in which heat is developed by a\nlarge current passing through the metal."
     ],
-    "references": [
-      "THOMSON PROCESS"
-    ]
+    "references": []
   },
   {
     "spellings": "THONG",
@@ -63922,8 +63844,7 @@
     "references": [
       "BASS",
       "CONTINUED",
-      "DASH",
-      "THOROUGH BASS"
+      "DASH"
     ]
   },
   {
@@ -67606,9 +67527,7 @@
     "variants": [
       "THOUGHT TRANSFERENCE\nThought transference.\n\nDefn: Telepathy."
     ],
-    "references": [
-      "THOUGHT TRANSFERENCE"
-    ]
+    "references": []
   },
   {
     "spellings": "THOUSAND",
@@ -67861,9 +67780,7 @@
     "variants": [
       "THOUSAND LEGS\nThou\"sand legs`. (Zoöl.)\n\nDefn: A millepid, or galleyworm; -- called also thousand-legged worm."
     ],
-    "references": [
-      "THOUSAND LEGS"
-    ]
+    "references": []
   },
   {
     "spellings": "THOUSANDTH",
@@ -69964,9 +69881,7 @@
     "variants": [
       "THREE-TORQUE SYSTEM OF CONTROL\nThree\"-torque` system of control. (Aëronautics)\n\nDefn: Any system of rudders by which the pilot can exert a turning\nmoment about each of the three rectangular axes of an aëroplane or\nairship."
     ],
-    "references": [
-      "THREE-TORQUE SYSTEM OF CONTROL"
-    ]
+    "references": []
   },
   {
     "spellings": "THREE-VALVED",
@@ -73361,9 +73276,7 @@
     "variants": [
       "THROWING STICK\nThrow\"ing stick`. (Anthropol.)\n\nDefn: An instrument used by various savage races for throwing a\nspear; -- called also throw stick and spear thrower. One end of the\nstick receives the butt of the spear, as upon a hook or thong, and\nthe other end is grasped with the hand, which also holds the spear,\ntoward the middle, above it with the finger and thumb, the effect\nbeing to bring the place of support nearer the center of the spear,\nand practically lengthen the arm in the act of throwing."
     ],
-    "references": [
-      "THROWING STICK"
-    ]
+    "references": []
   },
   {
     "spellings": "THROWN",
@@ -76595,8 +76508,7 @@
       "THYINE WOOD\nThy\"ine wood`. Etym: [Gr. (Bot.)\n\nDefn: The fragrant and beautiful wood of a North African tree\n(Callitris quadrivalvis), formerly called Thuja articulata. The tree\nis of the Cedar family, and furnishes a balsamic resin called\nsandarach. Rev. xviii. 12."
     ],
     "references": [
-      "THUJA",
-      "THYINE WOOD"
+      "THUJA"
     ]
   },
   {
@@ -77919,9 +77831,7 @@
     "variants": [
       "TIERS ETAT\nTiers` é`tat\". Etym: [F.]\n\nDefn: The third estate, or commonalty, in France, answering to the\ncommons in Great Britain; -- so called in distinction from, and as\ninferior to, the nobles and clergy.\n\nNote: The refusal of the clergy and nobility to give the tiers état a\nrepresentation in the States-general proportioned to their actual\nnumbers had an important influence in bringing on the French\nRevolution of 1789. Since that time the term has been purely\nhistorical."
     ],
-    "references": [
-      "TIERS ETAT"
-    ]
+    "references": []
   },
   {
     "spellings": "TIETICK",
@@ -78972,9 +78882,7 @@
     "variants": [
       "TILLEY; TILLEY SEED\nTil\"ley, n., or Til\"ley seed`. (Bot.)\n\nDefn: The seeds of a small tree (Croton Pavana) common in the Malay\nArchipelago. These seeds furnish croton oil, like those of Croton\nTiglium. [Written also tilly.]"
     ],
-    "references": [
-      "TILLEY; TILLEY SEED"
-    ]
+    "references": []
   },
   {
     "spellings": "TILLMAN",
@@ -79034,9 +78942,7 @@
     "variants": [
       "TIL SEED\nTil seed (til; tel).\n (a) The seed of sesame.\n (b) The seed of an African asteraceous plant (Guizotia abyssinica),\nyielding a bland fixed oil used in medicine."
     ],
-    "references": [
-      "TIL SEED"
-    ]
+    "references": []
   },
   {
     "spellings": "TILT",
@@ -79110,7 +79016,6 @@
       "OLIVER",
       "TILT",
       "TILTER",
-      "TILT HAMMER",
       "TILTING",
       "TILT-MILL",
       "TRIP HAMMER"
@@ -79151,9 +79056,7 @@
     "variants": [
       "TIL TREE\nTil\" tree`. (Bot.)\n\nDefn: See Teil."
     ],
-    "references": [
-      "TIL TREE"
-    ]
+    "references": []
   },
   {
     "spellings": "TILT-UP",
@@ -81761,9 +81664,7 @@
     "variants": [
       "TIME POLICY\nTime policy. (Insurance)\n\nDefn: A policy limited to become void at a specified time; -- often\ncontrasted with voyage policy."
     ],
-    "references": [
-      "TIME POLICY"
-    ]
+    "references": []
   },
   {
     "spellings": "TIMER",
@@ -81809,9 +81710,7 @@
     "variants": [
       "TIME SIGNATURE\nTime signature. (Music)\n\nDefn: A sign at the beginning of a composition or movement, placed\nafter the key signature, to indicate its time or meter. Also called\nrhythmical signature. It is in the form of a fraction, of which the\ndenominator indicates the kind of note taken as time unit for the\nbeat, and the numerator, the number of these to the measure."
     ],
-    "references": [
-      "TIME SIGNATURE"
-    ]
+    "references": []
   },
   {
     "spellings": "TIME-TABLE",
@@ -81980,8 +81879,7 @@
       "COURAGE",
       "GRASS",
       "MEADOW",
-      "PHLEUM",
-      "TIMOTHY; TIMOTHY GRASS"
+      "PHLEUM"
     ]
   },
   {
@@ -83614,7 +83512,6 @@
       "TESLA COIL; TESLA TRANSFORMER",
       "THERMOTENSION",
       "TIN",
-      "T IRON",
       "WHITE",
       "WROUGHT"
     ]
@@ -84051,9 +83948,7 @@
     "variants": [
       "TITAN CRANE\nTi\"tan crane. (Mach.)\n\nDefn: A massive crane with an overhanging counterbalanced arm\ncarrying a traveler and lifting crab, the whole supported by a\ncarriage mounted on track rails. It is used esp. for setting heavy\nmasonry blocks for piers, breakwaters, etc."
     ],
-    "references": [
-      "TITAN CRANE"
-    ]
+    "references": []
   },
   {
     "spellings": "TITANIC",
@@ -90482,9 +90377,7 @@
     "variants": [
       "TOBIAS FISH\nTo*bi\"as fish`. Etym: [See the Note under Asmodeus, in the Dictionary\nof Noted Names in Fiction.] (Zoöl.)\n\nDefn: The lant, or sand eel."
     ],
-    "references": [
-      "TOBIAS FISH"
-    ]
+    "references": []
   },
   {
     "spellings": "TOBIE",
@@ -90808,8 +90701,7 @@
       "TOE DROP\nToe drop. (Med.)\n\nDefn: A morbid condition of the foot in which the toe is depressed\nand the heel elevated."
     ],
     "references": [
-      "TOE",
-      "TOE DROP"
+      "TOE"
     ]
   },
   {
@@ -90817,9 +90709,7 @@
     "variants": [
       "TOE HOLD\nToe hold. (Wrestling)\n\nDefn: A hold in which the agressor bends back his opponent's foot."
     ],
-    "references": [
-      "TOE HOLD"
-    ]
+    "references": []
   },
   {
     "spellings": "TO-FALL",
@@ -92492,8 +92382,7 @@
       "TOISON D'OR\nToi`son\" d'or\" (dor\"). [F.]\n\nDefn: Lit., the golden fleece; specif., the order of the Golden\nFleece, or its jewel."
     ],
     "references": [
-      "GOLDEN",
-      "TOISON D'OR"
+      "GOLDEN"
     ]
   },
   {
@@ -93300,9 +93189,7 @@
     "variants": [
       "TOM AND JERRY\nTom and Jerry.\n\nDefn: A hot sweetened drink of rum and water spiced with cinnamon,\ncloves, etc., and beaten up with eggs."
     ],
-    "references": [
-      "TOM AND JERRY"
-    ]
+    "references": []
   },
   {
     "spellings": "TOMATO",
@@ -93393,9 +93280,7 @@
     "variants": [
       "TOM ' BEDLAM\nTom o' Bed\"lam.\n\nDefn: Formerly, a wandering mendicant discharged as incurable from\nBethlehem Hospitel, Eng.; hence, a wandering mendicant, either mad or\nfeigning to be so; a madman; a bedlamite."
     ],
-    "references": [
-      "TOM ' BEDLAM"
-    ]
+    "references": []
   },
   {
     "spellings": "TOMBESTER",
@@ -93558,9 +93443,7 @@
     "variants": [
       "TOMMY ATKINS\nTom\"my At\"kins.\n\nDefn: Any white regular soldier of the British army; also, such\nsoldiers collectively; -- said to be fictitious name inserted in the\nmodels given to soldiers to guide them in filling out account blanks,\netc."
     ],
-    "references": [
-      "TOMMY ATKINS"
-    ]
+    "references": []
   },
   {
     "spellings": "TOMNODDY",
@@ -93720,9 +93603,7 @@
     "variants": [
       "TONCA BEAN\nTon\"ca bean`. (Bot.)\n\nDefn: See Tonka bean."
     ],
-    "references": [
-      "TONCA BEAN"
-    ]
+    "references": []
   },
   {
     "spellings": "TONE",
@@ -94622,7 +94503,6 @@
       "COUMARIN",
       "COUMAROU",
       "TONCA BEAN",
-      "TONKA BEAN",
       "TONQUIN BEAN"
     ]
   },
@@ -94632,7 +94512,6 @@
       "TON MILE\nTon mile. (Railroads)\n\nDefn: A unit of measurement of the freight transportation performed\nby a railroad during a given period, usually a year, the total of\nwhich consists of the sum of the products obtained by multiplying the\naggregate weight of each shipment in tons during the given period by\nthe number of miles for which it is carried."
     ],
     "references": [
-      "TON MILE",
       "TON MILEAGE",
       "TRAFFIC MILE"
     ]
@@ -94642,9 +94521,7 @@
     "variants": [
       "TON MILEAGE\nTon mileage. (Railroads)\n\nDefn: Ton miles collectively; esp., the total ton miles performed by\na railroad in a given period."
     ],
-    "references": [
-      "TON MILEAGE"
-    ]
+    "references": []
   },
   {
     "spellings": "TONNAGE",
@@ -94729,8 +94606,7 @@
       "TONQUIN BEAN\nTon\"quin bean`\n\nDefn: See Tonka bean."
     ],
     "references": [
-      "BEAN",
-      "TONQUIN BEAN"
+      "BEAN"
     ]
   },
   {
@@ -94844,8 +94720,7 @@
     ],
     "references": [
       "SEMITONTINE",
-      "TONTINE",
-      "TONTINE INSURANCE"
+      "TONTINE"
     ]
   },
   {
@@ -95942,9 +95817,7 @@
     "variants": [
       "TOOL STEEL\nTool steel.\n\nDefn: Hard steel, usually crucible steel, capable of being tempered\nso as to be suitable for tools."
     ],
-    "references": [
-      "TOOL STEEL"
-    ]
+    "references": []
   },
   {
     "spellings": "TOOM",
@@ -97046,9 +96919,7 @@
     "variants": [
       "TOP FERMENTATION\nTop fermentation.\n\nDefn: An alcoholic fermentation during which the yeast cells are\ncarried to the top of the fermening liquid. It proceeds with some\nviolence and requires a temperature of 14-30º C. (58-86º F.). It is\nused in the production of ale, porter, etc., and of wines high in\nalcohol, and in distilling."
     ],
-    "references": [
-      "TOP FERMENTATION"
-    ]
+    "references": []
   },
   {
     "spellings": "TOPFUL",
@@ -97376,9 +97247,7 @@
     "variants": [
       "TOP OUT\nTop out. (Building)\n\nDefn: To top off; to finish by putting on a cap of top (uppermost)\ncourse (called a top`ping-out\" course)."
     ],
-    "references": [
-      "TOP OUT"
-    ]
+    "references": []
   },
   {
     "spellings": "TOPPER",
@@ -97440,9 +97309,7 @@
     "variants": [
       "TOP RAKE\nTop rake. (Mech.)\n\nDefn: The angle that the front edge of the point of a tool is set\nback from the normal to the surface being cut."
     ],
-    "references": [
-      "TOP RAKE"
-    ]
+    "references": []
   },
   {
     "spellings": "TOP-ROPE",
@@ -97795,27 +97662,21 @@
     "variants": [
       "TORCHON LACE\nTor\"chon lace` Etym: [F. torchon a kind of coarse napkin.]\n\nDefn: a simple thread lace worked upon a pillow with coarse thread;\nalso, a similar lace made by machinery."
     ],
-    "references": [
-      "TORCHON LACE"
-    ]
+    "references": []
   },
   {
     "spellings": "TORCHON PAPER",
     "variants": [
       "TORCHON PAPER\nTor\"chon pa\"per. [F. papier torchon.]\n\nDefn: Paper with a rough surface; esp., handmade paper of great\nhardness for the use of painters in water colors."
     ],
-    "references": [
-      "TORCHON PAPER"
-    ]
+    "references": []
   },
   {
     "spellings": "TORCH RACE",
     "variants": [
       "TORCH RACE\nTorch race.\n\nDefn: A race by men carrying torches, as in ancient Greece."
     ],
-    "references": [
-      "TORCH RACE"
-    ]
+    "references": []
   },
   {
     "spellings": "TORCHWOOD",
@@ -98231,36 +98092,28 @@
     "variants": [
       "TORPEDO-BOAT DESTROYER\nTor*pe\"do-boat` de*stroy\"er.\n\nDefn: A larger, swifter, and more powerful armed type of torpedo\nboat, originally intended principally for the destruction of torpedo\nboats, but later used also as a more formidable torpedo boat."
     ],
-    "references": [
-      "TORPEDO-BOAT DESTROYER"
-    ]
+    "references": []
   },
   {
     "spellings": "TORPEDO BODY",
     "variants": [
       "TORPEDO BODY\nTor*pe\"do body.\n\nDefn: An automobile body which is built so that the side surfaces are\nflush. [Cant]"
     ],
-    "references": [
-      "TORPEDO BODY"
-    ]
+    "references": []
   },
   {
     "spellings": "TORPEDO BOOM",
     "variants": [
       "TORPEDO BOOM\nTor*pe\"do boom.\n\nDefn: A spar formerly carried by men-of-war, having a torpedo on its\nend."
     ],
-    "references": [
-      "TORPEDO BOOM"
-    ]
+    "references": []
   },
   {
     "spellings": "TORPEDO CATCHER",
     "variants": [
       "TORPEDO CATCHER\nTor*pe\"do catch\"er.\n\nDefn: A small fast vessel for pursuing and destroying torpedo boats."
     ],
-    "references": [
-      "TORPEDO CATCHER"
-    ]
+    "references": []
   },
   {
     "spellings": "TORPEDOIST",
@@ -98274,36 +98127,28 @@
     "variants": [
       "TORPEDO SHELL\nTorpedo shell. (Ordnance)\n\nDefn: A shell longer than a deck-piercing shell, with thinner walls\nand a larger cavity for the bursting charge, which consists of about\n130 pounds of high explosive. It has no soft cap, and is intended to\neffect its damage by the powerful explosion which follows on slight\nresistance. It is used chiefly in 12-inch mortars."
     ],
-    "references": [
-      "TORPEDO SHELL"
-    ]
+    "references": []
   },
   {
     "spellings": "TORPEDO STATION",
     "variants": [
       "TORPEDO STATION\nTorpedo station.\n\nDefn: A headquarters for torpedo vessels and their supplies, usually\nhaving facilities for repairs and for instruction and experiments.\nThe principal torpedo station of the United States is at Newport, R.I."
     ],
-    "references": [
-      "TORPEDO STATION"
-    ]
+    "references": []
   },
   {
     "spellings": "TORPEDO STERN",
     "variants": [
       "TORPEDO STERN\nTorpedo stern.\n\nDefn: A broad stern without overhang, flattened on the bottom, used\nin some torpedo and fast power boats. It prevents settling in the\nwater at high speed."
     ],
-    "references": [
-      "TORPEDO STERN"
-    ]
+    "references": []
   },
   {
     "spellings": "TORPEDO TUBE",
     "variants": [
       "TORPEDO TUBE\nTorpedo tube. (Nav.)\n\nDefn: A tube fixed below or near the water line through which a\ntorpedo is fired, usually by a small charge of gunpowder. On torpedo\nvessels the tubes are on deck and usually in broadside, on larger\nvessels usually submerged in broadside and fitted with a movable\nshield which is pushed out from the vessel's side to protect the\ntorpedo until clear, but formerly sometimes in the bow. In submarine\ntorpedo boats they are in the bow."
     ],
-    "references": [
-      "TORPEDO TUBE"
-    ]
+    "references": []
   },
   {
     "spellings": "TORPENT",
@@ -98487,9 +98332,7 @@
     "variants": [
       "TORRENS SYSTEM\nTor\"rens sys`tem.\n\nDefn: A system of registration of titles to land (as distinct from\nregistration of deeds) introduced into South Australia by the Real\nProperty (or Torrens) Act (act 15 of 1857-58), drafted by Sir Robert\nTorrens (1814-84). Its essential feature is the guaranty by the\ngovernment of properly registered titles. The system has been\ngenerally adopted in Australia and British Columbia, and in its\noriginal or a modified form in some other countries, including some\nStates of the United States. Hence Torrens title, etc."
     ],
-    "references": [
-      "TORRENS SYSTEM"
-    ]
+    "references": []
   },
   {
     "spellings": "TORRENT",
@@ -98667,36 +98510,28 @@
     "variants": [
       "TORSION ELECTROMETER\nTor\"sion e*lec*trom\"e*ter. (Elec.)\n\nDefn: A torsion balance used for measuring electric attraction or\nrepulsion."
     ],
-    "references": [
-      "TORSION ELECTROMETER"
-    ]
+    "references": []
   },
   {
     "spellings": "TORSION GALVANOMETER",
     "variants": [
       "TORSION GALVANOMETER\nTorsion galvanometer. (Elec.)\n\nDefn: A galvanometer in which current is measured by torsion."
     ],
-    "references": [
-      "TORSION GALVANOMETER"
-    ]
+    "references": []
   },
   {
     "spellings": "TORSION HEAD",
     "variants": [
       "TORSION HEAD\nTorsion head.\n\nDefn: That part of a torsion balance from which the wire or filament\nis suspended."
     ],
-    "references": [
-      "TORSION HEAD"
-    ]
+    "references": []
   },
   {
     "spellings": "TORSION INDICATOR",
     "variants": [
       "TORSION INDICATOR\nTorsion indicator.\n\nDefn: An autographic torsion meter."
     ],
-    "references": [
-      "TORSION INDICATOR"
-    ]
+    "references": []
   },
   {
     "spellings": "TORSION METER",
@@ -98704,8 +98539,7 @@
       "TORSION METER\nTorsion meter. (Mech.)\n\nDefn: An instrument for determining the torque on a shaft, and hence\nthe horse power of an engine, esp. of a marine engine of high power,\nby measuring the amount of twist of a given length of the shaft.\nCalled also torsimeter, torsiometer, torsometer."
     ],
     "references": [
-      "TORSION INDICATOR",
-      "TORSION METER"
+      "TORSION INDICATOR"
     ]
   },
   {
@@ -99642,9 +99476,7 @@
     "variants": [
       "TOTEM POLE; TOTEM POST\nTo\"tem pole or post.\n\nDefn: A pole or pillar, carved and  painted with a series of totemic\nsymbols, set up  before the house of certain Indian tribes of the\nnorthwest coast of North America, esp. Indians of the Koluschan\nstock."
     ],
-    "references": [
-      "TOTEM POLE; TOTEM POST"
-    ]
+    "references": []
   },
   {
     "spellings": "TOTER",
@@ -100482,8 +100314,7 @@
       "TOURING CAR\nTour\"ing car.\n\nDefn: An automobile designed for touring; specif., a roomy car, not a\nlimousine, for five or more passengers."
     ],
     "references": [
-      "AUTOMOBILE",
-      "TOURING CAR"
+      "AUTOMOBILE"
     ]
   },
   {
@@ -103458,9 +103289,7 @@
     "variants": [
       "TRACTION WHEEL\nTraction wheel. (Mach.)\n (a) A locomotive driving wheel which acts by friction adhesion to a\nsmooth track.\n (b) A smooth-rimmed friction wheel for giving motion to an endless\nlink belt or the like."
     ],
-    "references": [
-      "TRACTION WHEEL"
-    ]
+    "references": []
   },
   {
     "spellings": "TRACTITE",
@@ -103509,9 +103338,7 @@
     "variants": [
       "TRACTOR SCREW; TRACTOR PROPELLER\nTractor screw or propeller. (Aviation)\n\nDefn: A propeller screw placed in front of the supporting planes of\nan aëroplane instead of behind them, so that it exerts a pull instead\nof a push. Hence, Tractor monoplane, Tractor biplane, etc."
     ],
-    "references": [
-      "TRACTOR SCREW; TRACTOR PROPELLER"
-    ]
+    "references": []
   },
   {
     "spellings": "TRACTORY",
@@ -103871,7 +103698,6 @@
       "PONCHO",
       "SACCHARINE",
       "SILUNDUM",
-      "TRADE NAME",
       "VESUVINE"
     ]
   },
@@ -103958,7 +103784,6 @@
       "PICKET",
       "RAT",
       "SCAB",
-      "TRADES UNION; TRADE UNION",
       "TRADES-UNIONIST; TRADE-UNIONIST",
       "UNION",
       "UNIONIST"
@@ -104340,9 +104165,7 @@
     "variants": [
       "TRAFFIC MILE\nTraf\"fic mile. (Railroad Accounting)\n\nDefn: Any unit of the total obtained by adding the passenger miles\nand ton miles in a railroad's transportation for a given period; -- a\nterm and practice of restricted or erroneous usage.\n\nTraffic mile is a term designed to furnish an excuse for the\nerroneous practice of adding together two things (ton miles and\npassenger miles) which, being of different kinds, cannot properly be\nadded.\nHadley."
     ],
-    "references": [
-      "TRAFFIC MILE"
-    ]
+    "references": []
   },
   {
     "spellings": "TRAGACANTH",
@@ -104501,7 +104324,6 @@
       "RAILROAD; RAILWAY",
       "SEAL",
       "STRAP",
-      "T RAIL",
       "TRAM",
       "WORKWAYS; WORKWISE"
     ]
@@ -104596,18 +104418,14 @@
     "variants": [
       "TRAILING EDGE\nTrail\"ing edge. (Aëronautics)\n\nDefn: A following edge. See Advancing edge, above."
     ],
-    "references": [
-      "TRAILING EDGE"
-    ]
+    "references": []
   },
   {
     "spellings": "TRAIL ROPE",
     "variants": [
       "TRAIL ROPE\nTrail rope. (Aëronautics)\n\nDefn: Same as Guide rope, above."
     ],
-    "references": [
-      "TRAIL ROPE"
-    ]
+    "references": []
   },
   {
     "spellings": "TRAIN",
@@ -104842,9 +104660,7 @@
     "variants": [
       "TRAIN DISPATCHER\nTrain dispatcher.\n\nDefn: An official who gives the orders on a railroad as to the\nrunning of trains and their right of way."
     ],
-    "references": [
-      "TRAIN DISPATCHER"
-    ]
+    "references": []
   },
   {
     "spellings": "TRAINEL",
@@ -104941,7 +104757,6 @@
       "TRAIN OIL\nTrain\" oil` (oil`). Etym: [D. or LG. traan train oil, blubber (cf.\nDan. & Sw. tran, G. thran) + E. oil.]\n\nDefn: Oil procured from the blubber or fat of whales, by boiling."
     ],
     "references": [
-      "TRAIN OIL",
       "TRAINY"
     ]
   },
@@ -105262,9 +105077,7 @@
     "variants": [
       "TRAMMEL WHEEL\nTram\"mel wheel`. (Mach.)\n\nDefn: A circular plate or a cross, with two or more cross grooves\nintersecting at the center, used on the end of a shaft to transmit\nmotion to another shaft not in line with the first."
     ],
-    "references": [
-      "TRAMMEL WHEEL"
-    ]
+    "references": []
   },
   {
     "spellings": "TRAMMING",
@@ -106856,8 +106669,7 @@
     ],
     "references": [
       "ALLEGHENIAN; ALLEGHANIAN",
-      "SONORAN",
-      "TRANSITION ZONE"
+      "SONORAN"
     ]
   },
   {
@@ -107418,9 +107230,7 @@
     "variants": [
       "TRANSMISSION DYNAMOMETER\nTrans*mis\"sion dy`na*mom\"e*ter. (Mach.)\n\nDefn: A dynamometer in which power is measured, without being\nabsorbed or used up, during transmission."
     ],
-    "references": [
-      "TRANSMISSION DYNAMOMETER"
-    ]
+    "references": []
   },
   {
     "spellings": "TRANSMISSIONIST",
@@ -109125,9 +108935,7 @@
     "variants": [
       "TRAP SHOOTING\nTrap shooting. (Sport)\n\nDefn: Shooting at pigeons liberated, or glass balls or clay pigeons\nsprung into the air, from a trap. -- Trap shooter."
     ],
-    "references": [
-      "TRAP SHOOTING"
-    ]
+    "references": []
   },
   {
     "spellings": "TRAPSTICK",
@@ -109565,8 +109373,7 @@
     ],
     "references": [
       "DRILL",
-      "TRAVERSE",
-      "TRAVERSE DRILL"
+      "TRAVERSE"
     ]
   },
   {
@@ -110289,9 +110096,7 @@
     "variants": [
       "TREASURY STOCK\nTreas\"ur*y stock. (Finance)\n\nDefn: Issued stock of an incorporated company held by the company\nitself."
     ],
-    "references": [
-      "TREASURY STOCK"
-    ]
+    "references": []
   },
   {
     "spellings": "TREAT",
@@ -112153,18 +111958,14 @@
     "variants": [
       "TREE BURIAL\nTree burial.\n\nDefn: Disposal of the dead by placing the corpse among the branches\nof a tree or in a hollow trunk, a practice among many primitive\npeoples."
     ],
-    "references": [
-      "TREE BURIAL"
-    ]
+    "references": []
   },
   {
     "spellings": "TREE CALF",
     "variants": [
       "TREE CALF\nTree calf.\n\nDefn: A bright brown polished calfskin binding of  books, stained\nwith a conventional treelike design."
     ],
-    "references": [
-      "TREE CALF"
-    ]
+    "references": []
   },
   {
     "spellings": "TREEFUL",
@@ -112942,8 +112743,7 @@
       "TRENTE ET QUARANTE\nTrente\" et` qua`rante\". [F., lit., thirty and forty.]\n\nDefn: Same as Rouge et noir, under Rouge."
     ],
     "references": [
-      "REFAIT",
-      "TRENTE ET QUARANTE"
+      "REFAIT"
     ]
   },
   {
@@ -112951,9 +112751,7 @@
     "variants": [
       "TRENTON PERIOD\nTren\"ton pe\"ri*od. (Geol.)\n\nDefn: A subdivision in the lower Silurian system of America; -- so\nnamed from Trenton Falls, in New York. The rocks are mostly\nlimestones, and the period is divided into the Trenton, Utica, and\nCincinnati epochs. See the Chart of Geology."
     ],
-    "references": [
-      "TRENTON PERIOD"
-    ]
+    "references": []
   },
   {
     "spellings": "TREPAN",
@@ -113759,9 +113557,7 @@
     "variants": [
       "TRIAL BALANCE\nTri\"al bal`ance. (Bookkeeping)\n\nDefn: The testing of a ledger to discover whether the debits and\ncredits balance, by finding whether the sum of the personal credits\nincreased by the difference between the debit and credit sums in the\nmerchandise and other impersonal accounts equals the sum of personal\ndebits. The equality would not show that the items were all correctly\nposted."
     ],
-    "references": [
-      "TRIAL BALANCE"
-    ]
+    "references": []
   },
   {
     "spellings": "TRIALITY",
@@ -116295,9 +116091,7 @@
     "variants": [
       "TRIGER PROCESS\nTri`ger proc\"ess. [After M. Triger, French engineer.] (Engin. &\nMining)\n\nDefn: A method of sinking through water-bearing ground, in which the\nshaft is lined with tubbing and provided with an air lock, work being\nproceeded with under air pressure."
     ],
-    "references": [
-      "TRIGER PROCESS"
-    ]
+    "references": []
   },
   {
     "spellings": "TRIGESIMO-SECUNDO",
@@ -117813,8 +117607,7 @@
       "TRIP HAMMER\nTrip\" ham`mer.\n\nDefn: A tilt hammer."
     ],
     "references": [
-      "TILT HAMMER",
-      "TRIP HAMMER"
+      "TILT HAMMER"
     ]
   },
   {
@@ -119614,18 +119407,14 @@
     "variants": [
       "TROILUS BUTTERFLY\nTro\"i*lus butterfly.\n\nDefn: A large American butterfly (Papilio troilus). It is black, with\nyellow marginal spots on the front wings, and blue on the rear."
     ],
-    "references": [
-      "TROILUS BUTTERFLY"
-    ]
+    "references": []
   },
   {
     "spellings": "TROIS POINT",
     "variants": [
       "TROIS POINT\nTrois` point\". [F. trois three.] (Backgammon)\n\nDefn: The third point from the outer edge on each player's home\ntable."
     ],
-    "references": [
-      "TROIS POINT"
-    ]
+    "references": []
   },
   {
     "spellings": "TROJAN",
@@ -119702,7 +119491,6 @@
     ],
     "references": [
       "TROLLEY; TROLLY",
-      "TROLLEY CAR",
       "TROLLEY WIRE"
     ]
   },
@@ -119711,9 +119499,7 @@
     "variants": [
       "TROLLEY WIRE\nTrolley wire.\n\nDefn: A heavy conducting wire on which the trolley car runs and from\nwhich it receives the current."
     ],
-    "references": [
-      "TROLLEY WIRE"
-    ]
+    "references": []
   },
   {
     "spellings": "TROLLMYDAMES",
@@ -121536,9 +121322,7 @@
     "variants": [
       "TRUDGEN STROKE\nTrudg\"en stroke. (Swimming)\n\nDefn: A racing stroke in which a double over-arm motion is used; --\nso called from its use by an amateur named Trudgen, but often\nerroneously written trudgeon."
     ],
-    "references": [
-      "TRUDGEN STROKE"
-    ]
+    "references": []
   },
   {
     "spellings": "TRUE",
@@ -122952,8 +122736,7 @@
     "references": [
       "INTERNAL-COMBUSTION; INTERNAL-COMBUSTION ENGINE",
       "STEAM ENGINE",
-      "TRUNK",
-      "TRUNK ENGINE"
+      "TRUNK"
     ]
   },
   {
@@ -122980,8 +122763,7 @@
       "TRUNK PISTON\nTrunk piston.\n\nDefn: In a single-acting engine, an elongated hollow piston, open at\nthe end, in which the end of the connecting rod is pivoted. The\npiston rod, crosshead and stuffing box are thus dispensed with."
     ],
     "references": [
-      "TRUNK ENGINE",
-      "TRUNK PISTON"
+      "TRUNK ENGINE"
     ]
   },
   {
@@ -122989,9 +122771,7 @@
     "variants": [
       "TRUNK STEAMER\nTrunk steamer.\n\nDefn: A freight steamer having a high hatch coaming extending almost\ncontinuously fore and aft, but not of whaleback form at the sides."
     ],
-    "references": [
-      "TRUNK STEAMER"
-    ]
+    "references": []
   },
   {
     "spellings": "TRUNKWORK",
@@ -123280,9 +123060,7 @@
     "variants": [
       "TRUST COMPANY\nTrust company.\n\nDefn: Any corporation formed for the purpose of acting as trustee.\nSuch companies usually do more or less of a banking business."
     ],
-    "references": [
-      "TRUST COMPANY"
-    ]
+    "references": []
   },
   {
     "spellings": "TRUSTEE",
@@ -123318,8 +123096,7 @@
     ],
     "references": [
       "ATTACHMENT",
-      "TRUSTEE",
-      "TRUSTEE PROCESS"
+      "TRUSTEE"
     ]
   },
   {
@@ -123334,9 +123111,7 @@
     "variants": [
       "TRUSTEE STOCK\nTrustee stock. (Finance)\n\nDefn: High-grade stock in which trust funds may be legally invested.\n[Colloq.]"
     ],
-    "references": [
-      "TRUSTEE STOCK"
-    ]
+    "references": []
   },
   {
     "spellings": "TRUSTER",
@@ -124147,8 +123922,7 @@
     ],
     "references": [
       "GAUGE",
-      "TRY",
-      "TRY COCK"
+      "TRY"
     ]
   },
   {
@@ -124358,8 +124132,7 @@
       "NORMAL",
       "QUADRABLE",
       "SQUARE",
-      "SUBQUADRATE",
-      "T SQUARE"
+      "SUBQUADRATE"
     ]
   },
   {
@@ -124368,7 +124141,6 @@
       "TSUNG-LI YAMEN\nTsung\"-li Ya\"men. [Written also Tsung-li-Yamen or Tsungli Yamen.]\n[Chin.]\n\nDefn: The board or department of foreign affairs in the Chinese\ngovernment. See Yamen."
     ],
     "references": [
-      "TSUNG-LI YAMEN",
       "WAI WU PU"
     ]
   },
@@ -124378,8 +124150,7 @@
       "TSUNG TU\nTsung\" tu`.\n\nDefn: A viceroy or governor-general, the highest provincial official\nin China, with civil and military authority over one or more\nprovinces."
     ],
     "references": [
-      "CHIH TAI",
-      "TSUNG TU"
+      "CHIH TAI"
     ]
   },
   {
@@ -124946,9 +124717,7 @@
     "variants": [
       "TUBERCULIN TEST\nTu*ber\"cu*lin test.\n\nDefn: The hypodermic injection of tuberculin, which has little or no\neffect with healthy cattle, but causes a marked rise in temperature\nin tuberculous animals."
     ],
-    "references": [
-      "TUBERCULIN TEST"
-    ]
+    "references": []
   },
   {
     "spellings": "TUBERCULIZATION",
@@ -125586,9 +125355,7 @@
     "variants": [
       "TUCK POINTING\nTuck pointing. (Masonry)\n\nDefn: The finishing of joints along the center lines with a narrow\nridge of putty or fine lime mortar."
     ],
-    "references": [
-      "TUCK POINTING"
-    ]
+    "references": []
   },
   {
     "spellings": "TUCUM",
@@ -125998,9 +125765,7 @@
     "variants": [
       "TULA METAL\nTu\"la met`al.\n\nDefn: An alloy of silver, copper, and lead made at Tula in Russia.\n[Written also toola metal.]"
     ],
-    "references": [
-      "TULA METAL"
-    ]
+    "references": []
   },
   {
     "spellings": "TULE",
@@ -126958,9 +126723,7 @@
     "variants": [
       "TUNGSTEN LAMP\nTung\"sten lamp.\n\nDefn: An electric glow lamp having filaments of metallic tungsten.\nSuch lamps, owing to the refractory nature of the metal, may be\nmaintained at a very high temperature and require an expenditure of\nonly about 1.25 watts per candle power."
     ],
-    "references": [
-      "TUNGSTEN LAMP"
-    ]
+    "references": []
   },
   {
     "spellings": "TUNGSTEN STEEL",
@@ -126969,7 +126732,6 @@
     ],
     "references": [
       "STEEL",
-      "TUNGSTEN STEEL",
       "WOLFRAM STEEL"
     ]
   },
@@ -127179,9 +126941,7 @@
     "variants": [
       "TUNNEL STERN\nTun\"nel stern.\n\nDefn: A design of motor-boat stern, for  use in shallow waters, in\nwhich the propeller is housed in a tunnel and does not extend below\nthe greatest draft."
     ],
-    "references": [
-      "TUNNEL STERN"
-    ]
+    "references": []
   },
   {
     "spellings": "TUNNY",
@@ -129180,8 +128940,7 @@
     ],
     "references": [
       "CYANOGEN",
-      "FERRICYANIDE",
-      "TURNBULL'S BLUE"
+      "FERRICYANIDE"
     ]
   },
   {
@@ -129839,9 +129598,7 @@
     "variants": [
       "TURPENTINE STATE\nTur\"pen*tine State.\n\nDefn: North Carolina; -- a nickname alluding to its extensive\nproduction of turpentine."
     ],
-    "references": [
-      "TURPENTINE STATE"
-    ]
+    "references": []
   },
   {
     "spellings": "TURPETH",
@@ -129938,9 +129695,7 @@
     "variants": [
       "TURRET DECK\nTur\"ret deck.\n\nDefn: A narrow superstructure running from stem to stern on the upper\ndeck of a steam cargo vessel having a rounded gunwale and sides\ncurved inward convexly."
     ],
-    "references": [
-      "TURRET DECK"
-    ]
+    "references": []
   },
   {
     "spellings": "TURRETED",
@@ -129959,9 +129714,7 @@
     "variants": [
       "TURRET STEAMER\nTur\"ret steam`er.\n\nDefn: A whaleback steamer with a hatch coaming, usually about seven\nfeet high, extending almost continuously fore and aft."
     ],
-    "references": [
-      "TURRET STEAMER"
-    ]
+    "references": []
   },
   {
     "spellings": "TURRIBANT",
@@ -130101,9 +129854,7 @@
     "variants": [
       "TURTLE PEG\nTur\"tle peg.\n\nDefn: A sharp steel spear attached to a cord, used in taking sea\nturtles. -- Turtle pegging."
     ],
-    "references": [
-      "TURTLE PEG"
-    ]
+    "references": []
   },
   {
     "spellings": "TURTLER",
@@ -130252,9 +130003,7 @@
     "variants": [
       "TUSSAC GRASS\nTus\"sac grass`.\n\nDefn: Tussock grass."
     ],
-    "references": [
-      "TUSSAC GRASS"
-    ]
+    "references": []
   },
   {
     "spellings": "TUSSAH; TUSSEH",
@@ -130270,9 +130019,7 @@
     "variants": [
       "TUSSAH SILK\nTus\"sah silk`. Etym: [Probably fr. Hind. tasar a shuttle, Skr.\ntasara, trasara.]\n(a) A silk cloth made from the cocoons of a caterpillar other than\nthe common silkworm, much used in Bengal and China.\n(b) The silk fiber itself. [Written also tusseh silk.]"
     ],
-    "references": [
-      "TUSSAH SILK"
-    ]
+    "references": []
   },
   {
     "spellings": "TUSSAL",
@@ -130599,9 +130346,7 @@
     "variants": [
       "TUXEDO COAT; TUXEDO\nTux*e\"do coat`, or Tux*e\"do, n.\n\nDefn: A kind of black coat for evening dress made without skirts; --\nso named after a fashionable country club at Tuxedo Park, New York.\n[U. S.]"
     ],
-    "references": [
-      "TUXEDO COAT; TUXEDO"
-    ]
+    "references": []
   },
   {
     "spellings": "TUYERE",
@@ -130636,9 +130381,7 @@
     "variants": [
       "TWADDELL; TWADDELL'S HYDROMETER\nTwad\"dell, n., Twad\"dell's hy*drom\"e*ter. [After one Twaddell, its\ninventor.]\n\nDefn: A form of hydrometer for liquids heavier than water, graduated\nwith an arbitrary scale such that the readings when multiplied by\n.005 and added to unity give the specific gravity."
     ],
-    "references": [
-      "TWADDELL; TWADDELL'S HYDROMETER"
-    ]
+    "references": []
   },
   {
     "spellings": "TWADDLE",
@@ -130856,9 +130599,7 @@
     "variants": [
       "TWEEDLEDUM AND TWEEDLEDEE\nTwee\"dle*dum` and Twee\"dle*dee`.\n\nDefn: Two things practically alike; -- a phrase coined by John Byrom\n(1692-1793) in his satire \"On the Feuds between Handel and\nBononcini.\""
     ],
-    "references": [
-      "TWEEDLEDUM AND TWEEDLEDEE"
-    ]
+    "references": []
   },
   {
     "spellings": "TWEEL",
@@ -132545,8 +132286,7 @@
       "TWITCH GRASS\nTwitch\" grass`. (Bot.)\n\nDefn: See Quitch grass."
     ],
     "references": [
-      "QUITCH GRASS",
-      "TWITCH GRASS"
+      "QUITCH GRASS"
     ]
   },
   {
@@ -135759,9 +135499,7 @@
     "variants": [
       "TYBURN TICKET\nTy\"burn tick`et. Etym: [So called in allusion to Tyburn, formerly a\nplace of execution in England.] (O. Eng. Law)\n\nDefn: A certificate given to one who prosecutes a felon to\nconviction, exempting him from certain parish and ward offices."
     ],
-    "references": [
-      "TYBURN TICKET"
-    ]
+    "references": []
   },
   {
     "spellings": "TYCHISM",

--- a/output/wordDisplayData#U-V.json
+++ b/output/wordDisplayData#U-V.json
@@ -2071,9 +2071,7 @@
     "variants": [
       "ULTRA VIRES\nUl`tra vi\"res, Etym: [Law Latin, from L. prep. ultra beyond + vires,\npl. of. vis strength.]\n\nDefn: Beyond power; transcending authority; -- a phrase used\nfrequently in relation to acts or enactments by corporations in\nexcess of their chartered or statutory rights."
     ],
-    "references": [
-      "ULTRA VIRES"
-    ]
+    "references": []
   },
   {
     "spellings": "ULTRAZODIACAL",
@@ -2428,8 +2426,7 @@
     "references": [
       "DIRT",
       "EAT",
-      "HUMBLE",
-      "UMBLE PIE"
+      "HUMBLE"
     ]
   },
   {
@@ -3440,9 +3437,7 @@
     "variants": [
       "UNA BOAT\nU\"na boat`. (Naut.)\n\nDefn: The English name for a catboat; -- so called because Una was\nthe name of the first boat of this kind taken to England. D. Kemp."
     ],
-    "references": [
-      "UNA BOAT"
-    ]
+    "references": []
   },
   {
     "spellings": "UNABRIDGED",
@@ -7447,8 +7442,7 @@
       "UNCUT VELVET\nUn*cut\" vel\"vet.\n\nDefn: A fabric woven like velvet, but with the loops of the warp\nthreads uncut."
     ],
     "references": [
-      "UNCUT",
-      "UNCUT VELVET"
+      "UNCUT"
     ]
   },
   {
@@ -12842,9 +12836,7 @@
     "variants": [
       "UNDERGROUND INSURANCE\nUn\"der*ground` in*sur\"ance.\n\nDefn: Wildcat insurance."
     ],
-    "references": [
-      "UNDERGROUND INSURANCE"
-    ]
+    "references": []
   },
   {
     "spellings": "UNDERGROVE",
@@ -13133,9 +13125,7 @@
     "variants": [
       "UNDERLOAD STARTER\nUn\"der*load start`er. (Elec.)\n\nDefn: A motor starter provided with an underload switch."
     ],
-    "references": [
-      "UNDERLOAD STARTER"
-    ]
+    "references": []
   },
   {
     "spellings": "UNDERLOAD SWITCH",
@@ -13143,8 +13133,7 @@
       "UNDERLOAD SWITCH\nUnderload switch. (Elec.)\n\nDefn: A switch which opens a circuit when the current falls below a\ncertain predetermined value, used to protect certain types of motors\nfrom running at excessive speed upon decrease of load."
     ],
     "references": [
-      "UNDERLOAD STARTER",
-      "UNDERLOAD SWITCH"
+      "UNDERLOAD STARTER"
     ]
   },
   {
@@ -21858,9 +21847,7 @@
     "variants": [
       "UNIVERSITY EXTENSION\nU`ni*ver\"si*ty ex*ten\"sion.\n\nDefn: The extension of the advantages of university instruction by\nmeans of lectures and classes at various centers."
     ],
-    "references": [
-      "UNIVERSITY EXTENSION"
-    ]
+    "references": []
   },
   {
     "spellings": "UNIVERSOLOGICAL",
@@ -36538,9 +36525,7 @@
     "variants": [
       "UPSETTING THERMOMETER\nUp*set\"ting ther*mom\"e*ter.\n\nDefn: A thermometer by merely inverting which the temperature may be\nregistered. The column of mercury is broken and, as it remains until\nthe instrument is reset, the reading may be made at leisure."
     ],
-    "references": [
-      "UPSETTING THERMOMETER"
-    ]
+    "references": []
   },
   {
     "spellings": "UPSHOOT",
@@ -36791,9 +36776,7 @@
     "variants": [
       "UPTAILS ALL\nUp\"tails` all\".\n\n1. An old game at cards. [Obs.]\n\n2. Revelers; roysterers. [Obs.] Decker.\n\n3. Revelry; confusion; frolic. [Obs.] Herrick."
     ],
-    "references": [
-      "UPTAILS ALL"
-    ]
+    "references": []
   },
   {
     "spellings": "UPTAKE",
@@ -42839,9 +42822,7 @@
     "variants": [
       "UTI POSSIDETIS\nU`ti pos`si*de\"tis. Etym: [L., as you possess.]\n\n1. (Internat. Law)\n\nDefn: The basis or principle of a treaty which leaves belligerents\nmutually in possession of what they have acquired by their arms\nduring the war. Brande & C.\n\n2. (Roman Law)\n\nDefn: A species of interdict granted to one who was in possession of\nan immovable thing, in order that he might be declared the legal\npossessor. Burrill."
     ],
-    "references": [
-      "UTI POSSIDETIS"
-    ]
+    "references": []
   },
   {
     "spellings": "UTIS",
@@ -49031,9 +49012,7 @@
     "variants": [
       "VACCINE POINT\nVac\"cine point`. (Med.)\n\nDefn: See Point, n., 26."
     ],
-    "references": [
-      "VACCINE POINT"
-    ]
+    "references": []
   },
   {
     "spellings": "VACCINIA",
@@ -49091,9 +49070,7 @@
     "variants": [
       "VACHETTE CLASP\nVa`chette\" clasp. [Cf. F. vachette cowhide leather used for\nligatures.] (Veter.)\n\nDefn: A piece of strong steel wire with the ends curved and pointed,\nused on toe or quarter cracks to bind the edges together and prevent\nmotion. It is clasped into two notches, one on each side of the\ncrack, burned into the wall with a cautery iron."
     ],
-    "references": [
-      "VACHETTE CLASP"
-    ]
+    "references": []
   },
   {
     "spellings": "VACILLANCY",
@@ -49313,9 +49290,7 @@
     "variants": [
       "VACUUM CLEANER\nVac\"u*um clean\"er.\n\nDefn: A machine for cleaning carpets, tapestry, upholstered work,\netc., by suction."
     ],
-    "references": [
-      "VACUUM CLEANER"
-    ]
+    "references": []
   },
   {
     "spellings": "VADANTES",
@@ -49340,9 +49315,7 @@
     "variants": [
       "VADE MECUM\nVa`de me\"cum. Etym: [L., go with me.]\n\nDefn: A book or other thing that a person carries with him as a\nconstant companion; a manual; a handbook."
     ],
-    "references": [
-      "VADE MECUM"
-    ]
+    "references": []
   },
   {
     "spellings": "VADIMONY",
@@ -50303,7 +50276,6 @@
       "VALENCIENNES LACE\nVa*len`ci*ennes\" lace\". Etym: [F.; -- so called after the town of\nValenciennes.]\n\nDefn: A rich kind of lace made at Valenciennes, in France. Each piece\nis made throughout, ground and pattern, by the same person and with\nthe same thread, the pattern being worked in the net."
     ],
     "references": [
-      "VALENCIENNES LACE",
       "YPRES LACE"
     ]
   },
@@ -50801,9 +50773,7 @@
     "variants": [
       "VALLET'S PILLS\nVal`let's pills\". Etym: [From Dr. Vallet of Paris.] (Med.)\n\nDefn: Pills containing sulphate of iron and carbonate of sodium,\nmixed with saccharine matter; -- called also Vallet's mass."
     ],
-    "references": [
-      "VALLET'S PILLS"
-    ]
+    "references": []
   },
   {
     "spellings": "VALLEY",
@@ -51903,8 +51873,7 @@
     ],
     "references": [
       "POLICY",
-      "VALUED",
-      "VALUED POLICY"
+      "VALUED"
     ]
   },
   {
@@ -51912,9 +51881,7 @@
     "variants": [
       "VALUED-POLICY LAW\nValued-policy law. (Fire Insurance)\n\nDefn: A law requiring insurance companies to pay to the insured, in\ncase of total loss, the full amount of the insurance, regardless of\nthe actual value of the property at the time of the loss."
     ],
-    "references": [
-      "VALUED-POLICY LAW"
-    ]
+    "references": []
   },
   {
     "spellings": "VALUELESS",
@@ -52438,9 +52405,7 @@
     "variants": [
       "VANADIUM BRONZE\nVa*na\"di*um bronze`. (Chem.)\n\nDefn: A yellow pigment consisting of a compound of vanadium."
     ],
-    "references": [
-      "VANADIUM BRONZE"
-    ]
+    "references": []
   },
   {
     "spellings": "VANADOUS",
@@ -52505,9 +52470,7 @@
     "variants": [
       "VANDYKE BEARD\nVan*dyke\" beard`.\n\nDefn: A trim, pointed beard, such as those often seen in pictures by\nVandyke."
     ],
-    "references": [
-      "VANDYKE BEARD"
-    ]
+    "references": []
   },
   {
     "spellings": "VANE",
@@ -52789,9 +52752,7 @@
     "variants": [
       "VANITY BOX\nVan\"i*ty box.\n\nDefn: A small box, usually jeweled or of precious metal and worn on a\nchain, containing a mirror, powder puff, and other small toilet\narticles for a woman."
     ],
-    "references": [
-      "VANITY BOX"
-    ]
+    "references": []
   },
   {
     "spellings": "VANJAS",
@@ -52818,9 +52779,7 @@
     "variants": [
       "VANNER HAWK\nVan\"ner hawk`.\n\nDefn: The kestrel. [Prov. Eng.]"
     ],
-    "references": [
-      "VANNER HAWK"
-    ]
+    "references": []
   },
   {
     "spellings": "VANNING",
@@ -52927,18 +52886,14 @@
     "variants": [
       "VANTAGE GAME\nVan\"tage game. (Lawn Tennis)\n\nDefn: The first game after the set is deuce. See Set, n., 9."
     ],
-    "references": [
-      "VANTAGE GAME"
-    ]
+    "references": []
   },
   {
     "spellings": "VANTAGE POINT",
     "variants": [
       "VANTAGE POINT\nVantage point.\n\nDefn: A point giving advantage; vantage ground."
     ],
-    "references": [
-      "VANTAGE POINT"
-    ]
+    "references": []
   },
   {
     "spellings": "VANTBRACE; VANTBRASS",
@@ -52963,9 +52918,7 @@
     "variants": [
       "VAN'T HOFF'S LAW\nVan't Hoff's law. [After J.H. van't Hoff, Dutch physical chemist.]\n(Phys. Chem.)\n\nDefn: The generalization that: when a system is in equilibrium, of\nthe two opposed interactions the endothermic is promoted by raising\nthe temperature, the exothermic by lowering it."
     ],
-    "references": [
-      "VAN'T HOFF'S LAW"
-    ]
+    "references": []
   },
   {
     "spellings": "VANWARD",
@@ -53235,8 +53188,7 @@
       "VAPOR GALVANIZING\nVa\"por gal\"va*niz`ing. (Metal.)\n\nDefn: A process for coating metal (usually iron or steel) surfaces\nwith zinc by exposing them to the vapor of zinc instead of, as in\nordinary galvanizing, to molten zinc; -- called also Sherardizing.\nVapor galvanizing is accomplished by heating the articles to be\ngalvanized together with zinc dust in an air tight receptacle to a\ntemperature of about 600º F., which is 188º below the melting point\nof zinc, or by exposing the articles to vapor from molten zinc in a\nseparate receptacle, using hydrogen or other reducing gas to prevent\noxidation."
     ],
     "references": [
-      "SHERARDIZE",
-      "VAPOR GALVANIZING"
+      "SHERARDIZE"
     ]
   },
   {
@@ -53363,9 +53315,7 @@
     "variants": [
       "VAPOR PRESSURE; VAPOR TENSION\nVapor pressure or tension . (Physics)\n\nDefn: The pressure or tension of a confined body of vapor. The\npressure of a given saturated vapor is a function of the temperature\nonly, and may be measured by introducing a small quantity of the\nsubstance into a barometer and noting the depression of the column of\nmercury."
     ],
-    "references": [
-      "VAPOR PRESSURE; VAPOR TENSION"
-    ]
+    "references": []
   },
   {
     "spellings": "VAPORY",
@@ -54810,9 +54760,7 @@
     "variants": [
       "VARIETY SHOW\nVariety show.\n\nDefn: A stage entertainment of successive separate performances,\nusually songs, dances, acrobatic feats, dramatic sketches,\nexhibitions of trained animals, or any specialties. Often loosely\ncalled vaudeville show."
     ],
-    "references": [
-      "VARIETY SHOW"
-    ]
+    "references": []
   },
   {
     "spellings": "VARIFORM",
@@ -56516,9 +56464,7 @@
     "variants": [
       "VASE CLOCK\nVase clock. (Art)\n\nDefn: A clock whose decorative case has the general form of a vase,\nesp. one in which there is no ordinary dial, but in which a part of a\nvase revolves while a single stationary indicator serves as a hand."
     ],
-    "references": [
-      "VASE CLOCK"
-    ]
+    "references": []
   },
   {
     "spellings": "VASECTOMY",
@@ -56976,8 +56922,7 @@
     ],
     "references": [
       "CATHEDRA",
-      "CATHOLIC",
-      "VATICAN COUNCIL"
+      "CATHOLIC"
     ]
   },
   {
@@ -57374,9 +57319,7 @@
     "variants": [
       "VAZA PARROT\nVa\"za par`rot. (Zoöl.)\n\nDefn: Any one of several species of parrots of the genus Coracopsis,\nnative of Madagascar; -- called also vasa parrot."
     ],
-    "references": [
-      "VAZA PARROT"
-    ]
+    "references": []
   },
   {
     "spellings": "VEADAR",
@@ -58405,9 +58348,7 @@
     "variants": [
       "VEILED PLATE\nVeiled plate. (Photog.)\n\nDefn: A fogged plate."
     ],
-    "references": [
-      "VEILED PLATE"
-    ]
+    "references": []
   },
   {
     "spellings": "VEILING",
@@ -58641,9 +58582,7 @@
     "variants": [
       "VEIN QUARTZ\nVein quartz.\n\nDefn: Quartz occurring as gangue in a vein."
     ],
-    "references": [
-      "VEIN QUARTZ"
-    ]
+    "references": []
   },
   {
     "spellings": "VEINSTONE",
@@ -58698,9 +58637,7 @@
     "variants": [
       "VELDT SORE\nVeldt sore. (Med.)\n\nDefn: An infective sore mostly on the hands and feet, often\ncontracted in walking on the veldt and apparently due to a specific\nmicroörganism."
     ],
-    "references": [
-      "VELDT SORE"
-    ]
+    "references": []
   },
   {
     "spellings": "VELE",
@@ -58981,9 +58918,7 @@
     "variants": [
       "VELOUTE; SAUCE VELOUTE\nVe*lou`té\", n., or Sauce velouté. [F. velouté, lit., velvety.]\n(Cookery)\n\nDefn: A white sauce or stock made by boiling down ham, veal, beef,\nfowl, bouillon, etc., then adding soup stock, seasoning, vegetables,\nand thickening, and again boiling and straining."
     ],
-    "references": [
-      "VELOUTE; SAUCE VELOUTE"
-    ]
+    "references": []
   },
   {
     "spellings": "VELTFARE",
@@ -59414,9 +59349,7 @@
     "variants": [
       "VENDOR'S LIEN\nVend\"or's lien. (Law)\n\nDefn: An implied lien (that is, one not created by mortgage or other\nexpress agreement) given in equity to a vendor of lands for the\nunpaid purchase money."
     ],
-    "references": [
-      "VENDOR'S LIEN"
-    ]
+    "references": []
   },
   {
     "spellings": "VENDS",
@@ -59911,9 +59844,7 @@
     "variants": [
       "VENIRE FACIAS\nVe*ni\"re fa\"ci*as. Etym: [L., make, or cause, to come.] (Law)\n(a) A judicial writ or precept directed to the sheriff, requiring him\nto cause a certain number of qualified persons to appear in court at\na specified time, to serve as jurors in said court.\n(b) A writ in the nature of a summons to cause the party indicted on\na penal statute to appear. Called also venire."
     ],
-    "references": [
-      "VENIRE FACIAS"
-    ]
+    "references": []
   },
   {
     "spellings": "VENISON",
@@ -61450,8 +61381,7 @@
       "VERD ANTIQUE\nVerd` an*tique\". Etym: [F. vert antique a kind of marble; verd, vert,\ngreen + antique ancient: cf. It. verde antico.] (Min.)\n(a) A mottled-green serpentine marble.\n(b) A green porphyry called oriental verd antique."
     ],
     "references": [
-      "MARBLE",
-      "VERD ANTIQUE"
+      "MARBLE"
     ]
   },
   {
@@ -62404,9 +62334,7 @@
     "variants": [
       "VERNER'S LAW\nVer\"ner's law. (Philol.)\n\nDefn: A statement, propounded by the Danish philologist Karl Verner\nin 1875, which explains certain apparent exceptions to Grimm's law by\nthe original position of the accent. Primitive Indo-European k, t, p,\nbecame first in Teutonic h, th, f, and appear without further change\nin old Teutonic, if the accent rested on the preceding syllable; but\nthese sounds became voiced and produced g, d, b, if the accent was\noriginally on a different syllable. Similarly s either remained\nunchanged, or it became z and later r. Example: Skt. sapta (accent on\nultima), Gr. 'e`pta, Gothic sibun (seven). Examples in English are\ndead by the side of death, to rise and to rear."
     ],
-    "references": [
-      "VERNER'S LAW"
-    ]
+    "references": []
   },
   {
     "spellings": "VERNICLE",
@@ -62676,9 +62604,7 @@
     "variants": [
       "VERS DE SOCIETE\nVers` de so`cié`té\". Etym: [F.]\n\nDefn: See Society verses, under Society."
     ],
-    "references": [
-      "VERS DE SOCIETE"
-    ]
+    "references": []
   },
   {
     "spellings": "VERSE",
@@ -65870,9 +65796,7 @@
     "variants": [
       "VERY'S NIGHT SIGNALS; VERY NIGHT SIGNALS; VERY'S LIGHT SIGNALS; VERY LIGHT SIGNALS\nVer\"y's, or Ver\"y, night signals . [After Lieut. Samuel W. Very, who\ninvented the system in 1877.] (Naut.)\n\nDefn: A system of signaling in which balls of red and green fire are\nfired from a pistol, the arrangement in groups denoting numbers\nhaving a code significance."
     ],
-    "references": [
-      "VERY'S NIGHT SIGNALS; VERY NIGHT SIGNALS; VERY'S LIGHT SIGNALS; VERY LIGHT SIGNALS"
-    ]
+    "references": []
   },
   {
     "spellings": "VESBIUM",
@@ -67326,9 +67250,7 @@
     "variants": [
       "VESTED SCHOOL\nVest\"ed school.\n\nDefn: In Ireland, a national school which has been built by the aid\nof grants from the board of Commissioners of National Education and\nis secured for educational purposes by leases to the commissioners\nthemselves, or to the commissioners and the trustees."
     ],
-    "references": [
-      "VESTED SCHOOL"
-    ]
+    "references": []
   },
   {
     "spellings": "VESTIARIAN",
@@ -67386,9 +67308,7 @@
     "variants": [
       "VESTIBULED TRAIN\nVestibuled train. (Railroad)\n\nDefn: Same as Vestibule  train, under Vestibule."
     ],
-    "references": [
-      "VESTIBULED TRAIN"
-    ]
+    "references": []
   },
   {
     "spellings": "VESTIBULUM",
@@ -67964,9 +67884,7 @@
     "variants": [
       "V HOOK\nV\" hook`. (Steam Engine)\n\nDefn: A gab at the end of an eccentric rod, with long jaws, shaped\nlike the letter V."
     ],
-    "references": [
-      "V HOOK"
-    ]
+    "references": []
   },
   {
     "spellings": "VIA",
@@ -68772,9 +68690,7 @@
     "variants": [
       "VICHY WATER\nVi\"chy wa`ter.\n\nDefn: A mineral water found at Vichy, France. It is essentially an\neffervescent solution of sodium, calcium, and magnetism carbonates,\nwith sodium and potassium chlorides; also, by extension, any\nartificial or natural water resembling in composition the Vichy water\nproper. Called also, colloquially, Vichy."
     ],
-    "references": [
-      "VICHY WATER"
-    ]
+    "references": []
   },
   {
     "spellings": "VICIATE",
@@ -68959,27 +68875,21 @@
     "variants": [
       "VICISSY DUCK\nVi*cis\"sy duck`. (Zoöl.)\n\nDefn: A West Indian duck, sometimes domesticated."
     ],
-    "references": [
-      "VICISSY DUCK"
-    ]
+    "references": []
   },
   {
     "spellings": "VICKERS' GUN",
     "variants": [
       "VICKERS' GUN\nVick\"ers' gun. (Ordnance)\n\nDefn: One of a system of guns manufactured by the firm of Vickers'\nSons, at Sheffield, Eng. now included in Vickers-Maxim guns."
     ],
-    "references": [
-      "VICKERS' GUN"
-    ]
+    "references": []
   },
   {
     "spellings": "VICKERS-MAXIM AUTOMATIC MACHINE GUN",
     "variants": [
       "VICKERS-MAXIM AUTOMATIC MACHINE GUN\nVick\"ers-Max\"im automatic machine gun.\n\nDefn: An automatic machine gun in which the mechanism is worked by\nthe recoil, assisted by the pressure of gases from the muzzle, which\nexpand in a gas chamber against a disk attached to the end of the\nbarrel, thus moving the latter to the rear with increased recoil, and\nagainst the front wall of the gas chamber, checking the recoil of the\nsystem."
     ],
-    "references": [
-      "VICKERS-MAXIM AUTOMATIC MACHINE GUN"
-    ]
+    "references": []
   },
   {
     "spellings": "VICKERS-MAXIM GUN",
@@ -68987,8 +68897,7 @@
       "VICKERS-MAXIM GUN\nVickers-Maxim gun. (Ordnance)\n\nDefn: One of a system of ordnance, including machine, quick-fire,\ncoast, and field guns, of all calibers, manufactured by the combined\nfirms of Vickers' Sons of Sheffield and Maxim of Birmingham and\nelsewhere, England."
     ],
     "references": [
-      "VICKERS' GUN",
-      "VICKERS-MAXIM GUN"
+      "VICKERS' GUN"
     ]
   },
   {
@@ -69134,9 +69043,7 @@
     "variants": [
       "VICTORIA CRAPE\nVictoria crape.\n\nDefn: A kind of cotton crape."
     ],
-    "references": [
-      "VICTORIA CRAPE"
-    ]
+    "references": []
   },
   {
     "spellings": "VICTORIAN",
@@ -69394,7 +69301,6 @@
       "VIDA FINCH\nVid\"a finch`. (Zoöl.)\n\nDefn: The whidah bird."
     ],
     "references": [
-      "VIDA FINCH",
       "WHIDAH BIRD"
     ]
   },
@@ -69518,9 +69424,7 @@
     "variants": [
       "VIENNA PASTE\nVi*en\"na paste`. (Pharm.)\n\nDefn: A caustic application made up of equal parts of caustic potash\nand quicklime; -- called also Vienna caustic."
     ],
-    "references": [
-      "VIENNA PASTE"
-    ]
+    "references": []
   },
   {
     "spellings": "VIENNESE",
@@ -71583,9 +71487,7 @@
     "variants": [
       "VINEGAR FLY\nVin\"e*gar fly.\n\nDefn: Any of several fruit flies, esp. Drosophila ampelopophila,\nwhich breed in imperfectly sealed preserves and in pickles."
     ],
-    "references": [
-      "VINEGAR FLY"
-    ]
+    "references": []
   },
   {
     "spellings": "VINEGARROON",
@@ -71668,7 +71570,6 @@
       "VINGT ET UN\nVingt` et` un\". Etym: [F., twenty and one.]\n\nDefn: A game at cards, played by two or more persons. The fortune of\neach player depends upon obtaining from the dealer such cards that\nthe sum of their pips, or spots, is twenty-one, or a number near to\nit."
     ],
     "references": [
-      "VINGT ET UN",
       "VINGTUN"
     ]
   },
@@ -71749,9 +71650,7 @@
     "variants": [
       "VIN ORDINAIRE\nVin` or`di`naire\". Etym: [F., lit., common wine.]\n\nDefn: A cheap claret, used as a table wine in France."
     ],
-    "references": [
-      "VIN ORDINAIRE"
-    ]
+    "references": []
   },
   {
     "spellings": "VINOSE",
@@ -74858,9 +74757,7 @@
     "variants": [
       "VISIBLE SPEECH\nVis\"i*ble speech\". (Phon.)\n\nDefn: A system of characters invented by Prof. Alexander Melville\nBell to represent all sounds that may be uttered by the speech\norgans, and intended to be suggestive of the position of the organs\nof speech in uttering them."
     ],
-    "references": [
-      "VISIBLE SPEECH"
-    ]
+    "references": []
   },
   {
     "spellings": "VISIGOTH",
@@ -75274,9 +75171,7 @@
     "variants": [
       "VIS MAJOR\nVis ma\"jor. [L. major greater.] (Law)\n\nDefn: A superior force which under certain circumstances is held to\nexempt from contract obligations; inevitable accident; -- a civil-law\nterm used as nearly equivalent to, but broader than, the common-law\nterm act of God (which see)."
     ],
-    "references": [
-      "VIS MAJOR"
-    ]
+    "references": []
   },
   {
     "spellings": "VISNE",
@@ -76350,7 +76245,6 @@
     "references": [
       "AYE; AY",
       "ELECTION",
-      "VIVA VOCE",
       "VOTE"
     ]
   },
@@ -76834,9 +76728,7 @@
     "variants": [
       "V MOTH\nV\" moth`. (Zoöl.)\n\nDefn: A common gray European moth (Halia vauaria) having a V-shaped\nspot of dark brown on each of the fore wings."
     ],
-    "references": [
-      "V MOTH"
-    ]
+    "references": []
   },
   {
     "spellings": "VOCABLE",
@@ -77966,9 +77858,7 @@
     "variants": [
       "VOIR DIRE\nVoir dire. Etym: [OF., to say the truth, fr. L. verus true + dicere\nto say.] (Law)\n\nDefn: An oath administered to a witness, usually before being sworn\nin chief, requiring him to speak the truth, or make true answers in\nreference to matters inquired of, to ascertain his competency to give\nevidence. Greenleaf. Ld. Abinger."
     ],
-    "references": [
-      "VOIR DIRE"
-    ]
+    "references": []
   },
   {
     "spellings": "VOITURE",
@@ -78359,18 +78249,14 @@
     "variants": [
       "VOLCANIC NECK\nVol*can\"ic neck. (Geol.)\n\nDefn: A column of igneous rock formed by congelation of lava in the\nconduit of a volcano and later exposed by the removal of surrounding\nrocks."
     ],
-    "references": [
-      "VOLCANIC NECK"
-    ]
+    "references": []
   },
   {
     "spellings": "VOLCANIC WIND",
     "variants": [
       "VOLCANIC WIND\nVolcanic wind. (Meteorol.)\n\nDefn: A wind associated with a volcanic outburst and due to the\neruption or to convection currents over hot lava."
     ],
-    "references": [
-      "VOLCANIC WIND"
-    ]
+    "references": []
   },
   {
     "spellings": "VOLCANISM",
@@ -78580,9 +78466,7 @@
     "variants": [
       "VOLLEY BALL\nVol\"ley ball.\n\nDefn: A game played by volleying a large inflated ball with the hands\nover a net 7 ft. 6 in. high."
     ],
-    "references": [
-      "VOLLEY BALL"
-    ]
+    "references": []
   },
   {
     "spellings": "VOLLEYED",
@@ -78781,9 +78665,7 @@
     "variants": [
       "VOLT AMPERE\nVolt ampère. (Elec.)\n\nDefn: A unit of electric measurement equal to the product of a volt\nand an ampere. For direct current it is a measure of power and is the\nsame as a watt; for alternating current it is a measure of apparent\npower."
     ],
-    "references": [
-      "VOLT AMPERE"
-    ]
+    "references": []
   },
   {
     "spellings": "VOLTAPLAST",
@@ -79281,27 +79163,21 @@
     "variants": [
       "VOLUNTEER NAVY\nVol`un*teer\" na\"vy.\n\nDefn: A navy of vessels fitted out and manned by volunteers who sail\nunder the flag of the regular navy and subject to naval discipline.\nPrussia in 1870, in the Franco-German war, organized such a navy,\nwhich was commanded by merchant seamen with temporary commissions,\nwith the claim (in which England acquiesced) that it did not come\nwithin the meaning of the term privateer."
     ],
-    "references": [
-      "VOLUNTEER NAVY"
-    ]
+    "references": []
   },
   {
     "spellings": "VOLUNTEERS OF AMERICA",
     "variants": [
       "VOLUNTEERS OF AMERICA\nVol`un*teers\" of America.\n\nDefn: A religious and philanthropic organization, similar to the\nSalvation Army, founded (1896) by Commander and Mrs. Ballington\nBooth."
     ],
-    "references": [
-      "VOLUNTEERS OF AMERICA"
-    ]
+    "references": []
   },
   {
     "spellings": "VOLUNTEER STATE",
     "variants": [
       "VOLUNTEER STATE\nVolunteer State.\n\nDefn: Tennessee; -- a nickname."
     ],
-    "references": [
-      "VOLUNTEER STATE"
-    ]
+    "references": []
   },
   {
     "spellings": "VOLUPERE",
@@ -79500,9 +79376,7 @@
     "variants": [
       "VOMIC NUT\nVom\"ic nut`. Etym: [Cf. F. noix vomique.]\n\nDefn: Same as Nux vomica."
     ],
-    "references": [
-      "VOMIC NUT"
-    ]
+    "references": []
   },
   {
     "spellings": "VOMIT",
@@ -79761,18 +79635,14 @@
     "variants": [
       "VORTEX FILAMENT\nVor\"tex fil\"a*ment.\n\nDefn: A vortex tube of infinitesimal cross section."
     ],
-    "references": [
-      "VORTEX FILAMENT"
-    ]
+    "references": []
   },
   {
     "spellings": "VORTEX FRINGE",
     "variants": [
       "VORTEX FRINGE\nVor\"tex fringe.\n\nDefn: The region immediately surrounding a disk moving flatwise\nthrough air; -- so called because the air has a cyclic motion as in\nvortex ring."
     ],
-    "references": [
-      "VORTEX FRINGE"
-    ]
+    "references": []
   },
   {
     "spellings": "VORTEX LINE",
@@ -79780,7 +79650,6 @@
       "VORTEX LINE\nVortex line.\n\nDefn: A line, within a rotating fluid, whose tangent at every point\nis the instantaneous axis of rotation as that point of the fluid."
     ],
     "references": [
-      "VORTEX LINE",
       "VORTEX TUBE"
     ]
   },
@@ -79790,8 +79659,7 @@
       "VORTEX RING\nVortex ring. (Physics)\n\nDefn: A ring-shaped mass of moving fluid which, by virtue of its\nmotion of rotation around an axis disposed in circular form, attains\na more or less distinct separation from the surrounding medium and\nhas many of the properties of a solid."
     ],
     "references": [
-      "VORTEX FRINGE",
-      "VORTEX RING"
+      "VORTEX FRINGE"
     ]
   },
   {
@@ -79799,9 +79667,7 @@
     "variants": [
       "VORTEX THEORY\nVortex theory. (Chem. & Physics)\n\nDefn: The theory, advanced by Thomson (Lord Kelvin) on the basis of\ninvestigation by Helmholtz, that the atoms are vortically moving\nring-shaped masses (or masses of other forms having a similar\ninternal motion) of a homogeneous, incompressible, frictionless\nfluid. Various properties of such atoms (vortex atoms) can be\nmathematically deduced."
     ],
-    "references": [
-      "VORTEX THEORY"
-    ]
+    "references": []
   },
   {
     "spellings": "VORTEX TUBE",
@@ -79809,8 +79675,7 @@
       "VORTEX TUBE\nVortex tube. (Physics)\n\nDefn: An imaginary tube within a rotating fluid, formed by drawing\nthe vortex lines through all points of a closed curve."
     ],
     "references": [
-      "VORTEX FILAMENT",
-      "VORTEX TUBE"
+      "VORTEX FILAMENT"
     ]
   },
   {
@@ -80402,9 +80267,7 @@
     "variants": [
       "VOX ANGELICA\nVox` an*gel\"i*ca. [L. angelica angelic.] (Music)\n\nDefn: An organ stop of delicate stringlike quality, having for each\nfinger key a pair of pipes, of which one is tuned slightly sharp to\ngive a wavy effect to their joint tone."
     ],
-    "references": [
-      "VOX ANGELICA"
-    ]
+    "references": []
   },
   {
     "spellings": "VOYAGE",
@@ -80654,9 +80517,7 @@
     "variants": [
       "VULCAN POWDER\nVul\"can pow\"der.\n\nDefn: A dynamite composed of nitroglycerin (30 parts), sodium nitrate\n(52.5), charcoal (10.5), and sulphur (7), used in mining and\nblasting."
     ],
-    "references": [
-      "VULCAN POWDER"
-    ]
+    "references": []
   },
   {
     "spellings": "VULGAR",

--- a/output/wordDisplayData#W-Z.json
+++ b/output/wordDisplayData#W-Z.json
@@ -3929,9 +3929,7 @@
     "variants": [
       "WAI WU PU\nWai Wu Pu. [Chinese wai foreign + wu affairs + pu office.]\n\nDefn: The Department of Foreign Affairs in the Chinese government.\n\nThe Tsung-li Yamen, or Foreign Office, created by a decree of January\n19, 1861, was in July, 1902, superseded by the formation of a new\nForeign Office called the Wai Wu Pu, . . . with precedence before all\nother boards.\nJ. Scott Keltie."
     ],
-    "references": [
-      "WAI WU PU"
-    ]
+    "references": []
   },
   {
     "spellings": "WAKE",
@@ -5306,9 +5304,7 @@
     "variants": [
       "WALLERIAN DEGENERATION\nWal*le\"ri*an de*gen`er*a\"tion. (Med.)\n\nDefn: A form of degeneration occurring in nerve fibers as a result of\ntheir division; -- so called from Dr. Waller, who published an\naccount of it in 1850."
     ],
-    "references": [
-      "WALLERIAN DEGENERATION"
-    ]
+    "references": []
   },
   {
     "spellings": "WALLET",
@@ -5471,9 +5467,7 @@
     "variants": [
       "WALL STREET\nWall Street.\n\nDefn: A street towards the southern end of the borough of Manhattan,\nNew York City, extending from Broadway to the East River; -- so\ncalled from the old wall which extended along it when the city\nbelonged to the Dutch. It is the chief financial center of the United\nStates, hence the name is often used for the money market and the\nfinancial interests of the country."
     ],
-    "references": [
-      "WALL STREET"
-    ]
+    "references": []
   },
   {
     "spellings": "WALLWORT",
@@ -8044,9 +8038,7 @@
     "variants": [
       "WARBURG'S TINCTURE\nWar\"burg's tinc\"ture. (Pharm.)\n\nDefn: A preparation containing quinine and many other ingredients,\noften used in the treatment of malarial affections. It was invented\nby Dr. Warburg of London.\n\n-WARD; -WARDS\n-ward, -wards. Etym: [AS. -weard, -weardes; akin to OS. & OFries. -\nward. OHG. -wert, G. -wärts, Icel. -verthr, Goth. -vaírÞs, L. vertere\nto turn, versus toward, and E. worth to become. *143. See Worth. v.\ni., and cf. Verse. Adverbs ending in -wards (AS. -weardes) and some\nother adverbs, such as besides, betimes, since (OE. sithens). etc.,\nwere originally genitive forms used adverbially.]\n\nDefn: Suffixes denoting course or direction to; motion or tendency\ntoward; as in backward, or backwards; toward, or towards, etc."
     ],
-    "references": [
-      "WARBURG'S TINCTURE"
-    ]
+    "references": []
   },
   {
     "spellings": "WARD",
@@ -8397,9 +8389,7 @@
     "variants": [
       "WAREGA FLY\nWa*re\"ga fly`.\n\nDefn: (Zoöl.) A Brazilian fly whose larvæ live in the skin of man and\nanimals, producing painful sores."
     ],
-    "references": [
-      "WAREGA FLY"
-    ]
+    "references": []
   },
   {
     "spellings": "WAREHOUSE",
@@ -9491,8 +9481,7 @@
       "WARP KNITTING\nWarp knitting.\n\nDefn: A kind of knitting in which a number of threads are\ninterchained each with one or more contiguous threads on either side."
     ],
     "references": [
-      "WARP",
-      "WARP KNITTING"
+      "WARP"
     ]
   },
   {
@@ -9833,8 +9822,7 @@
     ],
     "references": [
       "EMGALLA",
-      "PHACOCHERE",
-      "WART HOG"
+      "PHACOCHERE"
     ]
   },
   {
@@ -13836,9 +13824,7 @@
     "variants": [
       "WASH DRAWING\nWash drawing. (Art)\n\nDefn: In water-color painting, work in, or a work done chiefly in,\nwashes, as distinguished from that done in stipple, in body color,\netc."
     ],
-    "references": [
-      "WASH DRAWING"
-    ]
+    "references": []
   },
   {
     "spellings": "WASHED",
@@ -13906,9 +13892,7 @@
     "variants": [
       "WASHED SALE\nWashed sale.\n\nDefn: Same as Wash sale."
     ],
-    "references": [
-      "WASHED SALE"
-    ]
+    "references": []
   },
   {
     "spellings": "WASHEN",
@@ -14081,9 +14065,7 @@
     "variants": [
       "WASHOE PROCESS\nWash\"oe proc`ess. [From the Washoe district, Nevada.]\n\nDefn: The process of treating silver ores by grinding in pans or tubs\nwith the addition of mercury, and sometimes of chemicals such as blue\nvitriol and salt."
     ],
-    "references": [
-      "WASHOE PROCESS"
-    ]
+    "references": []
   },
   {
     "spellings": "WASH-OFF",
@@ -14114,8 +14096,7 @@
       "WASH SALE\nWash sale. (Stock Exchange)\n\nDefn: A sale made in washing. See Washing, n., 3, above."
     ],
     "references": [
-      "WASHED SALE",
-      "WASH SALE"
+      "WASHED SALE"
     ]
   },
   {
@@ -14130,9 +14111,7 @@
     "variants": [
       "WASH STAND\nWash stand.\n\nDefn: In a stable or garage, a place in the floor prepared so that\ncarriages or automobiles may be washed there and the water run off.\n[Cant]"
     ],
-    "references": [
-      "WASH STAND"
-    ]
+    "references": []
   },
   {
     "spellings": "WASHTUB",
@@ -15035,9 +15014,7 @@
     "variants": [
       "WATCH MEETING\nWatch meeting.\n\nDefn: A religious meeting held in the closing hours of the year."
     ],
-    "references": [
-      "WATCH MEETING"
-    ]
+    "references": []
   },
   {
     "spellings": "WATCHTOWER",
@@ -17237,7 +17214,6 @@
       "WATER ADDER\nWa\"ter ad\"der. (Zoöl.)\n(a) The water moccasin.\n(b) The common, harmless American water snake (Tropidonotus sipedon).\nSee Illust. under Water Snake."
     ],
     "references": [
-      "WATER ADDER",
       "WATER MOCCASIN"
     ]
   },
@@ -17254,8 +17230,7 @@
       "WATER AGRIMONY\nWa\"ter ag\"ri*mo*ny. (Bot.)\n\nDefn: A kind of bur marigold (Bidens tripartita) found in wet places\nin Europe."
     ],
     "references": [
-      "AGRIMONY",
-      "WATER AGRIMONY"
+      "AGRIMONY"
     ]
   },
   {
@@ -17263,9 +17238,7 @@
     "variants": [
       "WATER ALOE\nWa\"ter al\"oe. (Bot.)\n\nDefn: See Water soldier."
     ],
-    "references": [
-      "WATER ALOE"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER ANTELOPE",
@@ -17273,7 +17246,6 @@
       "WATER ANTELOPE\nWa\"ter an\"te*lope.\n\nDefn: See Water buck."
     ],
     "references": [
-      "WATER ANTELOPE",
       "WATER BUCK"
     ]
   },
@@ -17282,9 +17254,7 @@
     "variants": [
       "WATER ARUM\nWa\"ter a\"rum. (Bot.)\n\nDefn: An aroid herb (Calla palustris) having a white spathe. It is an\ninhabitant of the north temperate zone."
     ],
-    "references": [
-      "WATER ARUM"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER BACK",
@@ -17293,7 +17263,6 @@
     ],
     "references": [
       "BACK",
-      "WATER BACK",
       "WATER GAUGE"
     ]
   },
@@ -17302,45 +17271,35 @@
     "variants": [
       "WATER BAILIFF\nWa\"ter bail\"iff.\n\nDefn: An officer of the customs, whose duty it is to search vessels.\n[Eng.]"
     ],
-    "references": [
-      "WATER BAILIFF"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER BALLAST",
     "variants": [
       "WATER BALLAST\nWa\"ter bal\"last. (Naut.)\n\nDefn: Water confined in specially constructed compartments in a\nvessel's hold, to serve as ballast."
     ],
-    "references": [
-      "WATER BALLAST"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER BAROMETER",
     "variants": [
       "WATER BAROMETER\nWa\"ter ba*rom\"e*ter. (Physics)\n\nDefn: A barometer in which the changes of atmospheric pressure are\nindicated by the motion of a column of water instead of mercury. It\nrequires a column of water about thirty-three feet in height."
     ],
-    "references": [
-      "WATER BAROMETER"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER BATH",
     "variants": [
       "WATER BATH\nWa\"ter bath`.\n\nDefn: A device for regulating the temperature of anything subjected\nto heat, by surrounding the vessel containing it with another vessel\ncontaining water which can be kept at a desired temperature; also, a\nvessel designed for this purpose."
     ],
-    "references": [
-      "WATER BATH"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER BATTERY",
     "variants": [
       "WATER BATTERY\nWa\"ter bat\"ter*y.\n\n1. (Elec.)\n\nDefn: A voltaic battery in which the exciting fluid is water.\n\n2. (Mil.)\n\nDefn: A battery nearly on a level with the water."
     ],
-    "references": [
-      "WATER BATTERY"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER BEAR",
@@ -17348,8 +17307,7 @@
       "WATER BEAR\nWa\"ter bear`. (Zoöl.)\n\nDefn: Any species of Tardigrada, 2. See Illust. of Tardigrada."
     ],
     "references": [
-      "TARDIGRADA",
-      "WATER BEAR"
+      "TARDIGRADA"
     ]
   },
   {
@@ -17367,8 +17325,7 @@
       "WATER BED\nWa\"ter bed`.\n\nDefn: A kind of mattress made of, or covered with, waterproof fabric\nand filled with water. It is used in hospitals for bedridden\npatients."
     ],
     "references": [
-      "HYDROSTATIC; HYDROSTATICAL",
-      "WATER BED"
+      "HYDROSTATIC; HYDROSTATICAL"
     ]
   },
   {
@@ -17377,8 +17334,7 @@
       "WATER BEECH\nWa\"ter beech`. (Bot.)\n\nDefn: The American hornbeam. See Hornbeam."
     ],
     "references": [
-      "HORNBEAM",
-      "WATER BEECH"
+      "HORNBEAM"
     ]
   },
   {
@@ -17388,7 +17344,6 @@
     ],
     "references": [
       "REMIPED",
-      "WATER BEETLE",
       "WATER DEVIL",
       "WATER TIGER"
     ]
@@ -17398,9 +17353,7 @@
     "variants": [
       "WATER BELLOWS\nWa\"ter bel\"lows.\n\nDefn: Same as Tromp."
     ],
-    "references": [
-      "WATER BELLOWS"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER BIRD",
@@ -17412,7 +17365,6 @@
       "DARTER",
       "DEVIL-DIVER; DEVIL BIRD",
       "FETLOCK",
-      "WATER BIRD",
       "WEB"
     ]
   },
@@ -17421,9 +17373,7 @@
     "variants": [
       "WATER BLACKBIRD\nWa\"ter black\"*bird. (Zoöl.)\n\nDefn: The European water ousel, or dipper."
     ],
-    "references": [
-      "WATER BLACKBIRD"
-    ]
+    "references": []
   },
   {
     "spellings": "WATERBOARD",
@@ -17437,9 +17387,7 @@
     "variants": [
       "WATER BOATMAN\nWa\"ter boat`man. (Zoöl.)\n\nDefn: A boat bug."
     ],
-    "references": [
-      "WATER BOATMAN"
-    ]
+    "references": []
   },
   {
     "spellings": "WATERBOK",
@@ -17463,8 +17411,7 @@
       "WATER BRAIN\nWa\"ter brain`.\n\nDefn: A disease of sheep; gid."
     ],
     "references": [
-      "COENURUS",
-      "WATER BRAIN"
+      "COENURUS"
     ]
   },
   {
@@ -17475,7 +17422,6 @@
     "references": [
       "BRASH",
       "PYROSIS",
-      "WATER BRASH",
       "WATER QUALM"
     ]
   },
@@ -17484,18 +17430,14 @@
     "variants": [
       "WATER BREATHER\nWa\"ter breath\"er. (Zoöl.)\n\nDefn: Any arthropod that breathes by means of gills."
     ],
-    "references": [
-      "WATER BREATHER"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER BRIDGE",
     "variants": [
       "WATER BRIDGE\nWa\"ter bridge`. (Steam Boilers)\n\nDefn: See Water table."
     ],
-    "references": [
-      "WATER BRIDGE"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER BUCK",
@@ -17508,8 +17450,7 @@
       "LECHE",
       "ORDINARY",
       "WATER ANTELOPE",
-      "WATERBOK",
-      "WATER BUCK"
+      "WATERBOK"
     ]
   },
   {
@@ -17518,8 +17459,7 @@
       "WATER BUFFALO\nWa\"ter buf\"fa*lo. (Zoöl.)\n\nDefn: The European buffalo."
     ],
     "references": [
-      "CARABAO",
-      "WATER BUFFALO"
+      "CARABAO"
     ]
   },
   {
@@ -17528,8 +17468,7 @@
       "WATER BUG\nWa\"ter bug`. (Zoöl.)\n(a) The Croton bug.\n(b) Any one of numerous species of large, rapacious, aquatic,\nhemipterous insects belonging to Belostoma, Benacus, Zaitha, and\nother genera of the family Belostomatidæ. Their hind legs are long\nand fringed, and act like oars. Some of these insects are of great\nsize, being among the largest existing Hemiptera. Many of them come\nout of the water and fly about at night."
     ],
     "references": [
-      "CROTON BUG",
-      "WATER BUG"
+      "CROTON BUG"
     ]
   },
   {
@@ -17537,9 +17476,7 @@
     "variants": [
       "WATER BUTT\nWa\"ter butt`.\n\nDefn: A large, open-headed cask, set up on end, to contain water.\nDickens."
     ],
-    "references": [
-      "WATER BUTT"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER CALTROP",
@@ -17547,7 +17484,6 @@
       "WATER CALTROP\nWa\"ter cal\"trop. (Bot.)\n\nDefn: The water chestnut."
     ],
     "references": [
-      "WATER CALTROP",
       "WATER CHESTNUT"
     ]
   },
@@ -17558,7 +17494,6 @@
     ],
     "references": [
       "MUD",
-      "WATER CAN",
       "WATER CANKER"
     ]
   },
@@ -17567,18 +17502,14 @@
     "variants": [
       "WATER CANKER\nWa\"ter can\"ker. (Med.)\n\nDefn: See Canker, n., 1."
     ],
-    "references": [
-      "WATER CANKER"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER CARRIAGE",
     "variants": [
       "WATER CARRIAGE\nWa\"ter car\"riage.\n\n1. Transportation or conveyance by water; means of transporting by\nwater.\n\n2. A vessel or boat. [Obs.] Arbuthnot."
     ],
-    "references": [
-      "WATER CARRIAGE"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER CART",
@@ -17586,8 +17517,7 @@
       "WATER CART\nWa\"ter cart`.\n\nDefn: A cart carrying water; esp., one carrying water for sale, or\nfor sprinkling streets, gardens, etc."
     ],
     "references": [
-      "CRANE",
-      "WATER CART"
+      "CRANE"
     ]
   },
   {
@@ -17596,8 +17526,7 @@
       "WATER CAVY\nWa\"ter ca\"vy. (Zoöl.)\n\nDefn: The capybara."
     ],
     "references": [
-      "CAVY",
-      "WATER CAVY"
+      "CAVY"
     ]
   },
   {
@@ -17605,27 +17534,21 @@
     "variants": [
       "WATER CELERY\nWa\"ter cel\"er*y. (Bot.)\n\nDefn: A very acrid herb (Ranunculus sceleratus) growing in ditches\nand wet places; -- called also cursed crowfoot."
     ],
-    "references": [
-      "WATER CELERY"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER CELL",
     "variants": [
       "WATER CELL\nWa\"ter cell`.\n\nDefn: A cell containing water; specifically (Zoöl.), one of the cells\nor chambers in which water is stored up in the stomach of a camel."
     ],
-    "references": [
-      "WATER CELL"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER CEMENT",
     "variants": [
       "WATER CEMENT\nWa\"ter ce*ment\".\n\nDefn: Hydraulic cement."
     ],
-    "references": [
-      "WATER CEMENT"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER CHESTNUT",
@@ -17635,8 +17558,7 @@
     "references": [
       "JESUIT",
       "SALIGOT",
-      "WATER CALTROP",
-      "WATER CHESTNUT"
+      "WATER CALTROP"
     ]
   },
   {
@@ -17645,7 +17567,6 @@
       "WATER CHEVROTAIN\nWa\"ter chev`ro*tain\". (Zoöl.)\n\nDefn: A large West African chevrotain (Hyæmoschus aquaticus). It has\na larger body and shorter legs than the other allied species. Called\nalso water deerlet."
     ],
     "references": [
-      "WATER CHEVROTAIN",
       "WATER DEER",
       "WATER DEERLET"
     ]
@@ -17655,27 +17576,21 @@
     "variants": [
       "WATER CHICKEN\nWa\"ter chick\"en. (Zoöl.)\n\nDefn: The common American gallinule."
     ],
-    "references": [
-      "WATER CHICKEN"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER CHICKWEED",
     "variants": [
       "WATER CHICKWEED\nWa\"ter chick\"weed`. (Bot.)\n\nDefn: A small annual plant (Montia fontana) growing in wet places in\nsouthern regions."
     ],
-    "references": [
-      "WATER CHICKWEED"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER CHINQUAPIN",
     "variants": [
       "WATER CHINQUAPIN\nWa\"ter chin\"qua*pin. (Bot.)\n\nDefn: The American lotus, and its edible seeds, which somewhat\nresemble chinquapins. Cf. Yoncopin."
     ],
-    "references": [
-      "WATER CHINQUAPIN"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER CLOCK",
@@ -17684,8 +17599,7 @@
     ],
     "references": [
       "CLEPSYDRA",
-      "HYDROSCOPE",
-      "WATER CLOCK"
+      "HYDROSCOPE"
     ]
   },
   {
@@ -17704,9 +17618,7 @@
     "variants": [
       "WATER COCK\nWa\"ter cock`. (Zoöl.)\n\nDefn: A large gallinule (Gallicrex cristatus) native of Australia,\nIndia, and the East Indies. In the breeding season the male is black\nand has a fleshy red caruncle, or horn, on the top of its head.\nCalled also kora."
     ],
-    "references": [
-      "WATER COCK"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER COLOR",
@@ -17726,7 +17638,6 @@
       "TORCHON PAPER",
       "UMBER",
       "WASH",
-      "WATER COLOR",
       "WATER-COLORIST"
     ]
   },
@@ -17763,7 +17674,6 @@
       "ROCK",
       "SHIP",
       "SHOOT",
-      "WATER COURSE",
       "WATER WAY"
     ]
   },
@@ -17788,7 +17698,6 @@
     "references": [
       "BOAT",
       "LAND",
-      "WATER CRAFT",
       "WATERMAN"
     ]
   },
@@ -17797,9 +17706,7 @@
     "variants": [
       "WATER CRAKE\nWa\"ter crake`. (Zoöl.)\n(a) The dipper.\n(b) The spotted crake (Porzana maruetta). See Illust. of Crake.\n(c) The swamp hen, or crake, of Australia."
     ],
-    "references": [
-      "WATER CRAKE"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER CRANE",
@@ -17807,8 +17714,7 @@
       "WATER CRANE\nWa\"ter crane`.\n\nDefn: A goose-neck apparatus for supplying water from an elevated\ntank, as to the tender of a locomotive."
     ],
     "references": [
-      "CRANE",
-      "WATER CRANE"
+      "CRANE"
     ]
   },
   {
@@ -17819,7 +17725,6 @@
     "references": [
       "CRESS",
       "SALAD",
-      "WATER CRESS",
       "WATER GRASS",
       "WATER RADISH"
     ]
@@ -17830,7 +17735,6 @@
       "WATER CROW\nWa\"ter crow`. Etym: [So called in allusion to its dark plumage.]\n(Zoöl.)\n(a) The dipper.\n(b) The European coot."
     ],
     "references": [
-      "WATER CROW",
       "WATER CROWFOOT"
     ]
   },
@@ -17839,9 +17743,7 @@
     "variants": [
       "WATER CROWFOOT\nWa\"ter crow\"foot`. (Bot.)\n\nDefn: An aquatic kind of buttercup (Ranunculus aquatilis), used as\nfood for cattle in parts of England. Great water crowfoot, an\nAmerican water plant (Ranunculus multifidus), having deep yellow\nflowers."
     ],
-    "references": [
-      "WATER CROWFOOT"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER CURE",
@@ -17850,8 +17752,7 @@
     ],
     "references": [
       "CURE",
-      "HYDROPATHY",
-      "WATER CURE"
+      "HYDROPATHY"
     ]
   },
   {
@@ -17859,9 +17760,7 @@
     "variants": [
       "WATER DECK\nWa\"ter deck`.\n\nDefn: A covering of painting canvas for the equipments of a dragoon's\nhorse. Wilhelm."
     ],
-    "references": [
-      "WATER DECK"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER DEER",
@@ -17870,7 +17769,6 @@
     ],
     "references": [
       "WATER CHEVROTAIN",
-      "WATER DEER",
       "WATER DEERLET"
     ]
   },
@@ -17880,8 +17778,7 @@
       "WATER DEERLET\nWa\"ter deer\"let.\n\nDefn: See Water chevrotain."
     ],
     "references": [
-      "WATER CHEVROTAIN",
-      "WATER DEERLET"
+      "WATER CHEVROTAIN"
     ]
   },
   {
@@ -17889,27 +17786,21 @@
     "variants": [
       "WATER DEVIL\nWa\"ter dev\"il. (Zoöl.)\n\nDefn: The rapacious larva of a large water beetle (Hydrophilus\npiceus), and of other similar species. See Illust. of Water beetle."
     ],
-    "references": [
-      "WATER DEVIL"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER DOCK",
     "variants": [
       "WATER DOCK\nWa\"ter dock`. (Bot.)\n\nDefn: A tall, coarse dock growing in wet places. The American water\ndock is Rumex orbiculatus, the European is R. Hydrolapathum."
     ],
-    "references": [
-      "WATER DOCK"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER DOCTOR",
     "variants": [
       "WATER DOCTOR\nWa\"ter doc\"tor. (Med.)\n(a) One who professes to be able to divine diseases by inspection of\nthe urine.\n(b) A physician who treats diseases with water; an hydropathist."
     ],
-    "references": [
-      "WATER DOCTOR"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER DOG",
@@ -17917,8 +17808,7 @@
       "WATER DOG\nWa\"ter dog`.\n\n1. (Zoöl.)\n\nDefn: A dog accustomed to the water, or trained to retrieve\nwaterfowl. Retrievers, waters spaniels, and Newfoundland dogs are so\ntrained.\n\n2. (Zoöl.)\n\nDefn: The menobranchus.\n\n3. A small floating cloud, supposed to indicate rain.\n\n4. A sailor, esp. an old sailor; an old salt. [Colloq.]"
     ],
     "references": [
-      "HELLBENDER",
-      "WATER DOG"
+      "HELLBENDER"
     ]
   },
   {
@@ -17928,7 +17818,6 @@
     ],
     "references": [
       "WATER",
-      "WATER DRAIN",
       "WATER DRAINAGE"
     ]
   },
@@ -17938,8 +17827,7 @@
       "WATER DRAINAGE\nWa\"ter drain\"age (; 48).\n\nDefn: The draining off of water."
     ],
     "references": [
-      "WATER",
-      "WATER DRAINAGE"
+      "WATER"
     ]
   },
   {
@@ -17947,45 +17835,35 @@
     "variants": [
       "WATER DRESSING\nWa\"ter dress\"ing. (Med.)\n\nDefn: The treatment of wounds or ulcers by the application of water;\nalso, a dressing saturated with water only, for application to a\nwound or an ulcer."
     ],
-    "references": [
-      "WATER DRESSING"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER DROPWORT",
     "variants": [
       "WATER DROPWORT\nWa\"ter drop\"wort`. (Bot.)\n\nDefn: A European poisonous umbelliferous plant (Enanthe fistulosa)\nwith large hollow stems and finely divided leaves."
     ],
-    "references": [
-      "WATER DROPWORT"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER EAGLE",
     "variants": [
       "WATER EAGLE\nWa\"ter ea\"gle. (Zoöl.)\n\nDefn: The osprey."
     ],
-    "references": [
-      "WATER EAGLE"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER ELDER",
     "variants": [
       "WATER ELDER\nWa\"ter el\"der. (Bot.)\n\nDefn: The guelder-rose."
     ],
-    "references": [
-      "WATER ELDER"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER ELEPHANT",
     "variants": [
       "WATER ELEPHANT\nWa\"ter el\"e*phant. (Zoöl.)\n\nDefn: The hippopotamus. [R.]"
     ],
-    "references": [
-      "WATER ELEPHANT"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER ENGINE",
@@ -17993,7 +17871,6 @@
       "WATER ENGINE\nWa\"ter en\"gine.\n\nDefn: An engine to raise water; or an engine moved by water; also, an\nengine or machine for extinguishing fires; a fire engine."
     ],
     "references": [
-      "WATER ENGINE",
       "WATER MOTOR"
     ]
   },
@@ -18028,36 +17905,28 @@
     "variants": [
       "WATER FEATHER; WATER FEATHER-FOIL\nWa\"ter feath\"er or Wa\"ter feath\"er-foil`. (Bot.)\n\nDefn: The water violet (Hottonia palustris); also, the less showy\nAmerican plant H. inflata."
     ],
-    "references": [
-      "WATER FEATHER; WATER FEATHER-FOIL"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER FLAG",
     "variants": [
       "WATER FLAG\nWa\"ter flag`. (Bot.)\n\nDefn: A European species of Iris (Iris Pseudacorus) having bright\nyellow flowers."
     ],
-    "references": [
-      "WATER FLAG"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER FLANNEL",
     "variants": [
       "WATER FLANNEL\nWa\"ter flan\"nel. (Bot.)\n\nDefn: A floating mass formed in pools by the entangled filaments of a\nEuropean fresh-water alga (Cladophora crispata)."
     ],
-    "references": [
-      "WATER FLANNEL"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER FLEA",
     "variants": [
       "WATER FLEA\nWa\"ter flea`. (Zoöl.)\n\nDefn: Any one of numerous species of small aquatic Entomostraca\nbelonging to the genera Cyclops, Daphnia, etc; -- so called because\nthey swim with sudden leaps, or starts."
     ],
-    "references": [
-      "WATER FLEA"
-    ]
+    "references": []
   },
   {
     "spellings": "WATERFLOOD",
@@ -18073,7 +17942,6 @@
     ],
     "references": [
       "POLE",
-      "WATER FLOUNDER",
       "WINDOWPANE"
     ]
   },
@@ -18092,9 +17960,7 @@
     "variants": [
       "WATER FOX\nWa\"ter fox`. (Zoöl.)\n\nDefn: The carp; -- so called on account of its cunning. Walton."
     ],
-    "references": [
-      "WATER FOX"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER FRAME",
@@ -18102,7 +17968,6 @@
       "WATER FRAME\nWa\"ter frame`.\n\nDefn: A name given to the first power spinning machine, because\ndriven by water power."
     ],
     "references": [
-      "WATER FRAME",
       "WATER TU TWIST"
     ]
   },
@@ -18112,7 +17977,6 @@
       "WATER FURROW\nWa\"ter fur\"row. (Agric.)\n\nDefn: A deep furrow for conducting water from the ground, and keeping\nthe surface soil dry."
     ],
     "references": [
-      "WATER FURROW",
       "WATER-FURROW"
     ]
   },
@@ -18129,7 +17993,6 @@
       "WATER GAGE\nWa\"ter gage`.\n\nDefn: See Water gauge."
     ],
     "references": [
-      "WATER GAGE",
       "WATER GAUGE"
     ]
   },
@@ -18139,7 +18002,6 @@
       "WATER GALL\nWa\"ter gall`.\n\n1. A cavity made in the earth by a torrent of water; a washout.\n\n2. A watery appearance in the sky, accompanying the rainbow; a\nsecondary or broken rainbow.\nThese water galls, in her dim element, Foretell new storms to those\nalready spent. Shak.\nFalse good news are [is] always produced by true good, like the water\ngall by the rainbow. Walpole."
     ],
     "references": [
-      "WATER GALL",
       "WEATHER"
     ]
   },
@@ -18148,9 +18010,7 @@
     "variants": [
       "WATER GANG\nWa\"ter gang`. (O. E. Law)\n\nDefn: A passage for water, such as was usually made in a sea wall, to\ndrain water out of marshes. Burrill."
     ],
-    "references": [
-      "WATER GANG"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER GAS",
@@ -18163,8 +18023,7 @@
       "GAS",
       "GASOLINE",
       "HYDROGEN",
-      "RIVER",
-      "WATER GAS"
+      "RIVER"
     ]
   },
   {
@@ -18172,9 +18031,7 @@
     "variants": [
       "WATER GATE\nWa\"ter gate`.\n\nDefn: A gate, or valve, by which a flow of water is permitted,\nprevented, or regulated."
     ],
-    "references": [
-      "WATER GATE"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER GAUGE",
@@ -18186,8 +18043,7 @@
       "INDICATOR",
       "STEAM",
       "WATER",
-      "WATER GAGE",
-      "WATER GAUGE"
+      "WATER GAGE"
     ]
   },
   {
@@ -18195,9 +18051,7 @@
     "variants": [
       "WATER GAVEL\nWa\"ter gav\"el. (O. Eng. Law)\n\nDefn: A gavel or rent paid for a privilege, as of fishing, in some\nriver or water."
     ],
-    "references": [
-      "WATER GAVEL"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER GERMANDER",
@@ -18205,8 +18059,7 @@
       "WATER GERMANDER\nWa\"ter ger*man\"der. (Bot.)\n\nDefn: A labiate plant (Teucrium Scordium) found in marshy places in\nEurope."
     ],
     "references": [
-      "GERMANDER",
-      "WATER GERMANDER"
+      "GERMANDER"
     ]
   },
   {
@@ -18215,8 +18068,7 @@
       "WATER GILDING\nWa\"ter gild\"ing.\n\nDefn: The act, or the process, of gilding metallic surfaces by\ncovering them with a thin coating of amalgam of gold, and then\nvolatilizing the mercury by heat; -- called also wash gilding."
     ],
     "references": [
-      "WASH",
-      "WATER GILDING"
+      "WASH"
     ]
   },
   {
@@ -18226,8 +18078,7 @@
     ],
     "references": [
       "GLASS",
-      "SOAP",
-      "WATER GLASS"
+      "SOAP"
     ]
   },
   {
@@ -18235,9 +18086,7 @@
     "variants": [
       "WATER GOD\nWa\"ter god`. (Myth.)\n\nDefn: A fabulous deity supposed to dwell in, and preside over, some\nbody of water."
     ],
-    "references": [
-      "WATER GOD"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER GRASS",
@@ -18246,8 +18095,7 @@
     ],
     "references": [
       "INDIAN",
-      "RICE",
-      "WATER GRASS"
+      "RICE"
     ]
   },
   {
@@ -18255,18 +18103,14 @@
     "variants": [
       "WATER GRUEL\nWa\"ter gru\"el.\n\nDefn: A liquid food composed of water and a small portion of meal, or\nother farinaceous substance, boiled and seasoned."
     ],
-    "references": [
-      "WATER GRUEL"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER HAMMER",
     "variants": [
       "WATER HAMMER\nWa\"ter ham\"mer. (Physics)\n\n1. A vessel partly filled with water, exhausted of air, and\nhermetically sealed. When reversed or shaken, the water being\nunimpeded by air, strikes the sides in solid mass with a sound like\nthat of a hammer.\n\n2. A concussion, or blow, made by water in striking, as against the\nsides of a pipe or vessel containing it."
     ],
-    "references": [
-      "WATER HAMMER"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER HARE",
@@ -18274,7 +18118,6 @@
       "WATER HARE\nWa\"ter hare. (Zoöl.)\n\nDefn: A small American hare or rabbit (Lepus aquaticus) found on or\nnear the southern coasts of the United States; -- called also water\nrabbit, and swamp hare."
     ],
     "references": [
-      "WATER HARE",
       "WATER RABBIT"
     ]
   },
@@ -18287,8 +18130,7 @@
       "CICUTOXIN",
       "COWBANE",
       "HEMLOCK",
-      "MUSQUASH",
-      "WATER HEMLOCK"
+      "MUSQUASH"
     ]
   },
   {
@@ -18297,8 +18139,7 @@
       "WATER HEMP\nWa\"ter hemp`. (Bot.)\n\nDefn: See under Hemp."
     ],
     "references": [
-      "HEMP",
-      "WATER HEMP"
+      "HEMP"
     ]
   },
   {
@@ -18307,8 +18148,7 @@
       "WATER HEN\nWa\"ter hen`.\n\n1. (Zoöl.)\n\nDefn: Any gallinule.\n\n2. (Zoöl.)\n\nDefn: The common American coot."
     ],
     "references": [
-      "GALLINULE",
-      "WATER HEN"
+      "GALLINULE"
     ]
   },
   {
@@ -18319,8 +18159,7 @@
     "references": [
       "BUSH",
       "CAPYBARA",
-      "HOG",
-      "WATER HOG"
+      "HOG"
     ]
   },
   {
@@ -18329,8 +18168,7 @@
       "WATER HOREHOUND\nWa\"ter hore\"hound`. (Bot.)\n\nDefn: Bugleweed."
     ],
     "references": [
-      "HOREHOUND",
-      "WATER HOREHOUND"
+      "HOREHOUND"
     ]
   },
   {
@@ -18345,9 +18183,7 @@
     "variants": [
       "WATER HYACINTH\nWa\"ter hy\"a*cinth. (Bot.)\n\nDefn: Either of several tropical aquatic plants of the genus\nEichhornia, related to the pickerel weed."
     ],
-    "references": [
-      "WATER HYACINTH"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER ICE",
@@ -18358,8 +18194,7 @@
       "FRAPPE",
       "ICE",
       "NEAPOLITAN ICE; NEAPOLITAN ICE CREAM",
-      "SHERBET",
-      "WATER ICE"
+      "SHERBET"
     ]
   },
   {
@@ -18375,8 +18210,7 @@
       "WATER INCH\nWa\"ter inch`.\n\nDefn: Same as Inch of water, under Water."
     ],
     "references": [
-      "WATER",
-      "WATER INCH"
+      "WATER"
     ]
   },
   {
@@ -18432,8 +18266,7 @@
       "WATER JACKET\nWa\"ter jac\"ket.\n\nDefn: A chamber surrounding a vessel or tube in which water may be\ncirculated, thereby regulating the temperature or supply of heat to\nthe vessel. Used in laboratory and manufacturing equipment. water-\njacketed. Having a water jacket; -- as, a water-jacketed condenser."
     ],
     "references": [
-      "INTERNAL-COMBUSTION; INTERNAL-COMBUSTION ENGINE",
-      "WATER JACKET"
+      "INTERNAL-COMBUSTION; INTERNAL-COMBUSTION ENGINE"
     ]
   },
   {
@@ -18441,18 +18274,14 @@
     "variants": [
       "WATER JOINT\nWa\"ter joint`. (Arch.)\n\nDefn: A joint in a stone pavement where the stones are left slightly\nhigher than elsewhere, the rest of the surface being sunken or\ndished. The raised surface is intended to prevent the settling of\nwater in the joints."
     ],
-    "references": [
-      "WATER JOINT"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER JUNKET",
     "variants": [
       "WATER JUNKET\nWa\"ter jun\"ket. (Zoöl.)\n\nDefn: The common sandpiper."
     ],
-    "references": [
-      "WATER JUNKET"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER-LAID",
@@ -18475,9 +18304,7 @@
     "variants": [
       "WATER LAVEROCK\nWa\"ter la\"ver*ock. (Zoöl.)\n\nDefn: The common sandpiper."
     ],
-    "references": [
-      "WATER LAVEROCK"
-    ]
+    "references": []
   },
   {
     "spellings": "WATERLEAF",
@@ -18492,8 +18319,7 @@
       "WATER LEG\nWa\"ter leg`. (Steam Boilers)\n\nDefn: See Leg, 7."
     ],
     "references": [
-      "LEG",
-      "WATER LEG"
+      "LEG"
     ]
   },
   {
@@ -18501,9 +18327,7 @@
     "variants": [
       "WATER LEMON\nWa\"ter lem\"on. (Bot.)\n\nDefn: The edible fruit of two species of passion flower (Passiflora\nlaurifolia, and P. maliformis); -- so called in the West Indies."
     ],
-    "references": [
-      "WATER LEMON"
-    ]
+    "references": []
   },
   {
     "spellings": "WATERLESS",
@@ -18517,9 +18341,7 @@
     "variants": [
       "WATER LETTUCE\nWa\"ter let\"tuce. (Bot.)\n\nDefn: A plant (Pistia stratiotes) which floats on tropical waters,\nand forms a rosette of spongy, wedge-shaped leaves. J. Smith (Dict.\nEcon. Plants)."
     ],
-    "references": [
-      "WATER LETTUCE"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER LEVEL",
@@ -18531,8 +18353,7 @@
       "CAISSON",
       "GAUGE",
       "LEVEL",
-      "STEAM",
-      "WATER LEVEL"
+      "STEAM"
     ]
   },
   {
@@ -18555,7 +18376,6 @@
       "POND",
       "SACRED",
       "SPATTER-DOCK",
-      "WATER LILY",
       "WATER NYMPH"
     ]
   },
@@ -18564,9 +18384,7 @@
     "variants": [
       "WATER LIME\nWa\"ter lime`.\n\nDefn: Hydraulic lime."
     ],
-    "references": [
-      "WATER LIME"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER LINE",
@@ -18591,7 +18409,6 @@
       "SONDERCLASS",
       "STRAKE",
       "TORPEDO TUBE",
-      "WATER LINE",
       "WATERMARK"
     ]
   },
@@ -18600,9 +18417,7 @@
     "variants": [
       "WATER LIZARD\nWa\"ter liz\"ard. (Zoöl.)\n\nDefn: Any aquatic lizard of the genus Varanus, as the monitor of the\nNile. See Monitor, n., 3."
     ],
-    "references": [
-      "WATER LIZARD"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER LOCUST",
@@ -18610,8 +18425,7 @@
       "WATER LOCUST\nWa\"ter lo\"cust. (Bot.)\n\nDefn: A thorny leguminous tree (Gleditschia monosperma) which grows\nin the swamps of the Mississippi valley."
     ],
     "references": [
-      "LOCUST TREE",
-      "WATER LOCUST"
+      "LOCUST TREE"
     ]
   },
   {
@@ -18656,9 +18470,7 @@
     "variants": [
       "WATER MEADOW\nWa\"ter mead\"ow. (Agric.)\n\nDefn: A meadow, or piece of low, flat land, capable of being kept in\na state of fertility by being overflowed with water from some\nadjoining river or stream."
     ],
-    "references": [
-      "WATER MEADOW"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER MEASURE",
@@ -18667,7 +18479,6 @@
     ],
     "references": [
       "METER",
-      "WATER MEASURE",
       "WATER MEASURER"
     ]
   },
@@ -18676,9 +18487,7 @@
     "variants": [
       "WATER MEASURER\nWa\"ter meas\"ur*er. (Zoöl.)\n\nDefn: Any one of numerous species of water; the skater. See Skater,\nn., 2."
     ],
-    "references": [
-      "WATER MEASURER"
-    ]
+    "references": []
   },
   {
     "spellings": "WATERMELON",
@@ -18696,9 +18505,7 @@
     "variants": [
       "WATER METER\nWa\"ter me\"ter.\n\nDefn: A contrivance for measuring a supply of water delivered or\nreceived for any purpose, as from a street main."
     ],
-    "references": [
-      "WATER METER"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER MILFOIL",
@@ -18706,8 +18513,7 @@
       "WATER MILFOIL\nWa\"ter mil\"foil. (Bot.)\n\nDefn: Any plant of the genus Myriophyllum, aquatic herbs with whorled\nleaves, the submersed ones pinnately parted into capillary divisions."
     ],
     "references": [
-      "MILFOIL",
-      "WATER MILFOIL"
+      "MILFOIL"
     ]
   },
   {
@@ -18716,7 +18522,6 @@
       "WATER MILL\nWa\"ter mill`.\n\nDefn: A mill whose machinery is moved by water; -- distinguished from\na windmill, and a steam mill."
     ],
     "references": [
-      "WATER MILL",
       "WATER POWER"
     ]
   },
@@ -18727,8 +18532,7 @@
     ],
     "references": [
       "BROOK MINT",
-      "MINT",
-      "WATER MINT"
+      "MINT"
     ]
   },
   {
@@ -18737,7 +18541,6 @@
       "WATER MITE\nWa\"ter mite`. (Zoöl.)\n\nDefn: Any of numerous species of aquatic mites belonging to Hydrachna\nand allied genera of the family Hydrachnidæ, usually having the legs\nfringed and adapted for swimming. They are often red or red and black\nin color, and while young are parasites of fresh-water insects and\nmussels. Called also water tick, and water spider."
     ],
     "references": [
-      "WATER MITE",
       "WATER SPIDER",
       "WATER TICK"
     ]
@@ -18749,7 +18552,6 @@
     ],
     "references": [
       "WATER ADDER",
-      "WATER MOCCASIN",
       "WATER VIPER"
     ]
   },
@@ -18760,8 +18562,7 @@
     ],
     "references": [
       "DUCK",
-      "MOLE",
-      "WATER MOLE"
+      "MOLE"
     ]
   },
   {
@@ -18769,45 +18570,35 @@
     "variants": [
       "WATER MONITOR\nWa\"ter mon\"i*tor. (Zoöl.)\n\nDefn: A very large lizard (Varanaus salvator) native of India. It\nfrequents the borders of streams and swims actively. It becomes five\nor six feet long. Called also two-banded monitor, and kabaragoya. The\nname is also applied to other aquatic monitors."
     ],
-    "references": [
-      "WATER MONITOR"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER MONKEY",
     "variants": [
       "WATER MONKEY\nWater monkey.\n\nDefn: A jar or bottle, as of porous earthenware, in which water is\ncooled by evaporation."
     ],
-    "references": [
-      "WATER MONKEY"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER MOTOR",
     "variants": [
       "WATER MOTOR\nWa\"ter mo\"tor.\n\n1. A water engine.\n\n2. A water wheel; especially, a small water wheel driven by water\nfrom a street main."
     ],
-    "references": [
-      "WATER MOTOR"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER MOUSE",
     "variants": [
       "WATER MOUSE\nWa\"ter mouse`. (Zoöl.)\n\nDefn: Any one of several species of mice belonging to the genus\nHydromys, native of Australia and Tasmania. Their hind legs are\nstrong and their toes partially webbed. They live on the borders of\nstreams, and swim well. They are remarkable as being the only rodents\nfound in Australia."
     ],
-    "references": [
-      "WATER MOUSE"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER MURRAIN",
     "variants": [
       "WATER MURRAIN\nWa\"ter mur\"rain.\n\nDefn: A kind of murrain affecting cattle. Crabb."
     ],
-    "references": [
-      "WATER MURRAIN"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER NEWT",
@@ -18816,8 +18607,7 @@
     ],
     "references": [
       "ASK",
-      "ASKER",
-      "WATER NEWT"
+      "ASKER"
     ]
   },
   {
@@ -18827,8 +18617,7 @@
     ],
     "references": [
       "HYDRIAD",
-      "NAIAD",
-      "WATER NYMPH"
+      "NAIAD"
     ]
   },
   {
@@ -18837,8 +18626,7 @@
       "WATER OAT\nWa\"ter oat`.\n\nDefn: Indian rice. See under Rice."
     ],
     "references": [
-      "RICE",
-      "WATER OAT"
+      "RICE"
     ]
   },
   {
@@ -18847,7 +18635,6 @@
       "WATER OPOSSUM\nWa\"ter o*pos\"sum. (Zoöl.)\n\nDefn: See Yapock, and the Note under Opossum."
     ],
     "references": [
-      "WATER OPOSSUM",
       "YAPOCK"
     ]
   },
@@ -18857,8 +18644,7 @@
       "WATER ORDEAL\nWa\"ter or\"de*al.\n\nDefn: Same as Ordeal by water. See the Note under Ordeal, n., 1."
     ],
     "references": [
-      "PURGATION",
-      "WATER ORDEAL"
+      "PURGATION"
     ]
   },
   {
@@ -18870,7 +18656,6 @@
       "DIPPER",
       "OUSEL",
       "WATER BLACKBIRD",
-      "WATER OUSEL; WATER OUZEL",
       "WATER PIET",
       "WATER THRUSH"
     ]
@@ -18881,8 +18666,7 @@
       "WATER PARSNIP\nWa\"ter pars\"nip. (Bot.)\n\nDefn: Any plant of the aquatic umbelliferous genus Sium, poisonous\nherbs with pinnate or dissected leaves and small white flowers."
     ],
     "references": [
-      "PARSNIP",
-      "WATER PARSNIP"
+      "PARSNIP"
     ]
   },
   {
@@ -18890,18 +18674,14 @@
     "variants": [
       "WATER PARTING\nWater parting. (Phys. Geog.)\n\nDefn: A summit from the opposite sides of which rain waters flow to\ndifferent streams; a line separating the drainage districts of two\nstreams or coasts; a divide."
     ],
-    "references": [
-      "WATER PARTING"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER PARTRIDGE",
     "variants": [
       "WATER PARTRIDGE\nWa\"ter par\"tridge. (Zoöl.)\n\nDefn: The ruddy duck. [Local, U. S.]"
     ],
-    "references": [
-      "WATER PARTRIDGE"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER PENNYWORT",
@@ -18909,8 +18689,7 @@
       "WATER PENNYWORT\nWa\"ter pen\"ny*wort`. (Bot.)\n\nDefn: Marsh pennywort. See under Marsh."
     ],
     "references": [
-      "MARSH",
-      "WATER PENNYWORT"
+      "MARSH"
     ]
   },
   {
@@ -18921,8 +18700,7 @@
     "references": [
       "ARSESMART",
       "HYDROPIPER",
-      "LAKEWEED",
-      "WATER PEPPER"
+      "LAKEWEED"
     ]
   },
   {
@@ -18931,8 +18709,7 @@
       "WATER PHEASANT\nWa\"ter pheas\"ant. (Zoöl.)\n(a) The pintail. See Pintail, n., 1.\n(b) The goosander.\n(c) The hooded merganser."
     ],
     "references": [
-      "PHEASANT",
-      "WATER PHEASANT"
+      "PHEASANT"
     ]
   },
   {
@@ -18940,27 +18717,21 @@
     "variants": [
       "WATER PIET\nWa\"ter pi\"et. (Zoöl.)\n\nDefn: The water ousel."
     ],
-    "references": [
-      "WATER PIET"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER PIG",
     "variants": [
       "WATER PIG\nWa\"ter pig`.\n\n1. (Zoöl.)\n\nDefn: The capybara.\n\n2. (Zoöl.)\n\nDefn: The gourami."
     ],
-    "references": [
-      "WATER PIG"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER PILLAR",
     "variants": [
       "WATER PILLAR\nWa\"ter pil\"lar.\n\nDefn: A waterspout. [Obs.]"
     ],
-    "references": [
-      "WATER PILLAR"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER PIMPERNEL",
@@ -18969,8 +18740,7 @@
     ],
     "references": [
       "BROOKWEED",
-      "PIMPERNEL",
-      "WATER PIMPERNEL"
+      "PIMPERNEL"
     ]
   },
   {
@@ -18985,8 +18755,7 @@
       "FERRO-CONCRETE",
       "PALMETTO",
       "PET",
-      "TRAP",
-      "WATER PIPE"
+      "TRAP"
     ]
   },
   {
@@ -18994,9 +18763,7 @@
     "variants": [
       "WATER PITCHER\nWa\"ter pitch\"er.\n\n1. A pitcher for water.\n\n2. (Bot.)\n\nDefn: One of a family of plants having pitcher-shaped leaves. The\nsidesaddle flower (Sarracenia purpurea) is the type."
     ],
-    "references": [
-      "WATER PITCHER"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER PLANT",
@@ -19009,7 +18776,6 @@
       "PLANTAIN",
       "WASHERWOMAN",
       "WATER CROWFOOT",
-      "WATER PLANT",
       "WATER PLANTAIN",
       "WATER SPIDER"
     ]
@@ -19020,8 +18786,7 @@
       "WATER PLANTAIN\nWa\"ter plan\"tain. (Bot.)\n\nDefn: A kind of plant with acrid leaves. See under 2d Plantain."
     ],
     "references": [
-      "PLANTAIN",
-      "WATER PLANTAIN"
+      "PLANTAIN"
     ]
   },
   {
@@ -19029,27 +18794,21 @@
     "variants": [
       "WATER PLATE\nWa\"ter plate`.\n\nDefn: A plate heated by hot water contained in a double bottom or\njacket. Knight."
     ],
-    "references": [
-      "WATER PLATE"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER POA",
     "variants": [
       "WATER POA\nWa\"ter po\"a. (Bot.)\n\nDefn: Meadow reed grass. See under Reed."
     ],
-    "references": [
-      "WATER POA"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER POCKET",
     "variants": [
       "WATER POCKET\nWater pocket.\n\nDefn: A water hole in the bed of an intermittent stream, esp. the\nbowl at the foot of a cliff over which the stream leaps when in the\nflood stage. [Western U. S.]"
     ],
-    "references": [
-      "WATER POCKET"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER POISE",
@@ -19057,8 +18816,7 @@
       "WATER POISE\nWa\"ter poise`.\n\nDefn: A hydrometer."
     ],
     "references": [
-      "LEVEL",
-      "WATER POISE"
+      "LEVEL"
     ]
   },
   {
@@ -19066,9 +18824,7 @@
     "variants": [
       "WATER PORE\nWa\"ter pore`\n\n1. (Zoöl.)\n\nDefn: A pore by which the water tubes of various invertebrates open\nexternally.\n\n2. (Bot.)\n\nDefn: One of certain minute pores in the leaves of some plants. They\nare without true guardian cells, but in other respects closely\nresemble ordinary stomata. Goodale."
     ],
-    "references": [
-      "WATER PORE"
-    ]
+    "references": []
   },
   {
     "spellings": "WATERPOT",
@@ -19087,8 +18843,7 @@
     "references": [
       "HYDRODYNAMIC; HYDRODYNAMICAL",
       "POWER",
-      "WATER FRAME",
-      "WATER POWER"
+      "WATER FRAME"
     ]
   },
   {
@@ -19097,8 +18852,7 @@
       "WATER POX\nWa\"ter pox`. (Med.)\n\nDefn: A variety of chicken pox, or varicella. Dunglison."
     ],
     "references": [
-      "SWINE-POX",
-      "WATER POX"
+      "SWINE-POX"
     ]
   },
   {
@@ -19108,8 +18862,7 @@
     ],
     "references": [
       "PRIVILEGE",
-      "WATER POWER",
-      "WATER PRIVILEGE"
+      "WATER POWER"
     ]
   },
   {
@@ -19158,8 +18911,7 @@
     ],
     "references": [
       "PEPLIS",
-      "PURSLANE",
-      "WATER PURSLANE"
+      "PURSLANE"
     ]
   },
   {
@@ -19167,27 +18919,21 @@
     "variants": [
       "WATER QUALM\nWa\"ter qualm`. (Med.)\n\nDefn: See Water brash, under Brash."
     ],
-    "references": [
-      "WATER QUALM"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER RABBIT",
     "variants": [
       "WATER RABBIT\nWa\"ter rab\"bit. (Zoöl.)\n\nDefn: See Water hare."
     ],
-    "references": [
-      "WATER RABBIT"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER RADISH",
     "variants": [
       "WATER RADISH\nWa\"ter rad\"ish. (Bot.)\n\nDefn: A coarse yellow-flowered plant (Nasturtium amphibium) related\nto the water cress and to the horse-radish."
     ],
-    "references": [
-      "WATER RADISH"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER RAIL",
@@ -19201,8 +18947,7 @@
       "RAIL",
       "SKILTY",
       "SKITTY",
-      "VELVET",
-      "WATER RAIL"
+      "VELVET"
     ]
   },
   {
@@ -19210,9 +18955,7 @@
     "variants": [
       "WATER RAM\nWa\"ter ram`.\n\nDefn: An hydraulic ram."
     ],
-    "references": [
-      "WATER RAM"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER RAT",
@@ -19222,7 +18965,6 @@
     "references": [
       "CRABER",
       "VOLE",
-      "WATER RAT",
       "WATER RATE",
       "WATER RATTLE; WATER RATTLER"
     ]
@@ -19232,18 +18974,14 @@
     "variants": [
       "WATER RATE\nWa\"ter rate`.\n\nDefn: A rate or tax for a supply of water."
     ],
-    "references": [
-      "WATER RATE"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER RATTLE; WATER RATTLER",
     "variants": [
       "WATER RATTLE; WATER RATTLER\nWa\"ter rat\"tle or Wa\"ter rat\"tler. (Zoöl.)\n\nDefn: The diamond rattlesnake (Crotalus adamanteus); -- so called\nfrom its preference for damp places near water."
     ],
-    "references": [
-      "WATER RATTLE; WATER RATTLER"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER-RET",
@@ -19259,18 +18997,14 @@
     "variants": [
       "WATER RICE\nWa\"ter rice\".\n\nDefn: Indian rice. See under Rice."
     ],
-    "references": [
-      "WATER RICE"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER ROCKET",
     "variants": [
       "WATER ROCKET\nWa\"ter rock\"et.\n\n1. (Bot.)\n\nDefn: A cruciferous plant (Nasturtium sylvestre) with small yellow\nflowers.\n\n2. A kind of firework to be discharged in the water."
     ],
-    "references": [
-      "WATER ROCKET"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER-ROT",
@@ -19288,8 +19022,7 @@
     ],
     "references": [
       "FRESH-WATER",
-      "SALT",
-      "WATER SAIL"
+      "SALT"
     ]
   },
   {
@@ -19297,9 +19030,7 @@
     "variants": [
       "WATER SAPPHIRE\nWa\"ter sap\"phire. Etym: [Equiv. to F. saphir d'eau.] (Min.)\n\nDefn: A deep blue variety of iolite, sometimes used as a gem; --\ncalled also saphir d'eau."
     ],
-    "references": [
-      "WATER SAPPHIRE"
-    ]
+    "references": []
   },
   {
     "spellings": "WATERSCAPE",
@@ -19315,8 +19046,7 @@
     ],
     "references": [
       "NEPA",
-      "SCORPION",
-      "WATER SCORPION"
+      "SCORPION"
     ]
   },
   {
@@ -19324,9 +19054,7 @@
     "variants": [
       "WATER SCREW\nWa\"ter screw`.\n\nDefn: A screw propeller."
     ],
-    "references": [
-      "WATER SCREW"
-    ]
+    "references": []
   },
   {
     "spellings": "WATERSHED",
@@ -19343,9 +19071,7 @@
     "variants": [
       "WATER SHIELD\nWa\"ter shield`. (Bot.)\n\nDefn: An aquatic American plant (Brasenia peltata) having floating\noval leaves, and the covered with a clear jelly."
     ],
-    "references": [
-      "WATER SHIELD"
-    ]
+    "references": []
   },
   {
     "spellings": "WATERSHOOT",
@@ -19361,8 +19087,7 @@
     ],
     "references": [
       "OARED",
-      "SHREW",
-      "WATER SHREW"
+      "SHREW"
     ]
   },
   {
@@ -19370,9 +19095,7 @@
     "variants": [
       "WATER SNAIL\nWa\"ter snail`.\n\n1. (Zoöl.)\n\nDefn: Any aquatic pulmonate gastropod belonging to Planorbis, Limnæa,\nand allied genera; a pond snail.\n\n2. (Mech.)\n\nDefn: The Archimedean screw. [R.]"
     ],
-    "references": [
-      "WATER SNAIL"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER SNAKE",
@@ -19382,8 +19105,7 @@
     "references": [
       "ADDER",
       "SNAKE",
-      "WATER ADDER",
-      "WATER SNAKE"
+      "WATER ADDER"
     ]
   },
   {
@@ -19400,8 +19122,7 @@
     ],
     "references": [
       "FRESH-WATER",
-      "WATER ALOE",
-      "WATER SOLDIER"
+      "WATER ALOE"
     ]
   },
   {
@@ -19409,36 +19130,28 @@
     "variants": [
       "WATER SOUCHY\nWa\"ter souch`y. (Cookery)\n\nDefn: A dish consisting of small fish stewed and served in a little\nwater. [Written also water souchet.] See Zoutch."
     ],
-    "references": [
-      "WATER SOUCHY"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER SPANIEL",
     "variants": [
       "WATER SPANIEL\nWa\"ter span\"iel.\n\nDefn: A curly-haired breed of spaniels, naturally very fond of the\nwater."
     ],
-    "references": [
-      "WATER SPANIEL"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER SPARROW",
     "variants": [
       "WATER SPARROW\nWa\"ter spar\"row. (Zoöl.)\n(a) The reed warbler. [Prov. Eng.]\n(b) The reed bunting. [Prov. Eng.]"
     ],
-    "references": [
-      "WATER SPARROW"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER SPEEDWELL",
     "variants": [
       "WATER SPEEDWELL\nWa\"ter speed\"well. (Bot.)\n\nDefn: A kind of speedwell (Veronica Anagallis) found in wet places in\nEurope and America."
     ],
-    "references": [
-      "WATER SPEEDWELL"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER SPIDER",
@@ -19448,7 +19161,6 @@
     "references": [
       "TIPULA",
       "WATER MITE",
-      "WATER SPIDER",
       "WATER SPINNER"
     ]
   },
@@ -19458,8 +19170,7 @@
       "WATER SPINNER\nWa\"ter spin`ner. (Zoöl.)\n\nDefn: The water spider."
     ],
     "references": [
-      "TIPULA",
-      "WATER SPINNER"
+      "TIPULA"
     ]
   },
   {
@@ -19479,9 +19190,7 @@
     "variants": [
       "WATER SPRITE\nWa\"ter sprite`.\n\nDefn: A sprite, or spirit, imagined as inhabiting the water. J. R.\nDrake."
     ],
-    "references": [
-      "WATER SPRITE"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER-STANDING",
@@ -19496,8 +19205,7 @@
       "WATER STAR GRASS\nWa\"ter star\" grass`. (Bot.)\n\nDefn: An aquatic plant (Schollera graminea) with grassy leaves, and\nyellow star-shaped blossoms."
     ],
     "references": [
-      "STAR",
-      "WATER STAR GRASS"
+      "STAR"
     ]
   },
   {
@@ -19506,8 +19214,7 @@
       "WATER STARWORT\nWa\"ter star\"wort`.\n\nDefn: See under Starwort."
     ],
     "references": [
-      "STARWORT",
-      "WATER STARWORT"
+      "STARWORT"
     ]
   },
   {
@@ -19515,18 +19222,14 @@
     "variants": [
       "WATER SUPPLY\nWa\"ter sup*ply\".\n\nDefn: A supply of water; specifically, water collected, as in\nreservoirs, and conveyed, as by pipes, for use in a city, mill, or\nthe like."
     ],
-    "references": [
-      "WATER SUPPLY"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER TABBY",
     "variants": [
       "WATER TABBY\nWa\"ter tab\"by.\n\nDefn: A kind of waved or watered tabby. See Tabby, n., 1."
     ],
-    "references": [
-      "WATER TABBY"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER TABLE",
@@ -19534,8 +19237,7 @@
       "WATER TABLE\nWa\"ter ta\"ble. (Arch.)\n\nDefn: A molding, or other projection, in the wall of a building, to\nthrow off the water, -- generally used in the United States for the\nfirst table above the surface of the ground (see Table, n., 9), that\nis, for the table at the top of the foundation and the beginning of\nthe upper wall."
     ],
     "references": [
-      "WATER BRIDGE",
-      "WATER TABLE"
+      "WATER BRIDGE"
     ]
   },
   {
@@ -19550,36 +19252,28 @@
     "variants": [
       "WATER TELESCOPE\nWater telescope.\n\n1. (Optics) A telescope in which the medium between the objective and\nthe eye piece is water instead of air, used in some experiments in\naberration.\n\n2.  A telescope devised for looking into a body of water."
     ],
-    "references": [
-      "WATER TELESCOPE"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER TENDER",
     "variants": [
       "WATER TENDER\nWater tender. (Nav.)\n\nDefn: In the United States navy, a first-class petty officer in\ncharge in a fireroom. He \"tends\" water to the boilers, sees that\nfires are properly cleaned and stoked, etc. There is also a rating of\nchief water tender, who is a chief petty officer."
     ],
-    "references": [
-      "WATER TENDER"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER THERMOMETER",
     "variants": [
       "WATER THERMOMETER\nWa\"ter ther*mom\"e*ter. (Physics)\n\nDefn: A thermometer filled with water instead of mercury, for\nascertaining the precise temperature at which water attains its\nmaximum density. This is about 39º Fahr., or 4º Centigrade; and from\nthat point down to 32º Fahr., or 0º Centigrade, or the freezing\npoint, it expands."
     ],
-    "references": [
-      "WATER THERMOMETER"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER THIEF",
     "variants": [
       "WATER THIEF\nWa\"ter thief`.\n\nDefn: A pirate. [R.] Shak."
     ],
-    "references": [
-      "WATER THIEF"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER THRUSH",
@@ -19590,8 +19284,7 @@
       "ACCENTOR",
       "KICKUP",
       "THRUSH",
-      "WAGTAIL",
-      "WATER THRUSH"
+      "WAGTAIL"
     ]
   },
   {
@@ -19600,8 +19293,7 @@
       "WATER THYME\nWa\"ter thyme`. (Bot.)\n\nDefn: See Anacharis."
     ],
     "references": [
-      "ANACHARIS",
-      "WATER THYME"
+      "ANACHARIS"
     ]
   },
   {
@@ -19610,8 +19302,7 @@
       "WATER TICK\nWa\"ter tick`.\n\nDefn: Same as Water mite."
     ],
     "references": [
-      "WATER MITE",
-      "WATER TICK"
+      "WATER MITE"
     ]
   },
   {
@@ -19620,8 +19311,7 @@
       "WATER TIGER\nWa\"ter ti\"ger. (Zoöl.)\n\nDefn: A diving, or water, beetle, especially the larva of a water\nbeetle. See Illust. b of Water beetle."
     ],
     "references": [
-      "DIVING",
-      "WATER TIGER"
+      "DIVING"
     ]
   },
   {
@@ -19645,36 +19335,28 @@
     "variants": [
       "WATER TORCH\nWa\"ter torch`. (Bot.)\n\nDefn: The common cat-tail (Typha latifolia), the spike of which makes\na good torch soaked in oil. Dr. Prior."
     ],
-    "references": [
-      "WATER TORCH"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER TOWER",
     "variants": [
       "WATER TOWER\nWa\"ter tow\"er.\n\nDefn: A large metal pipe made to be extended vertically by sections,\nand used for discharging water upon burning buildings."
     ],
-    "references": [
-      "WATER TOWER"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER TREE",
     "variants": [
       "WATER TREE\nWa\"ter tree`. (Bot.)\n\nDefn: A climbing shrub (Tetracera alnifolia, or potatoria) of Western\nAfrica, which pours out a watery sap from the freshly cut stems."
     ],
-    "references": [
-      "WATER TREE"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER TREFOIL",
     "variants": [
       "WATER TREFOIL\nWa\"ter tre\"foil`. (Bot.)\n\nDefn: The buck bean."
     ],
-    "references": [
-      "WATER TREFOIL"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER TUBE",
@@ -19687,8 +19369,7 @@
       "RING",
       "SAND",
       "TUBE",
-      "WATER PORE",
-      "WATER TUBE"
+      "WATER PORE"
     ]
   },
   {
@@ -19696,9 +19377,7 @@
     "variants": [
       "WATER TUPELO\nWa\"ter tu\"pe*lo. (Bot.)\n\nDefn: A species of large tupelo (Nyssa aquatica) growing in swamps in\nthe southern of the United States. See Ogeechee lime."
     ],
-    "references": [
-      "WATER TUPELO"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER TURKEY",
@@ -19706,8 +19385,7 @@
       "WATER TURKEY\nWa\"ter tur\"key. (Zoöl.)\n\nDefn: The American snakebird. See Snakebird."
     ],
     "references": [
-      "SNAKEBIRD",
-      "WATER TURKEY"
+      "SNAKEBIRD"
     ]
   },
   {
@@ -19715,27 +19393,21 @@
     "variants": [
       "WATER TU TUYERE\nWa\"ter tu tu`yère\".\n\nDefn: A tuyère kept cool by water circulating within a casing. It is\nused for hot blast."
     ],
-    "references": [
-      "WATER TU TUYERE"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER TU TWIST",
     "variants": [
       "WATER TU TWIST\nWa\"ter tu twist`.\n\nDefn: Yarn made by the throstle, or water frame."
     ],
-    "references": [
-      "WATER TU TWIST"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER VINE",
     "variants": [
       "WATER VINE\nWa\"ter vine`. (Bot.)\n\nDefn: Any plant of the genus Phytocrene, climbing shrubs of Asia and\nAfrica, the stems of which are singularly porous, and when cut stream\nwith a limpid potable juice."
     ],
-    "references": [
-      "WATER VINE"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER VIOLET",
@@ -19746,8 +19418,7 @@
       "GILLYFLOWER",
       "PRIMULACEOUS",
       "VIOLET",
-      "WATER FEATHER; WATER FEATHER-FOIL",
-      "WATER VIOLET"
+      "WATER FEATHER; WATER FEATHER-FOIL"
     ]
   },
   {
@@ -19756,8 +19427,7 @@
       "WATER VIPER\nWa\"ter vi\"per. (Zoöl.)\n\nDefn: See Water moccasin."
     ],
     "references": [
-      "WATER MOCCASIN",
-      "WATER VIPER"
+      "WATER MOCCASIN"
     ]
   },
   {
@@ -19767,8 +19437,7 @@
     ],
     "references": [
       "VOLE",
-      "WATER RAT",
-      "WATER VOLE"
+      "WATER RAT"
     ]
   },
   {
@@ -19777,8 +19446,7 @@
       "WATER WAGTAIL\nWa\"ter wag\"tail`.\n\nDefn: See under Wagtail."
     ],
     "references": [
-      "WAGTAIL",
-      "WATER WAGTAIL"
+      "WAGTAIL"
     ]
   },
   {
@@ -19798,8 +19466,7 @@
     ],
     "references": [
       "DOCK",
-      "FLASH",
-      "WATER WAY"
+      "FLASH"
     ]
   },
   {
@@ -19848,7 +19515,6 @@
       "TURBINE",
       "UNDERSHOT",
       "WATER MOTOR",
-      "WATER WHEEL",
       "WHEEL",
       "WICKET",
       "WREST"
@@ -19866,27 +19532,21 @@
     "variants": [
       "WATER WILLOW\nWa\"ter wil`low. (Bot.)\n\nDefn: An American aquatic plant (Dianthera Americana) with long\nwillowlike leaves, and spikes of small purplish flowers."
     ],
-    "references": [
-      "WATER WILLOW"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER WING",
     "variants": [
       "WATER WING\nWa\"ter wing`. (Arch.)\n\nDefn: One of two walls built on either side of the junction of a\nbridge with the bank of a river, to protect the abutment of the\nbridge and the bank from the action of the current."
     ],
-    "references": [
-      "WATER WING"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER WITCH",
     "variants": [
       "WATER WITCH\nWa\"ter witch`. (Zoöl.)\n(a) The dabchick.\n(b) The stormy petrel. [Prov. Eng.]"
     ],
-    "references": [
-      "WATER WITCH"
-    ]
+    "references": []
   },
   {
     "spellings": "WATER-WITHE",
@@ -20036,9 +19696,7 @@
     "variants": [
       "WATTEAU BACK\nWatteau back.\n\nDefn: The back of a woman's gown in which one or more very broad\nfolds are carried from the neck to the floor without being held in at\nthe waist, while the front and sides of the gown are shaped to the\nperson and have a belt or its equivalent."
     ],
-    "references": [
-      "WATTEAU BACK"
-    ]
+    "references": []
   },
   {
     "spellings": "WATTLE",
@@ -22109,8 +21767,7 @@
       "WAY SHAFT\nWay\" shaft`.\n\n1. (Mach.)\n\nDefn: A rock shaft.\n\n2. (Mining)\n\nDefn: An interior shaft, usually one connecting two levels. Raymond."
     ],
     "references": [
-      "ROCK SHAFT",
-      "WAY SHAFT"
+      "ROCK SHAFT"
     ]
   },
   {
@@ -25501,9 +25158,7 @@
     "variants": [
       "WEATHER MAP\nWeath\"er map.\n\nDefn: A map or chart showing the principal meteorological elements at\na given hour and over an extended region. Such maps usually show the\nheight of the barometer, the temperature of the air, the relative\nhumidity, the state of the weather, and the direction and velocity of\nthe wind. Isobars and isotherms outline the general distribution of\ntemperature and pressure, while shaded areas indicate the sections\nover which rain has just fallen. Other lines inclose areas where the\ntemperature has fallen or risen markedly. In tabular form are shown\nchanges of pressure and of temperature, maximum and minimum\ntemperatures, and total rain for each weather station since the last\nissue, usually 12 hours."
     ],
-    "references": [
-      "WEATHER MAP"
-    ]
+    "references": []
   },
   {
     "spellings": "WEATHERMOST",
@@ -25524,9 +25179,7 @@
     "variants": [
       "WEATHER SIGNAL\nWeather signal.\n\nDefn: Any signal giving information about the weather. The system\nused by the United States Weather Bureau includes temperature, cold\nor hot wave, rain or snow, wind direction, storm, and hurricane\nsignals."
     ],
-    "references": [
-      "WEATHER SIGNAL"
-    ]
+    "references": []
   },
   {
     "spellings": "WEATHER STATION",
@@ -25534,8 +25187,7 @@
       "WEATHER STATION\nWeather station. (Meteor.)\n\nDefn: A station for taking meteorological observations, making\nweather forecasts, or disseminating such information. Such stations\nare of the first order when they make observations of all the\nimportant elements either hourly or by self-registering instruments;\nof the second order when only important observations are taken; of\nthe third order when simpler work is done, as to record rainfall and\nmaximum and minimum temperatures."
     ],
     "references": [
-      "WEATHER MAP",
-      "WEATHER STATION"
+      "WEATHER MAP"
     ]
   },
   {
@@ -26247,18 +25899,14 @@
     "variants": [
       "WEDGE GAUGE; WEDGE GAGE\nWedge gauge or gage .\n\nDefn: A wedge with a graduated edge, to measure the width of a space\ninto which it is thrust."
     ],
-    "references": [
-      "WEDGE GAUGE; WEDGE GAGE"
-    ]
+    "references": []
   },
   {
     "spellings": "WEDGE GEAR",
     "variants": [
       "WEDGE GEAR\nWedge gear.\n\nDefn: A friction gear wheel with wedge-shaped circumferential\ngrooves. -- Wedge gearing."
     ],
-    "references": [
-      "WEDGE GEAR"
-    ]
+    "references": []
   },
   {
     "spellings": "WEDGE-SHAPED",
@@ -26316,8 +25964,7 @@
       "WEDGWOOD WARE\nWedg\"wood` ware`. Etym: [From the name of the inventor, Josiah\nWedgwood, of England.]\n\nDefn: A kind of fine pottery, the most remarkable being what is\ncalled jasper, either white, or colored throughout the body, and\ncapable of being molded into the most delicate forms, so that fine\nand minute bas-reliefs like cameos were made of it, fit even for\nbeing set as jewels."
     ],
     "references": [
-      "SYDEROLITE",
-      "WEDGWOOD WARE"
+      "SYDEROLITE"
     ]
   },
   {
@@ -26909,9 +26556,7 @@
     "variants": [
       "WEEPING TREE\nWeep\"ing tree.\n (a) Any tree having pendulous branches.\n (b) A tree from which honeydew or other liquid secretions of insects\ndrip in considerable quantities, esp. one infested by the larvæ of\nany species of the genus Ptylus, allied to the cuckoo spits, which in\ntropical countries secrete large quantities of a watery fluid."
     ],
-    "references": [
-      "WEEPING TREE"
-    ]
+    "references": []
   },
   {
     "spellings": "WEERISH",
@@ -27997,9 +27642,7 @@
     "variants": [
       "WEIL'S DISEASE\nWeil's disease. (Med.)\n\nDefn: An acute infectious febrile disease, resembling typhoid fever,\nwith muscular pains, disturbance of the digestive organs, jaundice,\netc."
     ],
-    "references": [
-      "WEIL'S DISEASE"
-    ]
+    "references": []
   },
   {
     "spellings": "WEIR; WEAR",
@@ -28207,9 +27850,7 @@
     "variants": [
       "WEISS BEER\nWeiss beer. [G. weissbier white beer.]\n\nDefn: A light-colored highly effervescent beer made by the top-\nfermentation process."
     ],
-    "references": [
-      "WEISS BEER"
-    ]
+    "references": []
   },
   {
     "spellings": "WEIVE",
@@ -28431,18 +28072,14 @@
     "variants": [
       "WELDON'S PROCESS\nWel\"don's proc\"ess, (Chem.)\n\nDefn: A process for the recovery or regeneration of manganese dioxide\nin the manufacture of chlorine, by means of milk of lime and the\noxygen of the air; -- so called after the inventor."
     ],
-    "references": [
-      "WELDON'S PROCESS"
-    ]
+    "references": []
   },
   {
     "spellings": "WELD STEEL",
     "variants": [
       "WELD STEEL\nWeld steel.\n\nDefn: A compound of iron, such as puddled steel, made without\ncomplete fusion."
     ],
-    "references": [
-      "WELD STEEL"
-    ]
+    "references": []
   },
   {
     "spellings": "WELE",
@@ -29599,9 +29236,7 @@
     "variants": [
       "WELLINGTON BOOT\nWel\"ling*ton boot. [After the Duke of Wellington.]\n\nDefn: A riding boot for men, the front of which came above the knee;\nalso, a similar shorter boot worn under the trousers."
     ],
-    "references": [
-      "WELLINGTON BOOT"
-    ]
+    "references": []
   },
   {
     "spellings": "WELLINGTONIA",
@@ -30091,9 +29726,7 @@
     "variants": [
       "WENLOCK GROUP\nWen\"lock group`, (Geol.)\n\nDefn: The middle subdivision of the Upper Silurian in Great Britain;\n-- so named from the typical locality in Shropshire."
     ],
-    "references": [
-      "WENLOCK GROUP"
-    ]
+    "references": []
   },
   {
     "spellings": "WENNEL",
@@ -33166,7 +32799,6 @@
       "VANILLA",
       "VEGETABLE",
       "VICISSY DUCK",
-      "WEST INDIA; WEST INDIAN",
       "WEST INDIAN",
       "YACCA",
       "YELLOW",
@@ -33287,7 +32919,6 @@
       "VEGETABLE",
       "VICISSY DUCK",
       "WEST INDIA; WEST INDIAN",
-      "WEST INDIAN",
       "YACCA",
       "YELLOW",
       "YELTING",
@@ -33318,8 +32949,7 @@
     ],
     "references": [
       "ASSEMBLY",
-      "CONFESSION",
-      "WESTMINSTER ASSEMBLY"
+      "CONFESSION"
     ]
   },
   {
@@ -33593,9 +33223,7 @@
     "variants": [
       "WET-BULB THERMOMETER\nWet-bulb thermometer. (Physics)\n\nDefn: That one of the two similar thermometers of a psychrometer the\nbulb of which is moistened; also, the entire instrument."
     ],
-    "references": [
-      "WET-BULB THERMOMETER"
-    ]
+    "references": []
   },
   {
     "spellings": "WETHER",
@@ -33638,8 +33266,7 @@
     ],
     "references": [
       "DRY NURSE",
-      "NURSE",
-      "WET NURSE"
+      "NURSE"
     ]
   },
   {
@@ -33647,9 +33274,7 @@
     "variants": [
       "WET PLATE\nWet plate. (Photog.)\n\nDefn: A plate the film of which retains its sensitiveness only while\nwet. The film used in such plates is of collodion impregnated with\nbromides and iodides. Before exposure the plate is immersed in a\nsolution of silver nitrate, and immediately after exposure it is\ndeveloped and fixed."
     ],
-    "references": [
-      "WET PLATE"
-    ]
+    "references": []
   },
   {
     "spellings": "WET-SHOD",
@@ -36057,27 +35682,21 @@
     "variants": [
       "WHEAT RUST\nWheat rust.\n\nDefn: A disease of wheat and other grasses caused by the rust fungus\nPuccinia graminis; also, the fungus itself."
     ],
-    "references": [
-      "WHEAT RUST"
-    ]
+    "references": []
   },
   {
     "spellings": "WHEAT SAWFLY",
     "variants": [
       "WHEAT SAWFLY\nWheat sawfly.\n (a) A small European sawfly (Cephus pygmæus) whose larva does great\ninjury to wheat by boring in the stalks.\n (b) Any of several small American sawflies of the genus Dolerus, as\nD. sericeus and D. arvensis, whose larvæ injure the stems or heads of\nwheat.\n (c) Pachynematus extensicornis, whose larvæ feed chiefly on the\nblades of wheat; -- called also grass sawfly."
     ],
-    "references": [
-      "WHEAT SAWFLY"
-    ]
+    "references": []
   },
   {
     "spellings": "WHEATSEL BIRD",
     "variants": [
       "WHEATSEL BIRD\nWheat\"sel bird`. (Zoöl.)\n\nDefn: The male of the chaffinch. [Prov. Eng.]"
     ],
-    "references": [
-      "WHEATSEL BIRD"
-    ]
+    "references": []
   },
   {
     "spellings": "WHEATSTONE'S BRIDGE",
@@ -36085,8 +35704,7 @@
       "WHEATSTONE'S BRIDGE\nWheat\"stone's bridge`. (Elec.)\n\nDefn: See under Bridge."
     ],
     "references": [
-      "BRIDGE",
-      "WHEATSTONE'S BRIDGE"
+      "BRIDGE"
     ]
   },
   {
@@ -36094,9 +35712,7 @@
     "variants": [
       "WHEATSTONE'S RODS\nWheat\"stone's rods. (Acoustics)\n\nDefn: Flexible rods the period of vibration of which in two planes at\nright angles are in some exact ratio to one another. When one end of\nsuch a rod is fixed, the free end describes in vibrating the\ncorresponding Lissajous figure. So called because devised by Sir\nCharles Wheatstone."
     ],
-    "references": [
-      "WHEATSTONE'S RODS"
-    ]
+    "references": []
   },
   {
     "spellings": "WHEATWORM",
@@ -36602,9 +36218,7 @@
     "variants": [
       "WHEEL BASE\nWheel base.\n\nDefn: The figure inclosed by lines through the points contact of the\nwheels of a vehicle, etc., with the surface or rails on which they\nrun; more esp., the length of this figure between the points of\ncontact of the two extreme wheels on either side."
     ],
-    "references": [
-      "WHEEL BASE"
-    ]
+    "references": []
   },
   {
     "spellings": "WHEELBIRD",
@@ -36683,9 +36297,7 @@
     "variants": [
       "WHEEL OF FORTUNE\nWheel of fortune.\n\nDefn: A gambling or lottery device consisting of a wheel which is\nspun horizontally, articles or sums to which certain marks on its\ncircumference point when it stops being distributed according to\nvarying rules."
     ],
-    "references": [
-      "WHEEL OF FORTUNE"
-    ]
+    "references": []
   },
   {
     "spellings": "WHEEL-SHAPED",
@@ -42739,8 +42351,7 @@
       "WHEY CURE\nWhey cure.\n\nDefn: Treatment with whey as a drink and in baths."
     ],
     "references": [
-      "SEROTHERAPY",
-      "WHEY CURE"
+      "SEROTHERAPY"
     ]
   },
   {
@@ -47802,7 +47413,6 @@
     "references": [
       "PARADISE",
       "VIDA FINCH",
-      "WHIDAH BIRD",
       "WHYDAH BIRD; WHYDAH FINCH"
     ]
   },
@@ -49753,9 +49363,7 @@
     "variants": [
       "WHISKY RING; WHISKEY RING\nWhisky, or Whiskey, Ring . (U. S. Hist.)\n\nDefn: A conspiracy of distillers and government officials during the\nadministration of President Grant to defraud the government of the\nexcise taxes. The frauds were detected in 1875 through the efforts of\nthe Secretary of the Treasury. B. H. Bristow, and most of the\noffenders were convicted."
     ],
-    "references": [
-      "WHISKY RING; WHISKEY RING"
-    ]
+    "references": []
   },
   {
     "spellings": "WHISP",
@@ -51730,8 +51338,7 @@
       "WHITE ELEPHANT\nWhite elephant.\n\nDefn: Something requiring much care and expense and yielding little\nprofit; any burdensome possession. [Slang]"
     ],
     "references": [
-      "WHITE",
-      "WHITE ELEPHANT"
+      "WHITE"
     ]
   },
   {
@@ -51786,9 +51393,7 @@
     "variants": [
       "WHITE FLY\nWhite fly.\n\nDefn: Any one of numerous small injurious hemipterous insects of the\ngenus Aleyrodes, allied to scale insects. They are usually covered\nwith a white or gray powder."
     ],
-    "references": [
-      "WHITE FLY"
-    ]
+    "references": []
   },
   {
     "spellings": "WHITE-FOOT",
@@ -51805,8 +51410,7 @@
     "references": [
       "ALSATIAN",
       "CARMELITE",
-      "FRIAR",
-      "WHITE FRIAR"
+      "FRIAR"
     ]
   },
   {
@@ -51839,8 +51443,7 @@
       "PANACEAN",
       "SENTIMENTAL",
       "SERVO-MOTOR",
-      "TERSE",
-      "WHITEHEAD TORPEDO; WHITEHEAD"
+      "TERSE"
     ]
   },
   {
@@ -51859,8 +51462,7 @@
     ],
     "references": [
       "LEAD",
-      "WHITE",
-      "WHITE HORSE"
+      "WHITE"
     ]
   },
   {
@@ -51882,9 +51484,7 @@
     "variants": [
       "WHITE LIST\nWhite list.\n (a) A list of business concerns regarded as worthy of patronage by\nreason of compliance with certain conditions, as in regard to\ntreatment of employees; as, the white list of the Consumers' League.\n[Cant]\n (b) (New York Stock Exchange) The official list of all transactions,\npublished daily on white paper, divided into sales from 10 to 12, 12\nto 2, and 2 to 3."
     ],
-    "references": [
-      "WHITE LIST"
-    ]
+    "references": []
   },
   {
     "spellings": "WHITE-LIVERED",
@@ -51912,8 +51512,7 @@
     ],
     "references": [
       "MUSTARD",
-      "SINALBIN",
-      "WHITE MUSTARD"
+      "SINALBIN"
     ]
   },
   {
@@ -52013,8 +51612,7 @@
       "OCTOROON",
       "PALEFACE",
       "QUADROON",
-      "QUINTROON",
-      "WHITE PERSON"
+      "QUINTROON"
     ]
   },
   {
@@ -52022,9 +51620,7 @@
     "variants": [
       "WHITE PLAGUE\nWhite plague.\n\nDefn: Tuberculosis, esp. of the lungs."
     ],
-    "references": [
-      "WHITE PLAGUE"
-    ]
+    "references": []
   },
   {
     "spellings": "WHITE-POT",
@@ -52076,7 +51672,6 @@
       "WHITE SLAVE\nWhite slave.\n\nDefn: A woman held in involuntary confinement for purposes of\nprostitution; loosely, any woman forced into unwilling prostitution."
     ],
     "references": [
-      "WHITE SLAVE",
       "WHITE SLAVER"
     ]
   },
@@ -52085,18 +51680,14 @@
     "variants": [
       "WHITE SLAVER\nWhite slaver.\n\nDefn: A person engaged in procuring or holding a woman or women for\nunwilling prostitution."
     ],
-    "references": [
-      "WHITE SLAVER"
-    ]
+    "references": []
   },
   {
     "spellings": "WHITE SLAVING",
     "variants": [
       "WHITE SLAVING\nWhite slaving.\n\nDefn: The action of one who procures or holds a woman or women for\nunwilling prostitution."
     ],
-    "references": [
-      "WHITE SLAVING"
-    ]
+    "references": []
   },
   {
     "spellings": "WHITESMITH",
@@ -52560,9 +52151,7 @@
     "variants": [
       "WHITTEN TREE\nWhit\"ten tree`. Etym: [Probably from white; cf. AS. hwitingtreów.]\n(Bot.)\n\nDefn: Either of two shrubs (Viburnum Lantana, and V. Opulus), so\ncalled on account of their whitish branches."
     ],
-    "references": [
-      "WHITTEN TREE"
-    ]
+    "references": []
   },
   {
     "spellings": "WHITTERICK",
@@ -52621,9 +52210,7 @@
     "variants": [
       "WHITWORTH BALL\nWhit\"worth ball`. (Gun.)\n\nDefn: A prejectile used in the Whitworth gun."
     ],
-    "references": [
-      "WHITWORTH BALL"
-    ]
+    "references": []
   },
   {
     "spellings": "WHITWORTH GUN",
@@ -52631,8 +52218,7 @@
       "WHITWORTH GUN\nWhit\"worth gun`. (Gun.)\n\nDefn: A form of rifled cannon and small arms invented by Sir Joseph\nWhitworth, of Manchester, England.\n\nNote: In Mr. Whitworth's system, the bore of the gun has a polygonal\nsection, and the twist is rapid. The ball, which is pointed in front,\nis made to fit the bore accurately, and is very much elongated, its\nlength being about three and one half times as great as its diameter.\nH. L. Scott."
     ],
     "references": [
-      "WHITWORTH BALL",
-      "WHITWORTH GUN"
+      "WHITWORTH BALL"
     ]
   },
   {
@@ -61025,8 +60611,7 @@
       "WHYDAH BIRD; WHYDAH FINCH\nWhyd\"ah bird`, or Whyd\"ah finch`. (Zoöl.)\n\nDefn: The whidah bird."
     ],
     "references": [
-      "WHIDAH BIRD",
-      "WHYDAH BIRD; WHYDAH FINCH"
+      "WHIDAH BIRD"
     ]
   },
   {
@@ -61348,9 +60933,7 @@
     "variants": [
       "WICKEN TREE\nWick\"en tree`.\n\nDefn: Same as Quicken tree."
     ],
-    "references": [
-      "WICKEN TREE"
-    ]
+    "references": []
   },
   {
     "spellings": "WICKER",
@@ -61443,9 +61026,7 @@
     "variants": [
       "WICKIUP WICKYUP\n{ Wick\"i*up Wick\"y*up }, n.\n\nDefn: Vars of Wikiup."
     ],
-    "references": [
-      "WICKIUP WICKYUP"
-    ]
+    "references": []
   },
   {
     "spellings": "WICLIFITE; WICKLIFFITE",
@@ -61468,9 +61049,7 @@
     "variants": [
       "WIDAL'S TEST; WIDAL TEST; WIDAL'S REACTION; WIDAL REACTION\nWi*dal's\", or Wi*dal\", test or reaction . [After Fernand Widal (b.\n1862), French physician.] (Med.)\n\nDefn: A test for typhoid fever based on the fact that blood serum of\none affected, in a bouillon culture of typhoid bacilli, causes the\nbacilli to agglutinate and lose their motility."
     ],
-    "references": [
-      "WIDAL'S TEST; WIDAL TEST; WIDAL'S REACTION; WIDAL REACTION"
-    ]
+    "references": []
   },
   {
     "spellings": "WIDDY",
@@ -61915,9 +61494,7 @@
     "variants": [
       "WIDMANSTATTEN FIGURES; WIDMANSTAETTEN FIGURES\nWid\"man*stät`ten fig\"ures. (Min.)\n\nDefn: Certain figures appearing on etched meteoric iron; -- so called\nafter A. B. Widmanstätten, of Vienna, who first described them in\n1808. See the Note and Illust. under Meteorite."
     ],
-    "references": [
-      "WIDMANSTATTEN FIGURES; WIDMANSTAETTEN FIGURES"
-    ]
+    "references": []
   },
   {
     "spellings": "WIDOW",
@@ -61976,8 +61553,7 @@
       "WIDOW BIRD\nWid\"ow bird`. (Zoöl.)\n\nDefn: See Whidan bird."
     ],
     "references": [
-      "WHIDAH BIRD",
-      "WIDOW BIRD"
+      "WHIDAH BIRD"
     ]
   },
   {
@@ -62199,9 +61775,7 @@
     "variants": [
       "WIENER SCHNITZEL\nWie\"ner Schnit\"zel. [G., Vienna cutlet.]\n\nDefn: A veal cutlet variously seasoned garnished, often with lemon,\nsardines, and capers."
     ],
-    "references": [
-      "WIENER SCHNITZEL"
-    ]
+    "references": []
   },
   {
     "spellings": "WIER",
@@ -63490,9 +63064,7 @@
     "variants": [
       "WILFLEY TABLE\nWil\"fley ta`ble. (Ore Dressing)\n\nDefn: An inclined percussion table, usually with longitudinal grooves\nin its surface, agitated by side blows at right angles to the flow of\nthe pulp; -- so called after the inventor."
     ],
-    "references": [
-      "WILFLEY TABLE"
-    ]
+    "references": []
   },
   {
     "spellings": "WILFUL; WILFULLY; WILFULNESS",
@@ -65676,8 +65248,7 @@
       "WILLY NILLY\nWil\"ly nil\"ly.\n\nDefn: See Will I, nill I, etc., under 3d Will."
     ],
     "references": [
-      "WILL",
-      "WILLY NILLY"
+      "WILL"
     ]
   },
   {
@@ -65746,9 +65317,7 @@
     "variants": [
       "WILTON CARPET\nWil\"ton car`pet.\n\nDefn: A kind of carpet woven with loops like the Brussels, but\ndiffering from it in having the loops cut so as to form an elastic\nvelvet pile; -- so called because made originally at Wilton, England."
     ],
-    "references": [
-      "WILTON CARPET"
-    ]
+    "references": []
   },
   {
     "spellings": "WILWE",
@@ -67292,9 +66861,7 @@
     "variants": [
       "WIND SIGNAL\nWind signal.\n\nDefn: In general, any signal announcing information concerning winds,\nand esp. the expected approach of winds whose direction and force are\ndangerous to shipping, etc. The wind-signal system of the United\nStates Weather Bureau consists of storm, information, hurricane, hot\nwind, and inland storm signals."
     ],
-    "references": [
-      "WIND SIGNAL"
-    ]
+    "references": []
   },
   {
     "spellings": "WINDSOR",
@@ -68740,8 +68307,7 @@
       "WINTER'S BARK\nWin\"ter's bark`. (Bot.)\n\nDefn: The aromatic bark of tree (Drimys, or Drymis, Winteri) of the\nMagnolia family, which is found in Southern Chili. It was first used\nas a cure for scurvy by its discoverer, Captain John Winter, vice\nadmiral to sir Francis Drake, in 1577."
     ],
     "references": [
-      "DRIMYS",
-      "WINTER'S BARK"
+      "DRIMYS"
     ]
   },
   {
@@ -69034,9 +68600,7 @@
     "variants": [
       "WIRE GUN\nWire gun.\n\nDefn: = Wire-wound gun."
     ],
-    "references": [
-      "WIRE GUN"
-    ]
+    "references": []
   },
   {
     "spellings": "WIRE-HEEL",
@@ -69098,9 +68662,7 @@
     "variants": [
       "WIRE TAPPER\nWire tapper.\n\nDefn: One that taps, or cuts in on, telegraph wires and intercepts\nmessages; hence (Slang),\n\nDefn: a swindler who pretends to tap wires or otherwise intercept\nadvance telegraphic news for betting. -- Wire tapping."
     ],
-    "references": [
-      "WIRE TAPPER"
-    ]
+    "references": []
   },
   {
     "spellings": "WIREWORK",
@@ -69134,8 +68696,7 @@
       "WIRE-WOUND GUN\nWire\"-wound` gun. (Ordnance)\n\nDefn: A gun in the construction of which an inner tube (either entire\nor in segments) is wound with wire under tension to insure greater\nsoundness and uniformity of resistance. In modern construction hoops\nand jackets are shrunk on over the wire."
     ],
     "references": [
-      "WIRE GUN",
-      "WIRE-WOUND GUN"
+      "WIRE GUN"
     ]
   },
   {
@@ -69383,9 +68944,7 @@
     "variants": [
       "WISDOM LITERATURE\nWis\"dom lit\"er*a*ture.\n\nDefn: The class of ancient Hebrew writings which deal reflectively\nwith general ethical and religious topics, as distinguished from the\nprophetic and liturgical literature, and from the law. It is\ncomprised chiefly in the books of Job, Proverbs, Ecclesiasticus,\nEcclesiastes, and Wisdom of Solomon. The \"wisdom\" (Hokhmah) of these\nwritings consists in detached sage utterances on concrete issues of\nlife, without the effort at philosophical system that appeared in the\nlater Hellenistic reflective writing beginning with Philo Judæus."
     ],
-    "references": [
-      "WISDOM LITERATURE"
-    ]
+    "references": []
   },
   {
     "spellings": "WISE",
@@ -80327,9 +79886,7 @@
     "variants": [
       "WOLFRAM STEEL\nWol\"fram steel.\n\nDefn: Same as Tungsten steel."
     ],
-    "references": [
-      "WOLFRAM STEEL"
-    ]
+    "references": []
   },
   {
     "spellings": "WOLFSBANE",
@@ -80386,9 +79943,7 @@
     "variants": [
       "WOLLASTON'S DOUBLET\nWol\"las*ton's dou\"blet. [After W. H. Wollaston, English physicist.]\n(Optics)\n\nDefn: A magnifying glass consisting of two plano-convex lenses. It is\ndesigned to correct spherical aberration and chromatic dispersion."
     ],
-    "references": [
-      "WOLLASTON'S DOUBLET"
-    ]
+    "references": []
   },
   {
     "spellings": "WOLLE",
@@ -80416,9 +79971,7 @@
     "variants": [
       "WOLVERENE STATE\nWol`ver*ene\" State.\n\nDefn: Michigan; -- a nickname."
     ],
-    "references": [
-      "WOLVERENE STATE"
-    ]
+    "references": []
   },
   {
     "spellings": "WOLVES",
@@ -81177,9 +80730,7 @@
     "variants": [
       "WOMAN'S CHRISTIAN TEMPERANCE UNION\nWoman's Christian Temperance Union.\n\nDefn: An association of women formed in the United States in 1874,\nfor the advancement of temperance by organizing preventive,\neducational, evangelistic, social, and legal work."
     ],
-    "references": [
-      "WOMAN'S CHRISTIAN TEMPERANCE UNION"
-    ]
+    "references": []
   },
   {
     "spellings": "WOMB",
@@ -83615,7 +83166,6 @@
       "WOOD GUM\nWood gum. (Chem.)\n\nDefn: Xylan."
     ],
     "references": [
-      "WOOD GUM",
       "XYLAN"
     ]
   },
@@ -83654,9 +83204,7 @@
     "variants": [
       "WOOD HYACINTH\nWood hyacinth.\n\nDefn: A European squill (Scilla nonscripta) having a scape bearing a\nraceme of drooping blue, purple, white, or sometimes pink, bell-\nshaped flowers."
     ],
-    "references": [
-      "WOOD HYACINTH"
-    ]
+    "references": []
   },
   {
     "spellings": "WOODINESS",
@@ -83771,8 +83319,7 @@
       "WOOD PARTRIDGE\nWood partridge.\n (a) Any of several small partridges of Java, Sumatra, Borneo, and\nneighboring regions belonging to the genera Caloperdix, Rollulus, and\nMelanoperdix.\n (b) The Canada grouse. [Local, U. S.]"
     ],
     "references": [
-      "PARTRIDGE",
-      "WOOD PARTRIDGE"
+      "PARTRIDGE"
     ]
   },
   {
@@ -83883,9 +83430,7 @@
     "variants": [
       "WOOD'S METAL\nWood's\" met\"al.\n\nDefn: A fusible alloy consisting of one or two parts of cadmium, two\nparts of tin, four of lead, with seven or eight part of bismuth. It\nmelts at from 66º to 71º C. See Fusible metal, under Fusible."
     ],
-    "references": [
-      "WOOD'S METAL"
-    ]
+    "references": []
   },
   {
     "spellings": "WOODSTONE",
@@ -83907,8 +83452,7 @@
       "WOOD TICK\nWood\" tick`. (Zoöl.)\n\nDefn: Any one of several species of ticks of the genus Ixodes whose\nyoung cling to bushes, but quickly fasten themselves upon the bodies\nof any animal with which they come in contact. When they attach\nthemselves to the human body they often produce troublesome sores.\nThe common species of the Northern United States is Ixodes\nunipunctata."
     ],
     "references": [
-      "WOOD",
-      "WOOD TICK"
+      "WOOD"
     ]
   },
   {
@@ -86627,8 +86171,7 @@
       "WORD METHOD\nWord method. (Education)\n\nDefn: A method of teaching reading in which words are first taken as\nsingle ideograms and later analyzed into their phonetic and\nalphabetic elements; -- contrasted with the alphabet and sentence\nmethods."
     ],
     "references": [
-      "SENTENCE METHOD",
-      "WORD METHOD"
+      "SENTENCE METHOD"
     ]
   },
   {
@@ -88356,9 +87899,7 @@
     "variants": [
       "WORKMEN'S COMPENSATION ACT\nWorkmen's compensation act. (Law)\n\nDefn: A statute fixing the compensation that a workman may recover\nfrom an employer in case of accident, esp. the British act of 6 Edw.\nVII. c. 58 (1906) giving to a workman, except in certain cases of\n\"serious and willful misconduct,\" a right against his employer to a\ncertain compensation on the mere occurrence of an accident where the\ncommon law gives the right only for negligence of the employer."
     ],
-    "references": [
-      "WORKMEN'S COMPENSATION ACT"
-    ]
+    "references": []
   },
   {
     "spellings": "WORKROOM",
@@ -92254,9 +91795,7 @@
     "variants": [
       "WOULFE BOTTLE\nWoulfe\" bot`tle, n. (Chem.)\n\nDefn: A kind of wash bottle with two or three necks; -- so called\nafter the inventor, Peter Woulfe, an English chemist."
     ],
-    "references": [
-      "WOULFE BOTTLE"
-    ]
+    "references": []
   },
   {
     "spellings": "WOUND",
@@ -97810,8 +97349,7 @@
       "FLUOROSCOPY",
       "RAY",
       "RONTGEN RAY",
-      "SEXRADIATE",
-      "X RAYS; X-RAYS"
+      "SEXRADIATE"
     ]
   },
   {
@@ -97819,9 +97357,7 @@
     "variants": [
       "X-RAY TUBE\nX\"-ray\" tube. (Physics)\n\nDefn: A vacuum tube suitable for producing Röntgen rays."
     ],
-    "references": [
-      "X-RAY TUBE"
-    ]
+    "references": []
   },
   {
     "spellings": "XYLAMIDE",
@@ -99388,9 +98924,7 @@
     "variants": [
       "YAZOO FRAUD\nYaz\"oo Fraud. (U. S. Hist.)\n\nDefn: The grant by the State of Georgia, by Act of Jan. 7, 1795, of\n35,000,000 acres of her western territory, for $500,000, to four\ncompanies known as the Yazoo Companies from the region granted ; --\ncommonly so called, the act being known as the Yazoo Frauds Act,\nbecause of alleged corruption of the legislature, every member but\none being a shareholder in one or more of the companies. The act\ngranting the land was repealed in 1796 by a new legislature, and the\nrepealing provision was incorporated in the State constitution in\n1798. In 1802 the territory was ceded to the United States. The\nclaims of the purchasers, whom Georgia had refused to compensate,\nwere sustained by the United States Supreme Court, which (1810)\ndeclared the repealing act of 1796 unconstitutional. Congress in 1814\nordered the lands sold and appropriated $5,000,000 to pay the claims."
     ],
-    "references": [
-      "YAZOO FRAUD"
-    ]
+    "references": []
   },
   {
     "spellings": "YBE",
@@ -99445,8 +98979,7 @@
       "SPERMIST",
       "SPLIT DYNAMOMETER",
       "TOKEN",
-      "XERIFF",
-      "Y CURRENT"
+      "XERIFF"
     ]
   },
   {
@@ -100435,9 +99968,7 @@
     "variants": [
       "YEAR'S PURCHASE\nYear's purchase.\n\nDefn: The amount that is yielded by the annual income of property; --\nused in expressing the value of a thing in the number of years\nrequired for its income to yield its purchase price, in reckoning the\namount to be paid for annuities, etc."
     ],
-    "references": [
-      "YEAR'S PURCHASE"
-    ]
+    "references": []
   },
   {
     "spellings": "YEARTH",
@@ -101296,9 +100827,7 @@
     "variants": [
       "YELLOW BOOK\nYellow Book. [F. livre jaune.]\n\nDefn: In France, an official government publication bound in yellow\ncovers."
     ],
-    "references": [
-      "YELLOW BOOK"
-    ]
+    "references": []
   },
   {
     "spellings": "YELLOW-COVERED",
@@ -103222,8 +102751,7 @@
       "FLOOR",
       "LEVEL",
       "RAZE",
-      "Y",
-      "Y LEVEL"
+      "Y"
     ]
   },
   {
@@ -103665,8 +103193,7 @@
       "YORK RITE\nYork rite. (Freemasonry)\n\nDefn: The rite or ceremonial observed by one of the Masonic systems,\nderiving its name from the city of York, in England; also, the system\nitself, which, in England, confers only the first three degrees."
     ],
     "references": [
-      "SCOTCH RITE",
-      "YORK RITE"
+      "SCOTCH RITE"
     ]
   },
   {
@@ -103689,8 +103216,7 @@
       "YORK USE\nYork\" use`. (Eccl.)\n\nDefn: The one of the three printed uses of England which was followed\nin the north. It was based on the Sarum use. See Use, n., 6. Shipley."
     ],
     "references": [
-      "USE",
-      "YORK USE"
+      "USE"
     ]
   },
   {
@@ -105948,9 +105474,7 @@
     "variants": [
       "YOUNG MEN'S CHRISTIAN ASSOCIATION\nYoung Men's Christian Association.\n\nDefn: An organization for promoting the spiritual, intellectual,\nsocial, and physical welfare of young men, founded, June 6, 1844, by\nGeorge Williams (knighted therefor by Queen Victoria) in London. In\n1851 it extended to the United States and Canada, and in 1855\nrepresentatives of similar organizations throughout Europe and\nAmerica formed an international body. The movement has successfully\nexpanded not only among young men in general, but also specifically\namong railroad men, in the army and navy, with provision for Indians\nand negroes, and a full duplication of all the various lines of\noepration in the boys' departments."
     ],
-    "references": [
-      "YOUNG MEN'S CHRISTIAN ASSOCIATION"
-    ]
+    "references": []
   },
   {
     "spellings": "YOUNGNESS",
@@ -105970,8 +105494,7 @@
       "FAWN",
       "FETUS",
       "LIKING",
-      "SHROUD",
-      "YOUNG ONE"
+      "SHROUD"
     ]
   },
   {
@@ -106006,9 +105529,7 @@
     "variants": [
       "YOUNG WOMEN'S CHRISTIAN ASSOCIATION\nYoung Women's Christian Association.\n\nDefn: An organization for promoting the spiritual, intellectual,\nsocial, and economic welfare of young women, originating in 1855 with\nLady Kinnaird's home for young women, and Miss Emma Robert's prayer\nunion for young women,in England, which were combined in the year\n1884 as a national association. Now nearly all the civilized\ncountries, and esp. the United States, have local, national, and\ninternational organizations."
     ],
-    "references": [
-      "YOUNG WOMEN'S CHRISTIAN ASSOCIATION"
-    ]
+    "references": []
   },
   {
     "spellings": "YOUNKER",
@@ -107432,9 +106953,7 @@
     "variants": [
       "YPRES LACE\nY\"pres lace`.\n\nDefn: Fine bobbin lace made at Ypres in Belgium, usually exactly like\nValenciennes lace."
     ],
-    "references": [
-      "YPRES LACE"
-    ]
+    "references": []
   },
   {
     "spellings": "YPSILIFORM",
@@ -107643,9 +107162,7 @@
     "variants": [
       "YUCCA BORER\nYuc\"ca bor`er.\n (a) A California boring weevil (Yuccaborus frontalis).\n (b) A large mothlike butterfly (Megathymus yuccæ) of the family\nMegatimidæ, whose larva bores in yucca roots."
     ],
-    "references": [
-      "YUCCA BORER"
-    ]
+    "references": []
   },
   {
     "spellings": "YUCK",
@@ -108057,8 +107574,7 @@
       "ZANTE CURRANT\nZan\"te cur\"rant.\n\nDefn: A kind of seedless grape or raisin; -- so called from Zante,\none of the Ionian Islands."
     ],
     "references": [
-      "GRAPEVINE",
-      "ZANTE CURRANT"
+      "GRAPEVINE"
     ]
   },
   {
@@ -108598,9 +108114,7 @@
     "variants": [
       "ZEEMAN EFFECT\nZee\"man ef*fect\". (Physics)\n\nDefn: The widening and duplication, triplication, etc., of spectral\nlines when the radiations emanate in a strong magnetic field, first\nobserved in 1896 by P. Zeeman, a Dutch physicist, and regarded as an\nimportant confirmation of the electromagnetic theory of light."
     ],
-    "references": [
-      "ZEEMAN EFFECT"
-    ]
+    "references": []
   },
   {
     "spellings": "ZEHNER",
@@ -109603,9 +109117,7 @@
     "variants": [
       "ZIRCON LIGHT\nZir\"con light. (Physics)\n\nDefn: A light, similar to the calcium light, produced by incandescent\nzirconia."
     ],
-    "references": [
-      "ZIRCON LIGHT"
-    ]
+    "references": []
   },
   {
     "spellings": "ZIRCONO",
@@ -109905,9 +109417,7 @@
     "variants": [
       "ZOLLNER'S LINES\nZöll\"ner's lines`. [So called after Friedrich Zöllner, a German\nphysicist.]\n\nDefn: Parallel lines that are made to appear convergent or divergent\nby means of oblique intersections."
     ],
-    "references": [
-      "ZOLLNER'S LINES"
-    ]
+    "references": []
   },
   {
     "spellings": "ZOLLVEREIN",

--- a/src/parseWords.ts
+++ b/src/parseWords.ts
@@ -5,13 +5,18 @@ import { WordData, WordDataRaw, WordExportData, WordVariantRaw } from './wordDat
 
 const maxWordReferencesToStore = 5000;
 
-function getWordInfoForWordIds(wordIds: string[], wordIdToRawWord: Record<string, WordDataRaw>): string[] {
+function getWordInfoForWordIds(spellings: string, wordIds: string[], wordIdToRawWord: Record<string, WordDataRaw>): string[] {
   const references: Set<string> = new Set();
 
   wordIds.forEach(wordId => {
     const rawWord = wordIdToRawWord[wordId];
     if (references.has(rawWord.spellingsString)) {
       throw new Error(`duplicate ${rawWord.spellingsString}`);
+    }
+
+    if (rawWord.spellingsString === spellings) {
+      // Don't add a reference for a word to itself.
+      return;
     }
 
     references.add(rawWord.spellingsString);
@@ -62,7 +67,7 @@ export function parseWords(wordIdToRawWord: Record<string, WordDataRaw>, wordIdL
     const referenceWordIds: string[] = Array.from(wordIdToReferenceWordIds.get(wordId)?.keys() || []);
     if (referenceWordIds) {
       if (referenceWordIds && referenceWordIds.length > maxWordReferencesToStore) {
-        const references = getWordInfoForWordIds(referenceWordIds.slice(0, maxWordReferencesToStore - 1), wordIdToRawWord);
+        const references = getWordInfoForWordIds(rawWord.spellingsString, referenceWordIds.slice(0, maxWordReferencesToStore - 1), wordIdToRawWord);
         wordIdToWordExport[wordId] = {
           spellings: rawWord.spellingsString,
           variants,
@@ -70,7 +75,7 @@ export function parseWords(wordIdToRawWord: Record<string, WordDataRaw>, wordIdL
           hasMoreThan5000References: true
         }
       } else {
-        const references = getWordInfoForWordIds(referenceWordIds, wordIdToRawWord);
+        const references = getWordInfoForWordIds(rawWord.spellingsString, referenceWordIds, wordIdToRawWord);
         wordIdToWordExport[wordId] = {
           spellings: rawWord.spellingsString,
           variants,


### PR DESCRIPTION
Don't allow a word to reference itself in its references.